### PR TITLE
update read.md and remove default node pool in tf

### DIFF
--- a/ray-on-gke/README.md
+++ b/ray-on-gke/README.md
@@ -62,7 +62,7 @@ If you need to reinstall any resources, make sure to delete this file as well.
 
 5. To use the Ray dashboard, run the following command to port-forward:
 ```
-kubectl port-forward -n ray service/example-cluster-kuberay-head-svc 8265:8265
+kubectl port-forward -n <namespace> service/example-cluster-kuberay-head-svc 8265:8265
 ```
 
 And then open the dashboard using the following URL:
@@ -75,7 +75,7 @@ http://localhost:8265
 1. To connect to the remote GKE cluster with the Ray API, setup the Ray dashboard.
 Run the following command to port-forward:
 ```
-kubectl port-forward -n ray service/example-cluster-kuberay-head-svc 8265:8265
+kubectl port-forward -n <namespace> service/example-cluster-kuberay-head-svc 8265:8265
 ```
 
 And then open the dashboard using the following URL:

--- a/ray-on-gke/platform/modules/gke_standard/main.tf
+++ b/ray-on-gke/platform/modules/gke_standard/main.tf
@@ -23,8 +23,8 @@ resource "google_container_cluster" "ml_cluster" {
   name     = var.cluster_name
   location = var.region
   count    = var.enable_autopilot == false ? 1 : 0
-
-  initial_node_count = 3
+  remove_default_node_pool = true
+  initial_node_count = 1
 
   logging_config {
     enable_components = ["SYSTEM_COMPONENTS", "WORKLOADS"]


### PR DESCRIPTION
- small fix in `read.md`, command for port-forwarding needs namespace user defined instead of `ray`.
- remove default node pool creation in terraform template. We are not using the default node pool and it's not manageable. 