### PR TITLE
Remove sensitive from cluster_certificate in output.tf

### DIFF
--- a/ray-on-gke/platform/modules/gke_standard/output.tf
+++ b/ray-on-gke/platform/modules/gke_standard/output.tf
@@ -32,8 +32,7 @@ output "kubernetes_host" {
   value       = var.enable_autopilot ? null : resource.google_container_cluster.ml_cluster[0].endpoint
 }
 
-output "cluster_certicicate" {
-  description = "Kubernetes cluster ca certificate"
+output "cluster_certificate" {
+  description = "Kubernetes cluster CA certificate"
   value       = var.enable_autopilot ? null : base64decode(resource.google_container_cluster.ml_cluster[0].master_auth[0].cluster_ca_certificate)
-  sensitive   = true
 }


### PR DESCRIPTION
The cluster CA certificate is public and not a sensitive resource. Fix a typo.