### PR TITLE
update default machine type and gpu type

### DIFF
--- a/ray-on-gke/platform/modules/gke_standard/main.tf
+++ b/ray-on-gke/platform/modules/gke_standard/main.tf
@@ -76,7 +76,7 @@ resource "google_container_node_pool" "gpu_pool" {
 
     # preemptible  = true
     image_type   = "cos_containerd"
-    machine_type = "a2-highgpu-1g"
+    machine_type = "n1-standard-16"
     tags         = ["gke-node", "${var.project_id}-gke"]
 
     disk_size_gb = "100"

--- a/ray-on-gke/user/modules/kuberay/kuberay-values.yaml
+++ b/ray-on-gke/user/modules/kuberay/kuberay-values.yaml
@@ -95,7 +95,7 @@ head:
   annotations: {}
   nodeSelector:
     iam.gke.io/gke-metadata-server-enabled: "true"
-    cloud.google.com/gke-accelerator: "nvidia-tesla-a100"
+    cloud.google.com/gke-accelerator: "nvidia-tesla-t4"
   tolerations: []
   affinity: {}
   # Ray container security context.
@@ -179,7 +179,7 @@ worker:
     key: value
   nodeSelector:
     iam.gke.io/gke-metadata-server-enabled: "true"
-    cloud.google.com/gke-accelerator: "nvidia-tesla-a100"
+    cloud.google.com/gke-accelerator: "nvidia-tesla-t4"
   tolerations: []
   affinity: {}
   # Ray container security context.


### PR DESCRIPTION
**What is this PR for:**
 A100s gpus/A2 machines are facing stockout so this changes the default machine type and gpu type for the cluster and ray.