### PR TITLE
Add labels to match ray nodeselector

### DIFF
--- a/ray-on-gke/platform/modules/gke_standard/main.tf
+++ b/ray-on-gke/platform/modules/gke_standard/main.tf
@@ -74,6 +74,11 @@ resource "google_container_node_pool" "gpu_pool" {
       env = var.project_id
     }
 
+    guest_accelerator {
+      type = "nvidia-tesla-t4"
+      count = 2
+    }
+
     # preemptible  = true
     image_type   = "cos_containerd"
     machine_type = "n1-standard-16"


### PR DESCRIPTION
**What this PR is for:**
This change adds the correct labels to the node so that it matches the nodeSelector labels in the ray config yaml. Currently, without it, the ray cluster will run into an error with `Pod's node affinity/selector`