### PR TITLE
fix values for jupyterhub cpu and mem

### DIFF
--- a/ray-on-gke/user/jupyterhub/jupyter_config/config.yaml
+++ b/ray-on-gke/user/jupyterhub/jupyter_config/config.yaml
@@ -42,11 +42,11 @@ scheduling:
 
 singleuser:
   cpu:
-    limit: 1G
-    guarantee: 1G
-  memory:
     limit: .5
     guarantee: .5
+  memory:
+    limit: 1G
+    guarantee: 1G
   nodeSelector:
     iam.gke.io/gke-metadata-server-enabled: "true"
   image:


### PR DESCRIPTION
This should fixes the issue of 
```
Error: values don't meet the specifications of the schema(s) in the following chart(s):│ jupyterhub:│ - singleuser.cpu.limit: Invalid type. Expected: [number,null], given: string│ - singleuser.cpu.guarantee: Invalid type. Expected: [number,null], given: string
```
When running jupyterhub, with current config, it runs into the error above. This fixes the issue. 