### PR TITLE
Add image to jupyter config and more to readme

### DIFF
--- a/ray-on-gke/README.md
+++ b/ray-on-gke/README.md
@@ -62,6 +62,8 @@ Preinstall the following on your computer:
 
 ### JupyterHub
 
+> **_NOTE:_** Currently the cd/user/jupyterhub/jupyter_config/config.yaml has 3 profiles that uses the same jupyter images, this can be changed, as well as the description of these profiles
+
 1. `cd user/jupyterhub`
 
 2. Edit `variables.tf` with your GCP settings. The `<your user name>` that you specify will become a K8s namespace for your Jupyterhub services.

--- a/ray-on-gke/user/jupyterhub/jupyter_config/config.yaml
+++ b/ray-on-gke/user/jupyterhub/jupyter_config/config.yaml
@@ -50,8 +50,8 @@ singleuser:
   nodeSelector:
     iam.gke.io/gke-metadata-server-enabled: "true"
   image:
-    name: <image-name>
-    tag: <tag>
+    name: jupyter/tensorflow-notebook
+    tag: python-3.10
   startTimeout: 700
 # More info on kubespawner overrides: https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html#kubespawner.KubeSpawner
 #   profile example:
@@ -78,7 +78,7 @@ singleuser:
     - display_name: "Profile2 name"
       description: "description here"
       kubespawner_override:
-        image: <image-name>:<tag>
+        image: jupyter/tensorflow-notebook:python-3.10
         extra_resource_limits:
           # number of gpus needed on the node
           nvidia.com/gpu: "2"
@@ -88,7 +88,7 @@ singleuser:
     - display_name: "Profile3 name"
       description: "description"
       kubespawner_override:
-        image: <image-name>:<tag>
+        image: jupyter/tensorflow-notebook:python-3.10
         extra_resource_limits:
           nvidia.com/gpu: "2"
         # GPU requests 


### PR DESCRIPTION
Added default images to jupyterhub and added a note in the readme that lets the user know that the file can be changed. But we can also have different default image as well, since there isn't a point to have 3 profiles with the same image. 