### PR TITLE
add tpu node location in template

### DIFF
--- a/ray-on-gke/platform/modules/gke_standard/main.tf
+++ b/ray-on-gke/platform/modules/gke_standard/main.tf
@@ -126,7 +126,7 @@ resource "google_container_node_pool" "tpu_pool" {
   provider           = google-beta
   name               = "tpu-pool"
   location           = var.region
-  node_locations     = var.tpu_node_locations
+  node_locations     = ["us-central2-b"]
   cluster            = var.enable_autopilot == false && var.enable_tpu ? google_container_cluster.ml_cluster[0].name : null
   initial_node_count = var.num_nodes
   count              = var.enable_autopilot == false && var.enable_tpu ? 1 : 0

--- a/ray-on-gke/platform/modules/gke_standard/main.tf
+++ b/ray-on-gke/platform/modules/gke_standard/main.tf
@@ -126,6 +126,7 @@ resource "google_container_node_pool" "tpu_pool" {
   provider           = google-beta
   name               = "tpu-pool"
   location           = var.region
+  node_locations     = var.tpu_node_locations
   cluster            = var.enable_autopilot == false && var.enable_tpu ? google_container_cluster.ml_cluster[0].name : null
   initial_node_count = var.num_nodes
   count              = var.enable_autopilot == false && var.enable_tpu ? 1 : 0

--- a/ray-on-gke/platform/modules/gke_standard/variables.tf
+++ b/ray-on-gke/platform/modules/gke_standard/variables.tf
@@ -52,3 +52,9 @@ variable "enable_tpu" {
   description = "Set to true to create TPU node pool"
   default     = false
 }
+
+variable "tpu_node_locations" {
+  type        = list(string)
+  description = "Locations of TPU node. TPU V4 is only available in us-central2-b. It will be used when enable_tpu is set to true"
+  default     = ["us-central2-b"]
+}

--- a/ray-on-gke/platform/modules/gke_standard/variables.tf
+++ b/ray-on-gke/platform/modules/gke_standard/variables.tf
@@ -52,9 +52,3 @@ variable "enable_tpu" {
   description = "Set to true to create TPU node pool"
   default     = false
 }
-
-variable "tpu_node_locations" {
-  type        = list(string)
-  description = "Locations of TPU node. TPU V4 is only available in us-central2-b. It will be used when enable_tpu is set to true"
-  default     = ["us-central2-b"]
-}

--- a/ray-on-gke/user/jupyterhub/jupyterhub.tf
+++ b/ray-on-gke/user/jupyterhub/jupyterhub.tf
@@ -27,12 +27,12 @@ provider "helm" {
 }
 
 resource "helm_release" "jupyterhub" {
-  name       = "jupyterhub"
-  repository = "https://jupyterhub.github.io/helm-chart"
-  chart      = "jupyterhub"
-  namespace  = var.namespace
+  name             = "jupyterhub"
+  repository       = "https://jupyterhub.github.io/helm-chart"
+  chart            = "jupyterhub"
+  namespace        = var.namespace
   create_namespace = var.create_namespace
-  cleanup_on_fail = "true"
+  cleanup_on_fail  = "true"
 
   values = [
     file("${path.module}/jupyter_config/config.yaml")

--- a/ray-on-gke/user/jupyterhub/variables.tf
+++ b/ray-on-gke/user/jupyterhub/variables.tf
@@ -19,7 +19,7 @@ variable "namespace" {
 }
 
 variable "create_namespace" {
-  type = bool
+  type        = bool
   description = "Enable creation of jupyterhub namespace if it does not exist"
-  default = false
+  default     = false
 }


### PR DESCRIPTION
TPU V4 is only available in us-central2-b. Otherwise everytime we need to manually add this in template so can pass through. 


And a bit auto formatting.