### PR TITLE
Replace gcs bucket with github repo in TPU demo

### DIFF
--- a/gke-tpu-examples/single-host-inference/jax/bert/install-bert.yaml
+++ b/gke-tpu-examples/single-host-inference/jax/bert/install-bert.yaml
@@ -17,7 +17,8 @@ spec:
     - -c
     - |
       cd /tmp/
-      gsutil -m cp -r "gs://BUCKET_NAME/single-host-inference/jax" .
+      git clone https://github.com/GoogleCloudPlatform/ai-on-gke.git
+      cp -r ai-on-gke/gke-tpu-examples/single-host-inference/jax .
       echo got jax bert resources
   - name: export-bert
     image: python:3.10

--- a/gke-tpu-examples/single-host-inference/jax/stable-diffusion/install-stable-diffusion.yaml
+++ b/gke-tpu-examples/single-host-inference/jax/stable-diffusion/install-stable-diffusion.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     gke-gcsfuse/volumes: "true"
 spec:
+  serviceAccount: sax-sa
   restartPolicy: Never
   initContainers:
   - name: pull-demo
@@ -17,7 +18,8 @@ spec:
     - -c
     - |
       cd /tmp/
-      gsutil -m cp -r "gs://BUCKET_NAME/single-host-inference/jax" .
+      git clone https://github.com/GoogleCloudPlatform/ai-on-gke.git
+      cp -r ai-on-gke/gke-tpu-examples/single-host-inference/jax .
       echo got jax stable-diffusion resources
   - name: export-stable-diffusion
     image: python:3.10

--- a/gke-tpu-examples/single-host-inference/jax/stable-diffusion/install-stable-diffusion.yaml
+++ b/gke-tpu-examples/single-host-inference/jax/stable-diffusion/install-stable-diffusion.yaml
@@ -5,7 +5,6 @@ metadata:
   annotations:
     gke-gcsfuse/volumes: "true"
 spec:
-  serviceAccount: sax-sa
   restartPolicy: Never
   initContainers:
   - name: pull-demo

--- a/gke-tpu-examples/single-host-inference/tf/resnet50/model-conversion.yml
+++ b/gke-tpu-examples/single-host-inference/tf/resnet50/model-conversion.yml
@@ -18,7 +18,8 @@ spec:
     - -c
     - |
       cd /tmp/
-      gsutil -m cp -r "gs://BUCKET_NAME/single-host-inference/tf/resnet50" .
+      git clone https://github.com/GoogleCloudPlatform/ai-on-gke.git
+      cp -r ai-on-gke/gke-tpu-examples/single-host-inference/tf/resnet50 .
       echo got files for the demo!
   - name: export-resnet
     image: python:3.10


### PR DESCRIPTION
- download the demo source code from github repo instead of from gcs bucket