### PR TITLE
Ray on Autopilot 

### DIFF
--- a/gke-platform/main.tf
+++ b/gke-platform/main.tf
@@ -90,7 +90,8 @@ module "kubernetes" {
 module "kuberay" {
   source = "./modules/kuberay"
 
-  depends_on   = [module.gke_autopilot, module.gke_standard]
-  region       = var.region
-  cluster_name = var.cluster_name
+  depends_on       = [module.gke_autopilot, module.gke_standard]
+  region           = var.region
+  cluster_name     = var.cluster_name
+  enable_autopilot = var.enable_autopilot
 }

--- a/gke-platform/modules/gke_autopilot/main.tf
+++ b/gke-platform/modules/gke_autopilot/main.tf
@@ -47,6 +47,6 @@ resource "google_container_cluster" "ml_cluster" {
     channel = "RAPID"
   }
 
-  min_master_version = "1.27"
+  min_master_version = "1.28"
 }
 

--- a/gke-platform/modules/kuberay/kuberay-operator-autopilot-values.yaml
+++ b/gke-platform/modules/kuberay/kuberay-operator-autopilot-values.yaml
@@ -1,0 +1,103 @@
+# Default values for kuberay-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: kuberay/operator
+  tag: nightly
+  pullPolicy: IfNotPresent
+
+nameOverride: "kuberay-operator"
+fullnameOverride: "kuberay-operator"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "kuberay-operator"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do whelm to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 100m
+    # Anecdotally, managing 500 Ray pods requires roughly 500MB memory.
+    # Monitor memory usage and adjust as needed.
+    memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 512Mi
+
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 5
+
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 5
+
+batchScheduler:
+  enabled: false
+
+# Set up `securityContext` to improve Pod security.
+# See https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md for further guidance.
+securityContext: {}
+
+
+# If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on.
+rbacEnable: true
+
+# When crNamespacedRbacEnable is set to true, the KubeRay operator will create a Role for RayCluster preparation (e.g., Pods, Services)
+# and a corresponding RoleBinding for each namespace listed in the "watchNamespace" parameter. Please note that even if crNamespacedRbacEnable
+# is set to false, the Role and RoleBinding for leader election will still be created.
+#
+# Note:
+# (1) This variable is only effective when rbacEnable and singleNamespaceInstall are both set to true.
+# (2) In most cases, it should be set to true, unless you are using a Kubernetes cluster managed by GitOps tools such as ArgoCD.
+crNamespacedRbacEnable: true
+
+# When singleNamespaceInstall is true:
+# - Install namespaced RBAC resources such as Role and RoleBinding instead of cluster-scoped ones like ClusterRole and ClusterRoleBinding so that
+#   the chart can be installed by users with permissions restricted to a single namespace.
+#   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
+# - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen
+#   to resource events within its own namespace.
+singleNamespaceInstall: false
+
+# The KubeRay operator will watch the custom resources in the namespaces listed in the "watchNamespace" parameter.
+# watchNamespace:
+#   - n1
+#   - n2
+
+# Environment variables
+env:
+# If not set or set to true, kuberay auto injects an init container waiting for ray GCS.
+# If false, you will need to inject your own init container to ensure ray GCS is up before the ray workers start.
+# Warning: we highly recommend setting to true and let kuberay handle for you.
+- name: ENABLE_INIT_CONTAINER_INJECTION
+  value: "false"
+# If not set or set to "", kuberay will pick up the default k8s cluster domain `cluster.local`
+# Otherwise, kuberay will use your custom domain
+# - name: CLUSTER_DOMAIN
+#   value: ""
+# If not set or set to false, when running on OpenShift with Ingress creation enabled, kuberay will create OpenShift route
+# Otherwise, regardless of the type of cluster with Ingress creation enabled, kuberay will create Ingress
+# - name: USE_INGRESS_ON_OPENSHIFT
+#   value: "true"
+# Unconditionally requeue after the number of seconds specified in the
+# environment variable RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV. If the
+# environment variable is not set, requeue after the default value (300).
+# - name: RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV
+#   value: 300
+# If not set or set to "true", KubeRay will clean up the Redis storage namespace when a GCS FT-enabled RayCluster is deleted.
+# - name: ENABLE_GCS_FT_REDIS_CLEANUP
+#   value: "true"

--- a/gke-platform/modules/kuberay/kuberay-operator-values.yaml
+++ b/gke-platform/modules/kuberay/kuberay-operator-values.yaml
@@ -1,0 +1,103 @@
+# Default values for kuberay-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: kuberay/operator
+  tag: nightly
+  pullPolicy: IfNotPresent
+
+nameOverride: "kuberay-operator"
+fullnameOverride: "kuberay-operator"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: "kuberay-operator"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do whelm to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  limits:
+    cpu: 100m
+    # Anecdotally, managing 500 Ray pods requires roughly 500MB memory.
+    # Monitor memory usage and adjust as needed.
+    memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 512Mi
+
+livenessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 5
+
+readinessProbe:
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  failureThreshold: 5
+
+batchScheduler:
+  enabled: false
+
+# Set up `securityContext` to improve Pod security.
+# See https://github.com/ray-project/kuberay/blob/master/docs/guidance/pod-security.md for further guidance.
+securityContext: {}
+
+
+# If rbacEnable is set to false, no RBAC resources will be created, including the Role for leader election, the Role for Pods and Services, and so on.
+rbacEnable: true
+
+# When crNamespacedRbacEnable is set to true, the KubeRay operator will create a Role for RayCluster preparation (e.g., Pods, Services)
+# and a corresponding RoleBinding for each namespace listed in the "watchNamespace" parameter. Please note that even if crNamespacedRbacEnable
+# is set to false, the Role and RoleBinding for leader election will still be created.
+#
+# Note:
+# (1) This variable is only effective when rbacEnable and singleNamespaceInstall are both set to true.
+# (2) In most cases, it should be set to true, unless you are using a Kubernetes cluster managed by GitOps tools such as ArgoCD.
+crNamespacedRbacEnable: true
+
+# When singleNamespaceInstall is true:
+# - Install namespaced RBAC resources such as Role and RoleBinding instead of cluster-scoped ones like ClusterRole and ClusterRoleBinding so that
+#   the chart can be installed by users with permissions restricted to a single namespace.
+#   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
+# - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen
+#   to resource events within its own namespace.
+singleNamespaceInstall: false
+
+# The KubeRay operator will watch the custom resources in the namespaces listed in the "watchNamespace" parameter.
+# watchNamespace:
+#   - n1
+#   - n2
+
+# Environment variables
+env:
+# If not set or set to true, kuberay auto injects an init container waiting for ray GCS.
+# If false, you will need to inject your own init container to ensure ray GCS is up before the ray workers start.
+# Warning: we highly recommend setting to true and let kuberay handle for you.
+# - name: ENABLE_INIT_CONTAINER_INJECTION
+#   value: "true"
+# If not set or set to "", kuberay will pick up the default k8s cluster domain `cluster.local`
+# Otherwise, kuberay will use your custom domain
+# - name: CLUSTER_DOMAIN
+#   value: ""
+# If not set or set to false, when running on OpenShift with Ingress creation enabled, kuberay will create OpenShift route
+# Otherwise, regardless of the type of cluster with Ingress creation enabled, kuberay will create Ingress
+# - name: USE_INGRESS_ON_OPENSHIFT
+#   value: "true"
+# Unconditionally requeue after the number of seconds specified in the
+# environment variable RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV. If the
+# environment variable is not set, requeue after the default value (300).
+# - name: RAYCLUSTER_DEFAULT_REQUEUE_SECONDS_ENV
+#   value: 300
+# If not set or set to "true", KubeRay will clean up the Redis storage namespace when a GCS FT-enabled RayCluster is deleted.
+# - name: ENABLE_GCS_FT_REDIS_CLEANUP
+#   value: "true"

--- a/gke-platform/modules/kuberay/kuberay.tf
+++ b/gke-platform/modules/kuberay/kuberay.tf
@@ -16,4 +16,5 @@ resource "helm_release" "kuberay-operator" {
   name       = "kuberay-operator"
   repository = "https://ray-project.github.io/kuberay-helm/"
   chart      = "kuberay-operator"
+  values     = var.enable_autopilot ? [file("${path.module}/kuberay-operator-autopilot-values.yaml")] : [file("${path.module}/kuberay-operator-values.yaml")]
 }

--- a/gke-platform/modules/kuberay/variables.tf
+++ b/gke-platform/modules/kuberay/variables.tf
@@ -29,3 +29,9 @@ variable "namespace" {
   description = "Kubernetes namespace where resources are deployed"
   default     = "ray"
 }
+
+variable "enable_autopilot" {
+  type        = bool
+  description = "Set to true to enable GKE Autopilot clusters"
+  default     = false
+}

--- a/ray-on-gke/user/main.tf
+++ b/ray-on-gke/user/main.tf
@@ -49,6 +49,7 @@ module "kuberay" {
   depends_on = [module.kubernetes]
   namespace  = var.namespace
   enable_tpu = var.enable_tpu
+  enable_autopilot = var.enable_autopilot
 }
 
 module "prometheus" {

--- a/ray-on-gke/user/modules/kuberay/kuberay-autopilot-values.yaml
+++ b/ray-on-gke/user/modules/kuberay/kuberay-autopilot-values.yaml
@@ -1,0 +1,454 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for ray-cluster.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# The KubeRay community welcomes PRs to expose additional configuration
+# in this Helm chart.
+
+image:
+  # Replace this with your own image if needed.
+  repository: rayproject/ray
+  tag: 2.6.1-py310-gpu
+  pullPolicy: IfNotPresent
+
+nameOverride: "kuberay"
+fullnameOverride: ""
+
+imagePullSecrets: []
+  # - name: an-existing-secret
+
+head:
+  groupName: headgroup
+  # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
+  # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
+  # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
+  enableInTreeAutoscaling: true
+  # autoscalerOptions is an OPTIONAL field specifying configuration overrides for the Ray autoscaler.
+  # The example configuration shown below below represents the DEFAULT values.
+  autoscalerOptions:
+    upscalingMode: Default
+    idleTimeoutSeconds: 60
+    securityContext: {}
+    env: []
+    envFrom: []
+    # resources specifies optional resource request and limit overrides for the autoscaler container.
+    # For large Ray clusters, we recommend monitoring container resource usage to determine if overriding the defaults is required.
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+      requests:
+        cpu: "500m"
+        memory: "512Mi"
+  labels:
+    cloud.google.com/gke-ray-node-type: head
+  rayStartParams:
+    dashboard-host: '0.0.0.0'
+    block: 'true'
+  # containerEnv specifies environment variables for the Ray container,
+  # Follows standard K8s container env schema.
+  containerEnv:
+  # - name: EXAMPLE_ENV
+  #   value: "1"
+    - name: RAY_memory_monitor_refresh_ms
+      value: "0"
+  envFrom: []
+    # - secretRef:
+    #     name: my-env-secret
+  # ports optionally allows specifying ports for the Ray container.
+  # ports: []
+  # resource requests and limits for the Ray head container.
+  # Modify as needed for your application.
+  # Note that the resources in this example are much too small for production;
+  # we don't recommend allocating less than 8G memory for a Ray pod in production.
+  # Ray pods should be sized to take up entire K8s nodes when possible.
+  # Always set CPU and memory limits for Ray pods.
+  # It is usually best to set requests equal to limits.
+  # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources
+  # for further guidance.
+  resources:
+    limits:
+      cpu: "1"
+      # To avoid out-of-memory issues, never allocate less than 2G memory for the Ray head.
+      memory: "20G"
+      ephemeral-storage: 20Gi
+    requests:
+      cpu: "1"
+      memory: "20G"
+      ephemeral-storage: 10Gi
+  annotations: {}
+  nodeSelector:
+    iam.gke.io/gke-metadata-server-enabled: "true"
+  tolerations: []
+  affinity: {}
+  # Ray container security context.
+  securityContext: {}
+  volumes:
+    - name: ray-logs
+      emptyDir: {}
+    - name: fluentbit-config
+      configMap:
+        name: fluentbit-config
+  # Ray writes logs to /tmp/ray/session_latests/logs
+  volumeMounts:
+    - mountPath: /tmp/ray
+      name: ray-logs
+  # sidecarContainers specifies additional containers to attach to the Ray pod.
+  # Follows standard K8s container spec.
+  sidecarContainers:
+    - name: fluentbit
+      image: fluent/fluent-bit:1.9.6
+      # These resource requests for Fluent Bit should be sufficient in production.
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+          ephemeral-storage: 2Gi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+          ephemeral-storage: 4Gi
+      volumeMounts:
+      - mountPath: /tmp/ray
+        name: ray-logs
+      - mountPath: /fluent-bit/etc/
+        name: fluentbit-config
+
+worker:
+  # If you want to disable the default workergroup
+  # uncomment the line below
+  disabled: true
+  groupName: workergroup
+  replicas: 0
+  type: worker
+  labels:
+    cloud.google.com/gke-ray-node-type: worker
+  rayStartParams:
+    block: 'true'
+  initContainerImage: 'busybox:1.28'  # Enable users to specify the image for init container. Users can pull the busybox image from their private repositories.
+  # Security context for the init container.
+  initContainerSecurityContext: {}
+  # containerEnv specifies environment variables for the Ray container,
+  # Follows standard K8s container env schema.
+  containerEnv: []
+  # - name: EXAMPLE_ENV
+  #   value: "1"
+  envFrom: []
+    # - secretRef:
+    #     name: my-env-secret
+  # ports optionally allows specifying ports for the Ray container.
+  # ports: []
+  # resource requests and limits for the Ray head container.
+  # Modify as needed for your application.
+  # Note that the resources in this example are much too small for production;
+  # we don't recommend allocating less than 8G memory for a Ray pod in production.
+  # Ray pods should be sized to take up entire K8s nodes when possible.
+  # Always set CPU and memory limits for Ray pods.
+  # It is usually best to set requests equal to limits.
+  # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources
+  # for further guidance.
+  resources:
+    limits:
+      cpu: "1"
+      nvidia.com/gpu: "1"
+      memory: "20G"
+      ephemeral-storage: 20Gi
+    requests:
+      cpu: "1"
+      nvidia.com/gpu: "1"
+      memory: "20G"
+      ephemeral-storage: 10Gi
+  annotations:
+    key: value
+  nodeSelector:
+    iam.gke.io/gke-metadata-server-enabled: "true"
+    cloud.google.com/gke-accelerator: "nvidia-tesla-a100"
+  tolerations: []
+  affinity: {}
+  # Ray container security context.
+  securityContext: {}
+  volumes:
+    - name: ray-logs
+      emptyDir: {}
+    - name: fluentbit-config
+      configMap:
+        name: fluentbit-config
+  # Ray writes logs to /tmp/ray/session_latests/logs
+  volumeMounts:
+    - mountPath: /tmp/ray
+      name: ray-logs
+  # sidecarContainers specifies additional containers to attach to the Ray pod.
+  # Follows standard K8s container spec.
+  sidecarContainers:
+    - name: fluentbit
+      image: fluent/fluent-bit:1.9.6
+      # These resource requests for Fluent Bit should be sufficient in production.
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+          ephemeral-storage: 2Gi
+        limits:
+          cpu: 100m
+          memory: 128Mi
+          ephemeral-storage: 4Gi
+      volumeMounts:
+      - mountPath: /tmp/ray
+        name: ray-logs
+      - mountPath: /fluent-bit/etc/
+        name: fluentbit-config
+
+# The map's key is used as the groupName.
+# For example, key:small-group in the map below
+# will be used as the groupName
+additionalWorkerGroups:
+  smallGroup:
+    # Disabled by default
+    disabled: false
+    replicas: 0 
+    minReplicas: 0
+    maxReplicas: 10
+    type: worker
+    labels: {}
+    rayStartParams:
+      block: 'true'
+  # containerEnv specifies environment variables for the Ray container,
+  # Follows standard K8s container env schema.
+    containerEnv: []
+      # - name: EXAMPLE_ENV
+      #   value: "1"
+    envFrom: []
+        # - secretRef:
+        #     name: my-env-secret
+    # ports optionally allows specifying ports for the Ray container.
+    # ports: []
+  # resource requests and limits for the Ray head container.
+  # Modify as needed for your application.
+  # Note that the resources in this example are much too small for production;
+  # we don't recommend allocating less than 8G memory for a Ray pod in production.
+  # Ray pods should be sized to take up entire K8s nodes when possible.
+  # Always set CPU and memory limits for Ray pods.
+  # It is usually best to set requests equal to limits.
+  # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources
+  # for further guidance.
+    resources:
+      limits:
+        cpu: 1
+        memory: "20G"
+      requests:
+        cpu: 1
+        memory: "20G"
+    annotations:
+      key: value
+    nodeSelector: {}
+    tolerations: []
+    affinity: {}
+    # Ray container security context.
+    securityContext: {}
+    volumes:
+      - name: ray-logs
+        emptyDir: {}
+      - name: fluentbit-config
+        configMap:
+          name: fluentbit-config
+    # Ray writes logs to /tmp/ray/session_latests/logs
+    volumeMounts:
+      - mountPath: /tmp/ray
+        name: ray-logs
+    # sidecarContainers specifies additional containers to attach to the Ray pod.
+    # Follows standard K8s container spec.
+    sidecarContainers:
+      - name: fluentbit
+        image: fluent/fluent-bit:1.9.6
+        # These resource requests for Fluent Bit should be sufficient in production.
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+            ephemeral-storage: 2Gi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+            ephemeral-storage: 4Gi
+        volumeMounts:
+        - mountPath: /tmp/ray
+          name: ray-logs
+        - mountPath: /fluent-bit/etc/
+          name: fluentbit-config
+
+  mediumGroup:
+    # Disabled by default
+    disabled: false
+    replicas: 0 
+    minReplicas: 0
+    maxReplicas: 10
+    type: worker
+    labels: {}
+    rayStartParams:
+      block: 'true'
+  # containerEnv specifies environment variables for the Ray container,
+  # Follows standard K8s container env schema.
+    containerEnv: []
+      # - name: EXAMPLE_ENV
+      #   value: "1"
+    envFrom: []
+        # - secretRef:
+        #     name: my-env-secret
+    # ports optionally allows specifying ports for the Ray container.
+    # ports: []
+  # resource requests and limits for the Ray head container.
+  # Modify as needed for your application.
+  # Note that the resources in this example are much too small for production;
+  # we don't recommend allocating less than 8G memory for a Ray pod in production.
+  # Ray pods should be sized to take up entire K8s nodes when possible.
+  # Always set CPU and memory limits for Ray pods.
+  # It is usually best to set requests equal to limits.
+  # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources
+  # for further guidance.
+    resources:
+      limits:
+        cpu: "8"
+        nvidia.com/gpu: "1"
+        memory: "20G"
+        ephemeral-storage: 20Gi
+      requests:
+        cpu: "8"
+        nvidia.com/gpu: "1"
+        memory: "20G"
+        ephemeral-storage: 10Gi
+    annotations:
+      key: value
+    nodeSelector:
+      iam.gke.io/gke-metadata-server-enabled: "true"
+      cloud.google.com/gke-accelerator: "nvidia-tesla-t4"
+    tolerations: []
+    affinity: {}
+    # Ray container security context.
+    securityContext: {}
+    volumes:
+      - name: ray-logs
+        emptyDir: {}
+      - name: fluentbit-config
+        configMap:
+          name: fluentbit-config
+    # Ray writes logs to /tmp/ray/session_latests/logs
+    volumeMounts:
+      - mountPath: /tmp/ray
+        name: ray-logs
+    # sidecarContainers specifies additional containers to attach to the Ray pod.
+    # Follows standard K8s container spec.
+    sidecarContainers:
+      - name: fluentbit
+        image: fluent/fluent-bit:1.9.6
+        # These resource requests for Fluent Bit should be sufficient in production.
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+            ephemeral-storage: 2Gi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+            ephemeral-storage: 4Gi
+        volumeMounts:
+        - mountPath: /tmp/ray
+          name: ray-logs
+        - mountPath: /fluent-bit/etc/
+          name: fluentbit-config
+
+  largeGroup:
+    # Disabled by default
+    disabled: false
+    replicas: 0 
+    minReplicas: 0
+    maxReplicas: 1
+    type: worker
+    labels: {}
+    rayStartParams:
+      block: 'true'
+  # containerEnv specifies environment variables for the Ray container,
+  # Follows standard K8s container env schema.
+    containerEnv: []
+      # - name: EXAMPLE_ENV
+      #   value: "1"
+    envFrom: []
+        # - secretRef:
+        #     name: my-env-secret
+    # ports optionally allows specifying ports for the Ray container.
+    # ports: []
+  # resource requests and limits for the Ray head container.
+  # Modify as needed for your application.
+  # Note that the resources in this example are much too small for production;
+  # we don't recommend allocating less than 8G memory for a Ray pod in production.
+  # Ray pods should be sized to take up entire K8s nodes when possible.
+  # Always set CPU and memory limits for Ray pods.
+  # It is usually best to set requests equal to limits.
+  # See https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/config.html#resources
+  # for further guidance.
+    resources:
+      limits:
+        cpu: "8"
+        nvidia.com/gpu: "8"
+        memory: "40G"
+        ephemeral-storage: 20Gi
+      requests:
+        cpu: "8"
+        nvidia.com/gpu: "8"
+        memory: "40G"
+        ephemeral-storage: 10Gi
+    annotations:
+      key: value
+    nodeSelector:
+      iam.gke.io/gke-metadata-server-enabled: "true"
+      cloud.google.com/gke-accelerator: "nvidia-tesla-t4"
+    tolerations: []
+    affinity: {}
+    # Ray container security context.
+    securityContext: {}
+    volumes:
+      - name: ray-logs
+        emptyDir: {}
+      - name: fluentbit-config
+        configMap:
+          name: fluentbit-config
+    # Ray writes logs to /tmp/ray/session_latests/logs
+    volumeMounts:
+      - mountPath: /tmp/ray
+        name: ray-logs
+    # sidecarContainers specifies additional containers to attach to the Ray pod.
+    # Follows standard K8s container spec.
+    sidecarContainers:
+      - name: fluentbit
+        image: fluent/fluent-bit:1.9.6
+        # These resource requests for Fluent Bit should be sufficient in production.
+        resources:
+          requests:
+            cpu: 100m
+            memory: 128Mi
+            ephemeral-storage: 2Gi
+          limits:
+            cpu: 100m
+            memory: 128Mi
+            ephemeral-storage: 4Gi
+        volumeMounts:
+        - mountPath: /tmp/ray
+          name: ray-logs
+        - mountPath: /fluent-bit/etc/
+          name: fluentbit-config
+          
+service:
+  type: LoadBalancer 

--- a/ray-on-gke/user/modules/kuberay/kuberay.tf
+++ b/ray-on-gke/user/modules/kuberay/kuberay.tf
@@ -17,5 +17,5 @@ resource "helm_release" "ray-cluster" {
   repository = "https://ray-project.github.io/kuberay-helm/"
   chart      = "ray-cluster"
   namespace  = var.namespace
-  values     = var.enable_tpu ? [file("${path.module}/kuberay-tpu-values.yaml")] : [file("${path.module}/kuberay-values.yaml")]
+  values     = var.enable_autopilot ? [file("${path.module}/kuberay-autopilot-values.yaml")] : (var.enable_tpu ? [file("${path.module}/kuberay-tpu-values.yaml")] : [file("${path.module}/kuberay-values.yaml")])
 }

--- a/ray-on-gke/user/modules/kuberay/variables.tf
+++ b/ray-on-gke/user/modules/kuberay/variables.tf
@@ -23,3 +23,9 @@ variable "enable_tpu" {
   description = "Set to true to create TPU node pool"
   default     = false
 }
+
+variable "enable_autopilot" {
+  type        = bool
+  description = "Set to true to enable GKE Autopilot clusters"
+  default     = false
+}

--- a/ray-on-gke/user/variables.tf
+++ b/ray-on-gke/user/variables.tf
@@ -35,3 +35,9 @@ variable "enable_tpu" {
   description = "Set to true to create TPU node pool"
   default     = false
 }
+
+variable "enable_autopilot" {
+  type        = bool
+  description = "Set to true to enable GKE Autopilot clusters"
+  default     = false
+}


### PR DESCRIPTION
Making a few changes to support Ray on Autopilot:
* If `enable_autopilot` is set, bypass the init containers for Ray workers
* Use a custom Kuberay cluster spec if the cluster is Autopilot. The Kuberay cluster contains 3 worker groups - small (only CPU), medium (1 GPU), and large (8 GPUs). 


