### PR TITLE
tutorials: fix embedmd and reorder llama 70b steps

### DIFF
--- a/tutorials/finetuning-llama-7b-on-l4/README.md
+++ b/tutorials/finetuning-llama-7b-on-l4/README.md
@@ -129,6 +129,7 @@ kubectl create secret generic l4-demo \
 
 Let's use Kubernetes Job to download the Llama 2 7B model from HuggingFace.
 The file `download-model.yaml` in this repo shows how to do this:
+
 [embedmd]:# (download-model.yaml)
 ```yaml
 apiVersion: batch/v1
@@ -202,6 +203,7 @@ Let’s write our finetuning job code by using the HuggingFace library for train
 
 The `fine-tune.py` file in this repo will be used to do the finetuning. Let's take
 a look what's inside:
+
 [embedmd]:# (fine-tune.py)
 ```py
 from pathlib import Path

--- a/tutorials/serving-llama2-70b-on-l4-gpus/README.md
+++ b/tutorials/serving-llama2-70b-on-l4-gpus/README.md
@@ -59,6 +59,7 @@ kubectl create secret generic l4-demo --from-literal="HF_TOKEN=$HF_TOKEN"
 ```
 
 Create a file named `text-generation-interface.yaml` with the following content:
+
 [embedmd]:# (text-generation-interface.yaml)
 ```yaml
 apiVersion: apps/v1
@@ -111,23 +112,25 @@ spec:
         cloud.google.com/gke-accelerator: nvidia-l4
 ```
 
+Create the deployment for serving:
+```bash
+kubectl apply -f text-generation-interface.yaml
+```
+
 Inside the YAML file the following settings are used:
 - `NUM_SHARD`, this has to be set to 2 because 2 x NVIDIA L4 GPUs are used. In our testing without setting this value it will only use a single GPU.
 - `QUANTIZE` is set to `nf4` which means that the model is loaded in 4 bit instead of 32 bits. This allows us to reduce the amount of GPU memory needed and improves the inference speed, however it can also decrease the model accuracy. If you change this you might need additional GPUs
 
 Visit the [text-generation-inference docs](https://github.com/huggingface/text-generation-inference/blob/v1.1.0/docs/source/basic_tutorials/launcher.md) for more details about these settings.
 
-### How do you know how many GPUs you need?
-That depends on the value of `QUANTIZE` in our case `QUANTIZE` is set to `bitsandbytes-nf4`,
+How do you know how many GPUs you need?  
+That depends on the value of `QUANTIZE`, in our case it is set to `bitsandbytes-nf4`,
 which means that the model will be loaded in 4 bits. So a 70 billion parameter model would
 require a minimum of 70 billion * 4 bits = 35 GB of GPU memory, lets say there is 5GB of overhead, which takes the minimum to 40GB. The L4 GPU has 24GB of GPU memory, so a single
 L4 GPU wouldn't have enough memory, however 2 x 24 = 48GB GPU memory, so using 2 x L4 GPU
 is sufficient to run Llama 2 70B on L4 GPUs.
 
-Create the deployment for serving:
-```bash
-kubectl apply -f text-generation-interface.yaml
-```
+
 Check the logs and make sure there are no errors:
 ```bash
 kubectl logs -l app=llama-2-70b


### PR DESCRIPTION
There should be an empty line before embedmd otherwise it will render as normal text. This fixes that by adding the empty lines.

Also reorder the steps in llama 70b to execute deployment creation after creating the YAML file which flows better.