### PR TITLE
remove unnecessary pv/pvc logic from training-single-gpu examples

### DIFF
--- a/training-single-gpu/src/gke-config/standard-tensorflow-bash.yaml
+++ b/training-single-gpu/src/gke-config/standard-tensorflow-bash.yaml
@@ -20,46 +20,15 @@ spec:
       limits:
         nvidia.com/gpu: 1
     volumeMounts:
-    - name: gcs-fuse-csi-pv
+    - name: gcs-fuse-csi-vol
       mountPath: /data
       readOnly: false
   serviceAccountName: $K8S_SA_NAME
   volumes:
-  - name: gcs-fuse-csi-pv
+  - name: gcs-fuse-csi-vol
     csi:
       driver: gcsfuse.csi.storage.gke.io
       readOnly: false
       volumeAttributes:
         bucketName: $BUCKET_NAME
-        mountOptions: "implicit-dirs,uid=1001,gid=3003"
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: gcs-fuse-csi-pv
-spec:
-  accessModes:
-  - ReadWriteMany
-  capacity:
-    storage: 30Gi
-  claimRef:
-    name: gcs-fuse-csi-static-pvc
-  mountOptions:
-    - uid=1001
-    - gid=3003
-  csi:
-    driver: gcsfuse.csi.storage.gke.io
-    volumeHandle: $BUCKET_NAME
-    readOnly: false
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: gcs-fuse-csi-static-pvc
-spec:
-  accessModes:
-  - ReadWriteMany
-  resources:
-    requests:
-      storage: 30Gi
-  volumeName: gcs-fuse-csi-pv
+        mountOptions: "implicit-dirs"

--- a/training-single-gpu/src/gke-config/standard-tf-mnist-batch-predict.yaml
+++ b/training-single-gpu/src/gke-config/standard-tf-mnist-batch-predict.yaml
@@ -8,9 +8,6 @@ spec:
       name: mnist
       annotations:
         gke-gcsfuse/volumes: "true"
-        # gke-gcsfuse/cpu-limit: 500m
-        # gke-gcsfuse/memory-limit: 100Mi
-        # gke-gcsfuse/ephemeral-storage-limit: 50Gi
     spec:
       nodeSelector:
         cloud.google.com/gke-accelerator: nvidia-tesla-t4
@@ -26,9 +23,8 @@ spec:
         resources:
           limits:
             nvidia.com/gpu: 1
-            # ephemeral-storage: 30Gi
-          # requests:
-          #   ephemeral-storage: 30Gi
+            cpu: 1
+            memory: 3Gi
         volumeMounts:
         - name: gcs-fuse-csi-pv
           mountPath: /data
@@ -41,38 +37,5 @@ spec:
           readOnly: false
           volumeAttributes:
             bucketName: $BUCKET_NAME
-            mountOptions: "implicit-dirs,uid=1001,gid=3003"
+            mountOptions: "implicit-dirs"
       restartPolicy: "Never"
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: gcs-fuse-csi-pv
-spec:
-  accessModes:
-  - ReadWriteMany
-  capacity:
-    storage: 30Gi
-  storageClassName: example-storage-class
-  claimRef:
-    name: gcs-fuse-csi-static-pvc
-  mountOptions:
-    - uid=1001
-    - gid=3003
-  csi:
-    driver: gcsfuse.csi.storage.gke.io
-    volumeHandle: $BUCKET_NAME
-    readOnly: false
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: gcs-fuse-csi-static-pvc
-spec:
-  accessModes:
-  - ReadWriteMany
-  resources:
-    requests:
-      storage: 30Gi
-  volumeName: gcs-fuse-csi-pv
-  storageClassName: example-storage-class

--- a/training-single-gpu/src/gke-config/standard-tf-mnist-train.yaml
+++ b/training-single-gpu/src/gke-config/standard-tf-mnist-train.yaml
@@ -23,48 +23,19 @@ spec:
         resources:
           limits:
             nvidia.com/gpu: 1
+            cpu: 1
+            memory: 3Gi
         volumeMounts:
-        - name: gcs-fuse-csi-pv
+        - name: gcs-fuse-csi-vol
           mountPath: /data
           readOnly: false
       serviceAccountName: $K8S_SA_NAME
       volumes:
-      - name: gcs-fuse-csi-pv
+      - name: gcs-fuse-csi-vol
         csi:
           driver: gcsfuse.csi.storage.gke.io
           readOnly: false
           volumeAttributes:
             bucketName: $BUCKET_NAME
-            mountOptions: "implicit-dirs,uid=1001,gid=3003"
+            mountOptions: "implicit-dirs"
       restartPolicy: "Never"
----
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: gcs-fuse-csi-pv
-spec:
-  accessModes:
-  - ReadWriteMany
-  capacity:
-    storage: 30Gi
-  claimRef:
-    name: gcs-fuse-csi-static-pvc
-  mountOptions:
-    - uid=1001
-    - gid=3003
-  csi:
-    driver: gcsfuse.csi.storage.gke.io
-    volumeHandle: $BUCKET_NAME
-    readOnly: false
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: gcs-fuse-csi-static-pvc
-spec:
-  accessModes:
-  - ReadWriteMany
-  resources:
-    requests:
-      storage: 30Gi
-  volumeName: gcs-fuse-csi-pv


### PR DESCRIPTION
- Remove unnecessary pv/pvc logic from the training-single-gpu examples as the yaml files use the CSI ephemeral inline volumes.
- Remove unnecessary uid and gid mount options.
- Explicitly declare resource limits in the train and predict jobs to make them work on Autopilot clusters.