### PR TITLE
[EZ] remove text color info in cloudbuild logs 

### DIFF
--- a/ray-on-gke/cloudbuild.yaml
+++ b/ray-on-gke/cloudbuild.yaml
@@ -2,7 +2,7 @@ steps:
   - id: 'validate platform'
     name: 'gcr.io/$PROJECT_ID/terraform'
     script: |
-      terraform init
+      terraform init -no-color
       terraform validate -no-color
     dir: 'gke-platform/'
     waitFor: ['-']
@@ -10,7 +10,7 @@ steps:
   - id: 'validate user'
     name: 'gcr.io/$PROJECT_ID/terraform'
     script: |
-      terraform init
+      terraform init -no-color
       terraform validate -no-color
     dir: 'ray-on-gke/user/'
     waitFor: ['-']

--- a/ray-on-gke/cloudbuild.yaml
+++ b/ray-on-gke/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
     name: 'gcr.io/$PROJECT_ID/terraform'
     script: |
       terraform init
-      terraform validate
+      terraform validate -no-color
     dir: 'gke-platform/'
     waitFor: ['-']
   
@@ -11,7 +11,7 @@ steps:
     name: 'gcr.io/$PROJECT_ID/terraform'
     script: |
       terraform init
-      terraform validate 
+      terraform validate -no-color
     dir: 'ray-on-gke/user/'
     waitFor: ['-']
 
@@ -25,7 +25,7 @@ steps:
       - |
         terraform apply -var=project_id=$PROJECT_ID \
         -var=cluster_name=ray-$SHORT_SHA-$_PR_NUMBER-cluster \
-        -var=region=$_ZONE -auto-approve \
+        -var=region=$_ZONE -auto-approve -no-color \
         || ( terraform destroy -auto-approve && exit 1 )
     dir: 'gke-platform/'
     waitFor: ['validate platform', 'validate user']
@@ -52,19 +52,23 @@ steps:
         -var=project_id=$PROJECT_ID \
         -var=namespace=$SHORT_SHA \
         -var=service_account=$_USER_NAME-$SHORT_SHA-system-account \
-        -auto-approve || ( echo "false" > /workspace/user_result )
+        -auto-approve -no-color \
+        || ( echo "false" > /workspace/user_result )
 
+        # Make sure pods are running
         kubectl wait --all pods -n $SHORT_SHA --for=condition=Ready --timeout=300s
         kubectl port-forward -n $SHORT_SHA service/example-cluster-kuberay-head-svc 8265:8265 &
         # Wait port-forwarding to take its place
         sleep 5s
 
-        ray job submit --working-dir ../example_ray_job_scripts --address=http://127.0.0.1:8265 -- python ray_job.py || ( echo "false" >> /workspace/ray_result.txt )
+        ray job submit --working-dir ../example_ray_job_scripts \
+        --address=http://127.0.0.1:8265 -- python ray_job.py \
+        || ( echo "false" >> /workspace/ray_result.txt )
 
         terraform destroy -var=project_id=$PROJECT_ID \
         -var=namespace=$SHORT_SHA \
         -var=service_account=$_USER_NAME-$SHORT_SHA-system-account \
-        -auto-approve
+        -auto-approve -no-color
     dir: 'ray-on-gke/user/'
     waitFor: ['get kube config']
 


### PR DESCRIPTION
add -no-color tag to all terraform commands to remove special character in github cloudbuild logs 

```
Step #1 - "validate user": �[0m�[1mInitializing the backend...�[0m
```