### PR TITLE
Pin the image tag version for now, as there are errors with the current nightly

### DIFF
--- a/gke-platform/modules/kuberay/kuberay-operator-autopilot-values.yaml
+++ b/gke-platform/modules/kuberay/kuberay-operator-autopilot-values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kuberay/operator
-  tag: nightly
+  tag: 15ce568
   pullPolicy: IfNotPresent
 
 nameOverride: "kuberay-operator"

--- a/gke-platform/modules/kuberay/kuberay-operator-values.yaml
+++ b/gke-platform/modules/kuberay/kuberay-operator-values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: kuberay/operator
-  tag: nightly
+  tag: 15ce568
   pullPolicy: IfNotPresent
 
 nameOverride: "kuberay-operator"


### PR DESCRIPTION
Probably at least until 1.0 is released, we should pin the image version to a working one for now, in the event there may be issues with nightly.

The operator fails to come up with the nightly at the moment:

```
2023-10-13T18:58:20.166Z        ERROR   controller.raycluster-controller        Could not wait for Cache to sync       {"reconciler group": "[ray.io](http://ray.io/)", "reconciler kind": "RayCluster", "error": "failed to wait for raycluster-controller caches to sync: timed out waiting for cache to be synced"}
[sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2)
        /[opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:208](http://opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:208)
[sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start)
        /[opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:234](http://opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/internal/controller/controller.go:234)
[sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1](http://sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1)
        /[opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/manager/runnable_group.go:218](http://opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/manager/runnable_group.go:218)
2023-10-13T18:58:20.166Z        ERROR   error received after stop sequence was engaged  {"error": "failed to wait for rayservice caches to sync: timed out waiting for cache to be synced"}
[sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).engageStopProcedure.func1](http://sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).engageStopProcedure.func1)
        /[opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/manager/internal.go:541](http://opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/manager/internal.go:541)
2023-10-13T18:58:20.166Z        ERROR   error received after stop sequence was engaged  {"error": "failed to wait for raycluster-controller caches to sync: timed out waiting for cache to be synced"}
[sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).engageStopProcedure.func1](http://sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).engageStopProcedure.func1)
        /[opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/manager/internal.go:541](http://opt/app-root/src/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.1/pkg/manager/internal.go:541)
2023-10-13T18:58:20.166Z        INFO    Stopping and waiting for caches
2023-10-13T18:58:20.166Z        INFO    Stopping and waiting for webhooks
2023-10-13T18:58:20.166Z        INFO    Wait completed, proceeding to shutdown the manager
2023-10-13T18:58:20.166Z        ERROR   setup   problem running manager {"error": "failed to wait for rayjob caches to sync: timed out waiting for cache to be synced"}
main.main
        /workspace/main.go:172
runtime.main
        /usr/lib/golang/src/runtime/proc.go:250
```

