### PR TITLE
pin helm chart version for kuberay-operator to 0.6.1

### DIFF
--- a/gke-platform/modules/kuberay/kuberay.tf
+++ b/gke-platform/modules/kuberay/kuberay.tf
@@ -17,4 +17,5 @@ resource "helm_release" "kuberay-operator" {
   repository = "https://ray-project.github.io/kuberay-helm/"
   chart      = "kuberay-operator"
   values     = var.enable_autopilot ? [file("${path.module}/kuberay-operator-autopilot-values.yaml")] : [file("${path.module}/kuberay-operator-values.yaml")]
+  version    = "0.6.1"
 }


### PR DESCRIPTION
This ensures we continue to run the current helm chart version for kuberay-operator (0.6.1)  even after v1.0.0 is released. 