### PR TITLE
install kuberay-operator in a dedicated namespace (ray-system)

### DIFF
--- a/gke-platform/modules/kuberay/kuberay.tf
+++ b/gke-platform/modules/kuberay/kuberay.tf
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+resource "kubernetes_namespace" "ray_namespace" {
+  metadata {
+    name = var.namespace
+  }
+}
+
 resource "helm_release" "kuberay-operator" {
   name       = "kuberay-operator"
   repository = "https://ray-project.github.io/kuberay-helm/"
   chart      = "kuberay-operator"
   values     = var.enable_autopilot ? [file("${path.module}/kuberay-operator-autopilot-values.yaml")] : [file("${path.module}/kuberay-operator-values.yaml")]
   version    = "0.6.1"
+  namespace  = "${kubernetes_namespace.ray_namespace.metadata[0].name}"
 }

--- a/gke-platform/modules/kuberay/variables.tf
+++ b/gke-platform/modules/kuberay/variables.tf
@@ -27,7 +27,7 @@ variable "cluster_name" {
 variable "namespace" {
   type        = string
   description = "Kubernetes namespace where resources are deployed"
-  default     = "ray"
+  default     = "ray-system"
 }
 
 variable "enable_autopilot" {

--- a/ray-on-gke/user/modules/kuberay/variables.tf
+++ b/ray-on-gke/user/modules/kuberay/variables.tf
@@ -15,7 +15,7 @@
 variable "namespace" {
   type        = string
   description = "Kubernetes namespace where resources are deployed"
-  default     = "ray"
+  default     = "ray-system"
 }
 
 variable "enable_tpu" {


### PR DESCRIPTION
I got the impression from existing variables in the kuberay module that we intended to install kuberay-operator in the `ray` namespace, but since the namespace definition was missing from `helm_release` we are still installing kuberay-operator in the `default` namespace. This PR adds the namespace field to the helm release of kuberay-operator and changes the default value for the namespace to `ray-system`.