### PR TITLE
pin ray-cluster helm chart version to 0.6.1

### DIFF
--- a/ray-on-gke/user/modules/kuberay/kuberay.tf
+++ b/ray-on-gke/user/modules/kuberay/kuberay.tf
@@ -17,5 +17,6 @@ resource "helm_release" "ray-cluster" {
   repository = "https://ray-project.github.io/kuberay-helm/"
   chart      = "ray-cluster"
   namespace  = var.namespace
+  version    = "0.6.1"
   values     = var.enable_autopilot ? [file("${path.module}/kuberay-autopilot-values.yaml")] : (var.enable_tpu ? [file("${path.module}/kuberay-tpu-values.yaml")] : [file("${path.module}/kuberay-values.yaml")])
 }


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/ai-on-gke/pull/81 and https://github.com/GoogleCloudPlatform/ai-on-gke/pull/96 we pinned the kuberay-operator image version and the helm chart version to v0.6.1. However, the ray-cluster chart which installs the default RayCluster is using the latest version (v1.0.0-rc.1) which is trying to use the new v1 version of the CRDs that are not supported in v0.6.1 yet.  