### PR TITLE
Examples for Ray inferencing

### DIFF
--- a/gke-platform/main.tf
+++ b/gke-platform/main.tf
@@ -70,11 +70,14 @@ module "gke_autopilot" {
 module "gke_standard" {
   source = "./modules/gke_standard"
 
-  project_id       = var.project_id
-  region           = var.region
-  cluster_name     = var.cluster_name
-  enable_autopilot = var.enable_autopilot
-  enable_tpu       = var.enable_tpu
+  project_id                = var.project_id
+  region                    = var.region
+  cluster_name              = var.cluster_name
+  enable_autopilot          = var.enable_autopilot
+  enable_tpu                = var.enable_tpu
+  gpu_pool_machine_type     = var.gpu_pool_machine_type
+  gpu_pool_accelerator_type = var.gpu_pool_accelerator_type
+  gpu_pool_node_locations   = var.gpu_pool_node_locations
 }
 
 module "kubernetes" {

--- a/gke-platform/modules/gke_standard/main.tf
+++ b/gke-platform/modules/gke_standard/main.tf
@@ -79,6 +79,8 @@ resource "google_container_node_pool" "gpu_pool" {
   count      = var.enable_autopilot || var.enable_tpu ? 0 : 1
   cluster    = var.enable_autopilot || var.enable_tpu ? null : google_container_cluster.ml_cluster[0].name
 
+  node_locations = var.gpu_pool_node_locations
+  
   autoscaling {
     min_node_count = "1"
     max_node_count = "3"
@@ -105,17 +107,17 @@ resource "google_container_node_pool" "gpu_pool" {
     }
 
     guest_accelerator {
-      type  = "nvidia-tesla-t4"
+      type  = var.gpu_pool_accelerator_type
       count = 2
     }
 
     # preemptible  = true
     image_type   = "cos_containerd"
-    machine_type = "n1-standard-16"
+    machine_type = var.gpu_pool_machine_type
     tags         = ["gke-node", "${var.project_id}-gke"]
 
-    disk_size_gb = "100"
-    disk_type    = "pd-standard"
+    disk_size_gb = "200"
+    disk_type    = "pd-balanced"
 
     metadata = {
       disable-legacy-endpoints = "true"

--- a/gke-platform/modules/gke_standard/variables.tf
+++ b/gke-platform/modules/gke_standard/variables.tf
@@ -52,3 +52,21 @@ variable "enable_tpu" {
   description = "Set to true to create TPU node pool"
   default     = false
 }
+
+variable "gpu_pool_machine_type" {
+  type        = string
+  description = "Specify the gpu-pool machine type"
+  default     = "n1-standard-16"
+}
+
+variable "gpu_pool_accelerator_type" {
+  type        = string
+  description = "Specify the gpu-pool machine type"
+  default     = "nvidia-tesla-t4"
+}
+
+variable "gpu_pool_node_locations" {
+  type        = list
+  description = "Specify the gpu-pool node zone locations"
+  default     = ["us-central1-a", "us-central1-c", "us-central1-f"]
+}

--- a/gke-platform/modules/kuberay/kuberay-operator-autopilot-values.yaml
+++ b/gke-platform/modules/kuberay/kuberay-operator-autopilot-values.yaml
@@ -18,7 +18,7 @@
 
 image:
   repository: kuberay/operator
-  tag: v0.6.0
+  tag: v1.0.0
   pullPolicy: IfNotPresent
 
 nameOverride: "kuberay-operator"

--- a/gke-platform/modules/kuberay/kuberay-operator-values.yaml
+++ b/gke-platform/modules/kuberay/kuberay-operator-values.yaml
@@ -18,7 +18,7 @@
 
 image:
   repository: kuberay/operator
-  tag: v0.6.0
+  tag: v1.0.0
   pullPolicy: IfNotPresent
 
 nameOverride: "kuberay-operator"

--- a/gke-platform/modules/kuberay/kuberay.tf
+++ b/gke-platform/modules/kuberay/kuberay.tf
@@ -23,6 +23,6 @@ resource "helm_release" "kuberay-operator" {
   repository = "https://ray-project.github.io/kuberay-helm/"
   chart      = "kuberay-operator"
   values     = var.enable_autopilot ? [file("${path.module}/kuberay-operator-autopilot-values.yaml")] : [file("${path.module}/kuberay-operator-values.yaml")]
-  version    = "0.6.1"
+  version    = "1.0.0"
   namespace  = "${kubernetes_namespace.ray_namespace.metadata[0].name}"
 }

--- a/gke-platform/variables.tf
+++ b/gke-platform/variables.tf
@@ -41,3 +41,21 @@ variable "enable_tpu" {
   description = "Set to true to create TPU node pool"
   default     = false
 }
+
+variable "gpu_pool_machine_type" {
+  type        = string
+  description = "Specify the gpu-pool machine type"
+  default     = "n1-standard-16"
+}
+
+variable "gpu_pool_accelerator_type" {
+  type        = string
+  description = "Specify the gpu accelerator type"
+  default     = "nvidia-tesla-t4"
+}
+
+variable "gpu_pool_node_locations" {
+  type        = list
+  description = "Specify the gpu-pool node zone locations"
+  default     = ["us-central1-a", "us-central1-c", "us-central1-f"]
+}

--- a/ray-on-gke/.gitignore
+++ b/ray-on-gke/.gitignore
@@ -1,0 +1,1 @@
+**/hf-secret.yaml

--- a/ray-on-gke/rayservice-examples/README.md
+++ b/ray-on-gke/rayservice-examples/README.md
@@ -1,0 +1,269 @@
+# Serve meta llama2 (7b, 13b), llama2 70b quantized, falcon 7b or falcon40 quantized models
+
+Use `RayService` and `ray-llm`, which manages a Ray Cluster to load your models for inferencing 
+
+## Get a huggingface token and apply for access to the llama2 model
+- Sign up for huggingface account
+- Get your read API token
+  - Profile -> Settings -> Access Token -> New Token
+- Enable access to the [model](https://huggingface.co/meta-llama/Llama-2-7b-chat-hf) on huggingface
+
+## Pre-requisites
+- Navigate to the `gke-platform` folder
+- Specify values to deploy `L4` GPUs in the cluster, in the `gke-platform` folder.
+```zsh
+cat << EOF > terraform.tfvars
+gpu_pool_machine_type="g2-standard-24"
+gpu_pool_accelerator_type="nvidia-l4"
+gpu_pool_node_locations=["us-central1-a", "us-central1-c"]
+EOF
+```
+
+- Deploy GKE (tested on gke_standard)
+```zsh
+terraform init
+terraform apply --auto-approve
+```
+ 
+- Return to the `llm-on-ray` folder
+- Prepare your HF token as a secret
+> NOTE: In this example, this is needed for the llama-2 models, not the falcon.
+```zsh
+export HF_API_TOKEN=<<YOUR_HF_API_TOKEN>>
+kubectl create secret generic hf-secret \
+    --from-literal=hf_api_token=${HF_API_TOKEN} \
+    --dry-run=client -o yaml > hf-secret.yaml
+```
+
+- Get context to your GKE cluster
+```zsh
+gcloud container clusters get-credentials ml-cluster --region us-central1
+```
+
+> NOTE: The pre-built rayllm container image has models that references different accelerator types. For this example we are using nvidia `L4` GPUs, so the `spec.serveConfigV2` in `RayService` points to a [repo archive](https://github.com/kenthua/ai-ml) which contains models that uses the `L4` accelerator type. Alternatively, you can build an image as part of the pipeline and include your desired models.
+
+## Instructions for meta llama2 (7b, 13b) or falcon 7b chat model
+This example uses the `rayllm.backend:router_application` to load the model.
+
+- Deploy the RayService, below is the llama2 7b model, but you can change the `rayservice-*` filename to your desired model. llama2 (7b, 13b) or falcon 7b 
+```zsh
+kubectl apply -f hf-secret.yaml
+kubectl apply -f rayservice-meta-llama2-7b.yaml
+```
+
+- Confirm the model is ready, from status `DEPLOYING` to `RUNNING`
+```zsh
+export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -n default -o custom-columns=POD:metadata.name --no-headers)
+
+watch --color --interval 5 --no-title "kubectl exec -n default -it $HEAD_POD -- serve status | GREP_COLOR='01;92' egrep --color=always -e '^' -e 'RUNNING'"
+```
+
+### Access the serving endpoint
+- Port forward the serving port to your local environment
+```
+kubectl port-forward service/rayllm-serve-svc 8000:8000
+```
+
+- Test out the inference endpoint
+> NOTE: Change the model below in the json model value to reflect the deployed model. i.e. `tiiuae/falcon-7b` or `meta-llama/Llama-2-13b-chat-hf`.
+
+```zsh
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-llama/Llama-2-7b-chat-hf",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "What are the top 5 most popular programming languages? Please be brief."}
+    ],
+    "temperature": 0.7
+  }'
+```
+
+### Test out the endpoint with a sample gradio app
+
+The [sample gradio app](https://github.com/kenthua/gradio-app) at the moment only supports chat completions json spec so it won't work with TGI text spec, which is what the quantized models in the later section uses. If you deploy the gradio application, you do not need the port forward of 8000 above
+
+- Deploy the sample gradio application
+> NOTE: If you deploy other models such as the `falcon-7b` or the `llama2-13b`, be sure to change the model value in the `gradio.yaml`.
+
+```zsh
+kubectl apply -f gradio.yaml
+```
+
+- Extract out the external IP of the service to be used. It may take a few minutes for the IP to be available.
+```zsh
+EXTERNAL_IP=$(kubectl get services gradio \
+    --output jsonpath='{.status.loadBalancer.ingress[0].ip}')
+echo -e "\nGradio URL: http://${EXTERNAL_IP}\n"
+```
+
+## Instructions for meta llama-2 70b chat or falcon 40b model with 4bit quantization
+
+> NOTE: If you deployed the previous 7b example, it will be overwritten by this example. You will also need the huggingface api token for the falcon 40b example because it's an input for the huggingface transformer example.
+
+The `spec.serveConfigV2.applications.import_path` points to custom python which uses huggingface transformer `BitsAndBytesConfig` & `AutoModelForCausalLM` libraries to load the quantized model, so that we can fit the 70b or 40b parameter models into 2x `L4` GPUs. This example uses `ray-llm` as the container image though it's not using the `rayllm.backend:router_application` to load the model.
+
+- Deploy the RayService, below is the llama2 70b model, but you can change the `rayservice-*` filename to your desired model. llama2 70b or falcon 40b.
+```zsh
+kubectl apply -f hf-secret.yaml
+kubectl apply -f rayservice-meta-llama2-70b-quantized.yaml
+```
+
+- Confirm the model is ready, from status `DEPLOYING` to `RUNNING`
+```zsh
+export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -n default -o custom-columns=POD:metadata.name --no-headers)
+
+watch --color --interval 5 --no-title "kubectl exec -n default -it $HEAD_POD -- serve status | GREP_COLOR='01;92' egrep --color=always -e '^' -e 'RUNNING'"
+```
+
+### Access the serving endpoint
+- Port forward the serving port to your local environment
+```
+kubectl port-forward service/rayllm-serve-svc 8000:8000
+```
+
+- Test out the inference endpoint
+```zsh
+curl -X POST http://localhost:8000/ \
+  -H "Content-Type: application/json" \
+  -d '{"text": "How do I bake a pie?"}'
+```
+
+## Insights & Debugging
+
+Debugging and insights can be made available through Ray either via CLI or UI
+
+### UI
+
+Through the UI, the ray head group provides a layer to view the status of the Ray cluster. It provides observability of your Ray Cluster such as: status, resource consumption, jobs, etc
+
+- Forward the head port 8265 to access the UI
+```zsh
+export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -n default -o custom-columns=POD:metadata.name --no-headers)
+
+kubectl port-forward pod/$HEAD_POD 8265:8265
+```
+
+### CLI
+
+Ray provides both `ray` and `serve` CLI tools to view status of your Ray Cluster
+
+- Exec into the Ray head pod to be able to run the CLI commands
+```zsh
+export HEAD_POD=$(kubectl get pods --selector=ray.io/node-type=head -n default -o custom-columns=POD:metadata.name --no-headers)
+
+kubectl exec -n default -it $HEAD_POD -- bash
+```
+
+Once in the shell of the head pod you can run a few commands
+
+- The status of this Ray cluster
+```zsh
+ray status
+```
+
+Output (do not copy)
+```zsh
+======== Autoscaler status: 2023-11-13 14:16:18.210554 ========
+Node status
+---------------------------------------------------------------
+Healthy:
+ 1 node_dc3f939f1b0ed1b731eefe1857bdb2d86fca5a33555a1c32389c4d46
+ 1 node_9bae5b87f4cee179dabd482d3e13d5df9eb67e728c62d709925688b7
+Pending:
+ (no pending nodes)
+Recent failures:
+ (no failures)
+
+Resources
+---------------------------------------------------------------
+Usage:
+ 3.0/22.0 CPU (1.0 used of 4.0 reserved in placement groups)
+ 1.0/3.0 GPU (1.0 used of 1.0 reserved in placement groups)
+ 0.0/22.0 accelerator_type_cpu
+ 0.010000000000000018/1.0 accelerator_type_l4 (0.01 used of 0.02 reserved in placement groups)
+ 0B/26.63GiB memory
+ 88B/7.87GiB object_store_memory
+
+Demands:
+ (no resource demands)
+```
+
+- The nodes for this Ray cluster
+```zsh
+ray list nodes
+```
+
+Output (do not copy)
+```zsh
+======== List: 2023-11-13 14:16:39.406959 ========
+Stats:
+------------------------------
+Total: 2
+
+Table:
+------------------------------
+    NODE_ID                                                   NODE_IP     IS_HEAD_NODE    STATE    NODE_NAME    RESOURCES_TOTAL                 LABELS
+ 0  9bae5b87f4cee179dabd482d3e13d5df9eb67e728c62d709925688b7  10.92.0.10  True            ALIVE    10.92.0.10   CPU: 2.0                        ray.io/node_id: 9bae5b87f4cee179dabd482d3e13d5df9eb67e728c62d709925688b7
+                                                                                                                GPU: 2.0
+                                                                                                                accelerator_type:L4: 1.0
+                                                                                                                accelerator_type_cpu: 2.0
+                                                                                                                memory: 8.000 GiB
+                                                                                                                node:10.92.0.10: 1.0
+                                                                                                                node:__internal_head__: 1.0
+                                                                                                                object_store_memory: 2.307 GiB
+ 1  dc3f939f1b0ed1b731eefe1857bdb2d86fca5a33555a1c32389c4d46  10.92.0.11  False           ALIVE    10.92.0.11   CPU: 20.0                       ray.io/node_id: dc3f939f1b0ed1b731eefe1857bdb2d86fca5a33555a1c32389c4d46
+                                                                                                                GPU: 1.0
+                                                                                                                accelerator_type:L4: 1.0
+                                                                                                                accelerator_type_cpu: 20.0
+                                                                                                                accelerator_type_l4: 1.0
+                                                                                                                memory: 18.626 GiB
+                                                                                                                node:10.92.0.11: 1.0
+                                                                                                                object_store_memory: 5.561 GiB
+```
+
+- The config that Ray serve has loaded
+```zsh
+serve config
+```
+
+Output (do not copy)
+```zsh
+name: ray-llm
+route_prefix: /
+import_path: rayllm.backend:router_application
+runtime_env:
+  working_dir: https://github.com/kenthua/ai-ml/archive/refs/tags/v0.0.5.zip
+args:
+  models:
+  - ./models/meta-llama--Llama-2-7b-chat-hf.yaml
+```
+
+- The status of what Ray is serving
+```zsh
+serve status
+```
+
+Output (do not copy)
+```zsh
+proxies:
+  9bae5b87f4cee179dabd482d3e13d5df9eb67e728c62d709925688b7: HEALTHY
+  dc3f939f1b0ed1b731eefe1857bdb2d86fca5a33555a1c32389c4d46: HEALTHY
+applications:
+  ray-llm:
+    status: RUNNING
+    message: ''
+    last_deployed_time_s: 1699909731.439014
+    deployments:
+      VLLMDeployment:meta-llama--Llama-2-7b-chat-hf:
+        status: HEALTHY
+        replica_states:
+          RUNNING: 1
+        message: ''
+      Router:
+        status: HEALTHY
+        replica_states:
+          RUNNING: 2
+        message: ''
+```

--- a/ray-on-gke/rayservice-examples/gradio.yaml
+++ b/ray-on-gke/rayservice-examples/gradio.yaml
@@ -1,0 +1,55 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gradio
+  labels:
+    app: gradio
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gradio
+  template:
+    metadata:
+      labels:
+        app: gradio
+    spec:
+      containers:
+      - name: gradio
+        image: ghcr.io/kenthua/gradio-app:0.0.3
+        env:
+        - name: MODEL_ID
+          value: "meta-llama/Llama-2-7b-chat-hf"
+        - name: CONTEXT_PATH
+          value: "/v1/chat/completions"
+        - name: HOST
+          value: "http://rayllm-serve-svc:8000"
+        ports:
+        - containerPort: 7860
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: gradio
+spec:
+  selector:
+    app: gradio
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 7860
+  type: LoadBalancer

--- a/ray-on-gke/rayservice-examples/ingress/README.md
+++ b/ray-on-gke/rayservice-examples/ingress/README.md
@@ -1,0 +1,39 @@
+# Expose your serve endpoint
+
+> NOTE: This is just an example for testing. One scenario you would expose it as an [internal IP](https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#deploy_a_regional_internal_gateway) that you would call within your VPC. Another scenario if external, you would have Google Cloud [manage a certificate](https://cloud.google.com/kubernetes-engine/docs/how-to/deploying-gateways#deploy_a_global_external_gateway) for you or provide your own.
+
+## Deploy the resources for your gateway
+- The gateway resource
+```zsh
+kubectl apply -f gateway.yaml
+```
+
+- Deploy the HTTPRoute resource that will route traffic to your aviary endpoint
+```zsh
+kubectl apply -f httproute.yaml
+```
+
+- Deploy a custom health check policy because the aviary endpoint does not respond with a 200 on "/", however when deployed "/-/routes" does
+```zsh
+kubectl apply -f healthcheckpolicy.yaml
+```
+
+- Check to see what the external IP is in this example
+```zsh
+EXTERNAL_IP=$(kubectl get gateways.gateway.networking.k8s.io external-http -o=jsonpath="{.status.addresses[0].value}")
+echo ${EXTERNAL_IP}
+```
+
+- Try the call to your ray serve endpoint now
+```zsh
+curl http://${EXTERNAL_IP}/meta-llama--Llama-2-7b-chat-hf/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "meta-llama/Llama-2-7b-chat-hf",
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "What are the top 5 most popular programming languages? Please be brief."}
+    ],
+    "temperature": 0.7
+  }'
+```

--- a/ray-on-gke/rayservice-examples/ingress/gateway.yaml
+++ b/ray-on-gke/rayservice-examples/ingress/gateway.yaml
@@ -1,0 +1,24 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: external-http
+spec:
+  gatewayClassName: gke-l7-global-external-managed
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80

--- a/ray-on-gke/rayservice-examples/ingress/healthcheckpolicy.yaml
+++ b/ray-on-gke/rayservice-examples/ingress/healthcheckpolicy.yaml
@@ -1,0 +1,35 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: networking.gke.io/v1
+kind: HealthCheckPolicy
+metadata:
+  name: endpoint-lb-healthcheck
+spec:
+  default:
+    checkIntervalSec: 30
+    timeoutSec: 10
+    healthyThreshold: 3
+    unhealthyThreshold: 3
+    logConfig:
+      enabled: true
+    config:
+      type: HTTP
+      httpHealthCheck:
+        port: 8000
+        requestPath: "/-/routes"
+  targetRef:
+    group: ""
+    kind: Service
+    name: rayllm-head-svc

--- a/ray-on-gke/rayservice-examples/ingress/httproute.yaml
+++ b/ray-on-gke/rayservice-examples/ingress/httproute.yaml
@@ -1,0 +1,26 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: HTTPRoute
+apiVersion: gateway.networking.k8s.io/v1beta1
+metadata:
+  name: serve-api-endpoint
+spec:
+  parentRefs:
+  - kind: Gateway
+    name: external-http
+  rules:
+  - backendRefs:
+    - name: rayllm-head-svc
+      port: 8000

--- a/ray-on-gke/rayservice-examples/model/meta-llama--Llama-2-13b-chat-hf.yaml
+++ b/ray-on-gke/rayservice-examples/model/meta-llama--Llama-2-13b-chat-hf.yaml
@@ -1,0 +1,53 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+deployment_config:
+  autoscaling_config:
+    min_replicas: 1
+    initial_replicas: 1
+    max_replicas: 8
+    target_num_ongoing_requests_per_replica: 16
+    metrics_interval_s: 10.0
+    look_back_period_s: 30.0
+    smoothing_factor: 0.5
+    downscale_delay_s: 300.0
+    upscale_delay_s: 15.0
+  max_concurrent_queries: 48
+  ray_actor_options:
+    resources:
+      accelerator_type_l4: 0.01
+engine_config:
+  model_id: meta-llama/Llama-2-13b-chat-hf
+  hf_model_id: meta-llama/Llama-2-13b-chat-hf
+  type: VLLMEngine
+  engine_kwargs:
+    max_num_batched_tokens: 12288
+    max_num_seqs: 48
+  max_total_tokens: 4096
+  generation:
+    prompt_format:
+      system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
+      user: "[INST] {system}{instruction} [/INST]"
+      system_in_user: true
+      default_system_message: ""
+    stopping_sequences: ["<unk>"]
+scaling_config:
+  num_workers: 2
+  num_gpus_per_worker: 1
+  num_cpus_per_worker: 8
+  placement_strategy: "STRICT_PACK"
+  resources_per_worker:
+    accelerator_type_l4: 0.01

--- a/ray-on-gke/rayservice-examples/model/meta-llama--Llama-2-7b-chat-hf.yaml
+++ b/ray-on-gke/rayservice-examples/model/meta-llama--Llama-2-7b-chat-hf.yaml
@@ -1,0 +1,55 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+deployment_config:
+  autoscaling_config:
+    min_replicas: 1
+    initial_replicas: 1
+    max_replicas: 8
+    target_num_ongoing_requests_per_replica: 24
+    metrics_interval_s: 10.0
+    look_back_period_s: 30.0
+    smoothing_factor: 0.5
+    downscale_delay_s: 300.0
+    upscale_delay_s: 15.0
+  max_concurrent_queries: 64
+  ray_actor_options:
+    resources:
+      accelerator_type_l4: 0.01
+engine_config:
+  model_id: meta-llama/Llama-2-7b-chat-hf
+  hf_model_id: meta-llama/Llama-2-7b-chat-hf
+  type: VLLMEngine
+  engine_kwargs:
+    trust_remote_code: true
+    max_num_batched_tokens: 4096
+    max_num_seqs: 64
+    gpu_memory_utilization: 0.9
+  max_total_tokens: 4096
+  generation:
+    prompt_format:
+      system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
+      user: "[INST] {system}{instruction} [/INST]"
+      system_in_user: true
+      default_system_message: ""
+    stopping_sequences: ["<unk>"]
+scaling_config:
+  num_workers: 1
+  num_gpus_per_worker: 1
+  num_cpus_per_worker: 3
+  placement_strategy: "STRICT_PACK"
+  resources_per_worker:
+    accelerator_type_l4: 0.01

--- a/ray-on-gke/rayservice-examples/model/tiiuae--falcon-7b.yaml
+++ b/ray-on-gke/rayservice-examples/model/tiiuae--falcon-7b.yaml
@@ -1,0 +1,55 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+deployment_config:
+  autoscaling_config:
+    min_replicas: 1
+    initial_replicas: 1
+    max_replicas: 8
+    target_num_ongoing_requests_per_replica: 24
+    metrics_interval_s: 10.0
+    look_back_period_s: 30.0
+    smoothing_factor: 0.5
+    downscale_delay_s: 300.0
+    upscale_delay_s: 15.0
+  max_concurrent_queries: 64
+  ray_actor_options:
+    resources:
+      accelerator_type_l4: 0.01
+engine_config:
+  model_id: tiiuae/falcon-7b
+  hf_model_id: tiiuae/falcon-7b
+  type: VLLMEngine
+  engine_kwargs:
+    trust_remote_code: false
+    max_num_batched_tokens: 2048
+    max_num_seqs: 64
+    gpu_memory_utilization: 0.9
+  max_total_tokens: 2048
+  generation:
+    prompt_format:
+      system: "<<SYS>>\n{instruction}\n<</SYS>>\n\n"
+      assistant: " {instruction} </s><s>"
+      trailing_assistant: ""
+      user: "[INST] {system}{instruction} [/INST]"
+      system_in_user: true
+      default_system_message: ""
+    stopping_sequences: ["<unk>"]
+scaling_config:
+  num_workers: 1
+  num_gpus_per_worker: 1
+  num_cpus_per_worker: 3
+  placement_strategy: "STRICT_PACK"
+  resources_per_worker:
+    accelerator_type_l4: 0.01

--- a/ray-on-gke/rayservice-examples/rayservice-meta-llama2-13b.yaml
+++ b/ray-on-gke/rayservice-examples/rayservice-meta-llama2-13b.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: ray.io/v1alpha1
+apiVersion: ray.io/v1
 kind: RayService
 metadata:
   name: rayllm

--- a/ray-on-gke/rayservice-examples/rayservice-meta-llama2-13b.yaml
+++ b/ray-on-gke/rayservice-examples/rayservice-meta-llama2-13b.yaml
@@ -1,0 +1,108 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1alpha1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 1200 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 1200 # Config for the health check threshold for deployments. Default value is 60.
+  serveConfigV2: |
+    applications:
+    - name: ray-llm
+      route_prefix: /
+      import_path: rayllm.backend:router_application
+      runtime_env:
+        working_dir: "https://github.com/kenthua/ai-ml/archive/refs/tags/v0.0.5.zip"
+      args:
+        models:
+        - "./models/meta-llama--Llama-2-13b-chat-hf.yaml"
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.4.0
+            resources:
+              limits:
+                cpu: 2
+                memory: 8Gi
+              requests:
+                cpu: 2
+                memory: 8Gi
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+            - containerPort: 7860
+              name: gradio           
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 22, \"accelerator_type_l4\": 2}"'
+      # pod template
+      template:
+        spec:
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.4.0
+            env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_api_token
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "22"
+                memory: "80G"
+                nvidia.com/gpu: 2
+              requests:
+                cpu: "22"
+                memory: "80G"
+                nvidia.com/gpu: 2
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4

--- a/ray-on-gke/rayservice-examples/rayservice-meta-llama2-70b-quantized.yaml
+++ b/ray-on-gke/rayservice-examples/rayservice-meta-llama2-70b-quantized.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: ray.io/v1alpha1
+apiVersion: ray.io/v1
 kind: RayService
 metadata:
   name: rayllm

--- a/ray-on-gke/rayservice-examples/rayservice-meta-llama2-70b-quantized.yaml
+++ b/ray-on-gke/rayservice-examples/rayservice-meta-llama2-70b-quantized.yaml
@@ -1,0 +1,109 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1alpha1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 2400 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 2400 # Config for the health check threshold for deployments. Default value is 60.
+  # setting the MODEL_ID env var on the workerGroupSpec did not work, it couldn't find it during exec
+  serveConfigV2: |
+    applications:
+    - name: llama-2
+      route_prefix: /
+      import_path: model_nf4_mg:chat_app_nf4_mg
+      runtime_env:
+        working_dir: "https://github.com/kenthua/ai-ml/archive/refs/tags/v0.0.5.zip"
+        env_vars:
+          MODEL_ID: "meta-llama/Llama-2-70b-chat-hf"
+      deployments:
+      - name: Chat
+        num_replicas: 1
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.4.0
+            resources:
+              limits:
+                cpu: 2
+                memory: 8Gi
+              requests:
+                cpu: 2
+                memory: 8Gi
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 22, \"accelerator_type_l4\": 2}"'
+      # pod template
+      template:
+        spec:
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.4.0
+            env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_api_token
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "22"
+                memory: "40G"
+                nvidia.com/gpu: 2
+              requests:
+                cpu: "22"
+                memory: "40G"
+                nvidia.com/gpu: 2
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4

--- a/ray-on-gke/rayservice-examples/rayservice-meta-llama2-7b.yaml
+++ b/ray-on-gke/rayservice-examples/rayservice-meta-llama2-7b.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: ray.io/v1alpha1
+apiVersion: ray.io/v1
 kind: RayService
 metadata:
   name: rayllm

--- a/ray-on-gke/rayservice-examples/rayservice-meta-llama2-7b.yaml
+++ b/ray-on-gke/rayservice-examples/rayservice-meta-llama2-7b.yaml
@@ -1,0 +1,106 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1alpha1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 1200 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 1200 # Config for the health check threshold for deployments. Default value is 60.
+  serveConfigV2: |
+    applications:
+    - name: ray-llm
+      route_prefix: /
+      import_path: rayllm.backend:router_application
+      runtime_env:
+        working_dir: "https://github.com/kenthua/ai-ml/archive/refs/tags/v0.0.5.zip"
+      args:
+        models:
+        - "./models/meta-llama--Llama-2-7b-chat-hf.yaml"
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.4.0
+            resources:
+              limits:
+                cpu: 2
+                memory: 8Gi
+              requests:
+                cpu: 2
+                memory: 8Gi
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 20, \"accelerator_type_l4\": 1}"'
+      # pod template
+      template:
+        spec:
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.4.0
+            env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_api_token
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "20"
+                memory: "20G"
+                nvidia.com/gpu: 1
+              requests:
+                cpu: "20"
+                memory: "20G"
+                nvidia.com/gpu: 1
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4

--- a/ray-on-gke/rayservice-examples/rayservice-tiiuae-falcon-40b-quantized.yaml
+++ b/ray-on-gke/rayservice-examples/rayservice-tiiuae-falcon-40b-quantized.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: ray.io/v1alpha1
+apiVersion: ray.io/v1
 kind: RayService
 metadata:
   name: rayllm

--- a/ray-on-gke/rayservice-examples/rayservice-tiiuae-falcon-40b-quantized.yaml
+++ b/ray-on-gke/rayservice-examples/rayservice-tiiuae-falcon-40b-quantized.yaml
@@ -1,0 +1,109 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1alpha1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 2400 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 2400 # Config for the health check threshold for deployments. Default value is 60.
+  # setting the MODEL_ID env var on the workerGroupSpec did not work, it couldn't find it during exec
+  serveConfigV2: |
+    applications:
+    - name: falcon
+      route_prefix: /
+      import_path: model_nf4_mg:chat_app_nf4_mg
+      runtime_env:
+        working_dir: "https://github.com/kenthua/ai-ml/archive/refs/tags/v0.0.5.zip"
+        env_vars:
+          MODEL_ID: "tiiuae/falcon-40b"
+      deployments:
+      - name: Chat
+        num_replicas: 1
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.4.0
+            resources:
+              limits:
+                cpu: 2
+                memory: 8Gi
+              requests:
+                cpu: 2
+                memory: 8Gi
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 22, \"accelerator_type_l4\": 2}"'
+      # pod template
+      template:
+        spec:
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.4.0
+            env:
+            - name: HUGGING_FACE_HUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-secret
+                  key: hf_api_token
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "22"
+                memory: "40G"
+                nvidia.com/gpu: 2
+              requests:
+                cpu: "22"
+                memory: "40G"
+                nvidia.com/gpu: 2
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4

--- a/ray-on-gke/rayservice-examples/rayservice-tiiuae-falcon-7b.yaml
+++ b/ray-on-gke/rayservice-examples/rayservice-tiiuae-falcon-7b.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: ray.io/v1alpha1
+apiVersion: ray.io/v1
 kind: RayService
 metadata:
   name: rayllm

--- a/ray-on-gke/rayservice-examples/rayservice-tiiuae-falcon-7b.yaml
+++ b/ray-on-gke/rayservice-examples/rayservice-tiiuae-falcon-7b.yaml
@@ -1,0 +1,100 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: ray.io/v1alpha1
+kind: RayService
+metadata:
+  name: rayllm
+spec:
+  serviceUnhealthySecondThreshold: 1200 # Config for the health check threshold for service. Default value is 60.
+  deploymentUnhealthySecondThreshold: 1200 # Config for the health check threshold for deployments. Default value is 60.
+  serveConfigV2: |
+    applications:
+    - name: ray-llm
+      route_prefix: /
+      import_path: rayllm.backend:router_application
+      runtime_env:
+        working_dir: "https://github.com/kenthua/ai-ml/archive/refs/tags/v0.0.5.zip"
+      args:
+        models:
+        - "./models/tiiuae--falcon-7b.yaml"
+  rayClusterConfig:
+    # Ray head pod template
+    headGroupSpec:
+      # The `rayStartParams` are used to configure the `ray start` command.
+      # See https://github.com/ray-project/kuberay/blob/master/docs/guidance/rayStartParams.md for the default settings of `rayStartParams` in KubeRay.
+      # See https://docs.ray.io/en/latest/cluster/cli.html#ray-start for all available options in `rayStartParams`.
+      rayStartParams:
+        resources: '"{\"accelerator_type_cpu\": 2}"'
+        dashboard-host: '0.0.0.0'
+        block: 'true'
+      #pod template
+      template:
+        spec:
+          containers:
+          - name: ray-head
+            image: anyscale/ray-llm:0.4.0
+            resources:
+              limits:
+                cpu: 2
+                memory: 8Gi
+              requests:
+                cpu: 2
+                memory: 8Gi
+            ports:
+            - containerPort: 6379
+              name: gcs-server
+            - containerPort: 8265 # Ray dashboard
+              name: dashboard
+            - containerPort: 10001
+              name: client
+            - containerPort: 8000
+              name: serve
+    workerGroupSpecs:
+    # the pod replicas in this group typed worker
+    - replicas: 1
+      minReplicas: 0
+      maxReplicas: 1
+      # logical group name, for this called small-group, also can be functional
+      groupName: gpu-group
+      rayStartParams:
+        block: 'true'
+        resources: '"{\"accelerator_type_cpu\": 20, \"accelerator_type_l4\": 1}"'
+      # pod template
+      template:
+        spec:
+          containers:
+          - name: llm
+            image: anyscale/ray-llm:0.4.0
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh","-c","ray stop"]
+            resources:
+              limits:
+                cpu: "20"
+                memory: "20G"
+                nvidia.com/gpu: 1
+              requests:
+                cpu: "20"
+                memory: "20G"
+                nvidia.com/gpu: 1
+          # Please ensure the following taint has been applied to the GPU node in the cluster.
+          tolerations:
+            - key: "ray.io/node-type"
+              operator: "Equal"
+              value: "worker"
+              effect: "NoSchedule"
+          nodeSelector:
+            cloud.google.com/gke-accelerator: nvidia-l4


### PR DESCRIPTION
- Modify `gke-platform` so that gpu-pool machinetype, accelerator and nodepool locations are variables. Primarily to support L4 accelerators
- Examples for llm serving with rayllm & ray serve (with various model parameter sizes)

