### PR TITLE
Add flags for disk type and machine type; Update default values to im…

### DIFF
--- a/gke-disk-image-builder/cli/main.go
+++ b/gke-disk-image-builder/cli/main.go
@@ -42,7 +42,9 @@ func main() {
 	imageName := flag.String("image-name", "", "name of the image that will be generated")
 	zone := flag.String("zone", "", "zone where the resources will be used to create the image creator resources")
 	gcsPath := flag.String("gcs-path", "", "gcs location to dump the logs")
-	diskSizeGb := flag.Int64("disk-size-gb", 10, "size of a disk that will host the unpacked images")
+	machineType := flag.String("machine-type", "n2-standard-16", "GCE instance machine type to generate the disk image")
+	diskType := flag.String("disk-type", "pd-ssd", "disk type to generate the disk image")
+	diskSizeGb := flag.Int64("disk-size-gb", 60, "disk size to prepare unpack container images")
 	gcpOAuth := flag.String("gcp-oauth", "", "path to GCP service account credential file")
 	imagePullAuth := flag.String("image-pull-auth", "None", "auth mechanism to pull the container image, valid values: [None, ServiceAccountToken].\nNone means that the images are publically available and no authentication is required to pull them.\nServiceAccountToken means the service account oauth token will be used to pull the images.\nFor more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications")
 	timeout := flag.String("timeout", "20m", "Default timout for each step, defaults to 20m")
@@ -73,6 +75,8 @@ func main() {
 		ProjectName:     *projectName,
 		Zone:            *zone,
 		GCSPath:         *gcsPath,
+		MachineType:     *machineType,
+		DiskType:        *diskType,
 		DiskSizeGB:      *diskSizeGb,
 		GCPOAuth:        *gcpOAuth,
 		ContainerImages: containerImages,

--- a/gke-disk-image-builder/cli/main.go
+++ b/gke-disk-image-builder/cli/main.go
@@ -44,7 +44,7 @@ func main() {
 	gcsPath := flag.String("gcs-path", "", "gcs location to dump the logs")
 	machineType := flag.String("machine-type", "n2-standard-16", "GCE instance machine type to generate the disk image")
 	diskType := flag.String("disk-type", "pd-ssd", "disk type to generate the disk image")
-	diskSizeGb := flag.Int64("disk-size-gb", 60, "disk size to prepare unpack container images")
+	diskSizeGb := flag.Int64("disk-size-gb", 60, "disk size to unpack container images")
 	gcpOAuth := flag.String("gcp-oauth", "", "path to GCP service account credential file")
 	imagePullAuth := flag.String("image-pull-auth", "None", "auth mechanism to pull the container image, valid values: [None, ServiceAccountToken].\nNone means that the images are publically available and no authentication is required to pull them.\nServiceAccountToken means the service account oauth token will be used to pull the images.\nFor more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications")
 	timeout := flag.String("timeout", "20m", "Default timout for each step, defaults to 20m")

--- a/gke-disk-image-builder/imager.go
+++ b/gke-disk-image-builder/imager.go
@@ -51,6 +51,8 @@ type Request struct {
 	ProjectName     string
 	Zone            string
 	GCSPath         string
+	MachineType     string
+	DiskType        string
 	DiskSizeGB      int64
 	GCPOAuth        string
 	ContainerImages []string
@@ -107,7 +109,7 @@ func GenerateDiskImage(ctx context.Context, req Request) error {
 					},
 					Disk: compute.Disk{
 						Name:   fmt.Sprintf("%s-disk", name),
-						Type:   "pd-balanced",
+						Type:   req.DiskType,
 						SizeGb: req.DiskSizeGB,
 					},
 				},
@@ -124,7 +126,8 @@ func GenerateDiskImage(ctx context.Context, req Request) error {
 							StartupScript: "startup.sh",
 						},
 						Instance: compute.Instance{
-							Name: fmt.Sprintf("%s-instance", name),
+							Name:        fmt.Sprintf("%s-instance", name),
+							MachineType: fmt.Sprintf("zones/%s/machineTypes/%s", req.Zone, req.MachineType),
 							Disks: []*compute.AttachedDisk{
 								&compute.AttachedDisk{
 									AutoDelete: true,
@@ -134,7 +137,7 @@ func GenerateDiskImage(ctx context.Context, req Request) error {
 									Mode:       "READ_WRITE",
 									InitializeParams: &compute.AttachedDiskInitializeParams{
 										DiskSizeGb:  req.DiskSizeGB,
-										DiskType:    fmt.Sprintf("projects/%s/zones/%s/diskTypes/pd-balanced", req.ProjectName, req.Zone),
+										DiskType:    fmt.Sprintf("projects/%s/zones/%s/diskTypes/%s", req.ProjectName, req.Zone, req.DiskType),
 										SourceImage: "projects/debian-cloud/global/images/debian-11-bullseye-v20230912",
 									},
 								},


### PR DESCRIPTION
Add flags for disk type and machine type; Update default values to improve performance.
The time is improved from 12 mins to 8 mins (33% reduction) for a 6.39 GB container nvcr.io/nvidia/tritonserver:23.09-py3

```
$ time go run ./cli     --project-name=$PROJECT_NAME     --image-name=triton-2309-py3-n2     --zone=$ZONE     --gcs-path=gs://$GCS_PATH/     --container-image='nvcr.io/nvidia/tritonserver:23.09-py3'     --disk-size-gb=100
Wed Nov 22 07:15:20 PM UTC 2023: executing "go run ./cli --project-name=$PROJECT_NAME --image-name=triton-2309-py3-n2 --zone=$ZONE --gcs-path=gs://$GCS_PATH/ --container-image='nvcr.io/nvidia/tritonserver:23.09-py3' --disk-size-gb=100"
[secondary-disk-image]: 2023-11-22T19:15:22Z Validating workflow
[secondary-disk-image]: 2023-11-22T19:15:22Z Validating step "create-disk"
[secondary-disk-image]: 2023-11-22T19:15:22Z Validating step "create-instance"
[secondary-disk-image]: 2023-11-22T19:15:23Z Validating step "wait-on-image-creation"
[secondary-disk-image]: 2023-11-22T19:15:23Z Validating step "detach-disk"
[secondary-disk-image]: 2023-11-22T19:15:23Z Validating step "create-image"
[secondary-disk-image]: 2023-11-22T19:15:24Z Validation Complete
[secondary-disk-image]: 2023-11-22T19:15:24Z Workflow Project: xxx
[secondary-disk-image]: 2023-11-22T19:15:24Z Workflow Zone: us-west1-b
[secondary-disk-image]: 2023-11-22T19:15:24Z Workflow GCSPath: xxx
[secondary-disk-image]: 2023-11-22T19:15:24Z Daisy scratch path: xxx
[secondary-disk-image]: 2023-11-22T19:15:24Z Uploading sources
[secondary-disk-image]: 2023-11-22T19:15:24Z Running workflow
[secondary-disk-image]: 2023-11-22T19:15:24Z Running step "create-disk" (CreateDisks)
[secondary-disk-image.create-disk]: 2023-11-22T19:15:24Z CreateDisks: Creating disk "secondary-disk-image-disk".
[secondary-disk-image]: 2023-11-22T19:15:25Z Step "create-disk" (CreateDisks) successfully finished.
[secondary-disk-image]: 2023-11-22T19:15:25Z Running step "create-instance" (CreateInstances)
[secondary-disk-image.create-instance]: 2023-11-22T19:15:25Z CreateInstances: Creating instance "secondary-disk-image-instance".
...
[secondary-disk-image]: 2023-11-22T19:20:53Z Running step "detach-disk" (DetachDisks)
[secondary-disk-image.detach-disk]: 2023-11-22T19:20:53Z DetachDisks: Detaching disk "secondary-disk-image-disk" from instance "secondary-disk-image-instance".
[secondary-disk-image]: 2023-11-22T19:20:56Z Step "detach-disk" (DetachDisks) successfully finished.
[secondary-disk-image]: 2023-11-22T19:20:56Z Running step "create-image" (CreateImages)
[secondary-disk-image.create-image]: 2023-11-22T19:20:56Z CreateImages: Creating image "triton-2309-py3-n2".
[secondary-disk-image]: 2023-11-22T19:22:48Z Step "create-image" (CreateImages) successfully finished.
[secondary-disk-image]: 2023-11-22T19:22:48Z Workflow "secondary-disk-image" cleaning up (this may take up to 2 minutes).
[secondary-disk-image]: 2023-11-22T19:23:37Z Workflow "secondary-disk-image" finished cleanup.
Image has successfully been created at: xxx

real    8m16.860s
user    0m3.416s
sys     0m3.539s

```