### PR TITLE
[gke-disk-image-builder] Set device name explicitly in startup.sh

### DIFF
--- a/gke-disk-image-builder/script/startup.sh
+++ b/gke-disk-image-builder/script/startup.sh
@@ -28,6 +28,8 @@ else
 fi
 
 # Check if disk is partitioned and update device node file path accordingly if so.
+# The disk name prefix is defined here: https://github.com/GoogleCloudPlatform/ai-on-gke/blob/71ebab897948cbca722c9abf4ec3ff2bc1318b3b/gke-disk-image-builder/imager.go#L32
+# The full disk name is then created here: https://github.com/GoogleCloudPlatform/ai-on-gke/blob/71ebab897948cbca722c9abf4ec3ff2bc1318b3b/gke-disk-image-builder/imager.go#L111
 DEVICE_NODE=/dev/disk/by-id/google-secondary-disk-image-disk
 if [[ -e "$DEVICE_NODE-part1" ]]; then
   DEVICE_NODE="$DEVICE_NODE-part1"

--- a/gke-disk-image-builder/script/startup.sh
+++ b/gke-disk-image-builder/script/startup.sh
@@ -27,16 +27,23 @@ else
   exit 1
 fi
 
+# Check if disk is partitioned and update disk path accordingly if so.
+DEVICE_NODE=/dev/disk/by-id/google-secondary-disk-image-disk
+if [[ -e "$DEVICE_NODE-part1" ]]; then
+  DEVICE_NODE="$DEVICE_NODE-part1"
+fi
+echo "using device node: $DEVICE_NODE"
+
 # Check if the device exists
-if ! [ -b /dev/sdb ]; then
-  echo Device /dev/sdb does not exist. Please rerun the tool to try it again.
+if ! [ -b /dev/disk/by-id/google-secondary-disk-image-disk ]; then
+  echo Device /dev/disk/by-id/google-secondary-disk-image-disk does not exist. Please rerun the tool to try it again.
   exit 1
 fi
 # Set ext4 as the file system.
-sudo mkfs.ext4 -F -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/sdb
+sudo mkfs.ext4 -F -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/disk/by-id/google-secondary-disk-image-disk
 # Check if the filesystem was created successfully
 if [ $? -ne 0 ]; then
-  echo Failed to create the filesystem on /dev/sdb. Please rerun the tool to try it again.
+  echo Failed to create the filesystem on /dev/disk/by-id/google-secondary-disk-image-disk. Please rerun the tool to try it again.
   exit 1
 fi
 
@@ -134,7 +141,7 @@ function unpack() {
   # Prepare the disk image directories.
   echo Preparing the disk image directories...
   sudo mkdir -p /mnt/disks/container_layers
-  sudo mount -o discard,defaults /dev/sdb /mnt/disks/container_layers
+  sudo mount -o discard,defaults /dev/disk/by-id/google-secondary-disk-image-disk /mnt/disks/container_layers
   # Check if the directory was successfully created
   if [ $? -ne 0 ]; then
     echo Failed to create the view for $snapshot. Please rerun the tool to try it again.

--- a/gke-disk-image-builder/script/startup.sh
+++ b/gke-disk-image-builder/script/startup.sh
@@ -27,7 +27,7 @@ else
   exit 1
 fi
 
-# Check if disk is partitioned and update disk path accordingly if so.
+# Check if disk is partitioned and update device node file path accordingly if so.
 DEVICE_NODE=/dev/disk/by-id/google-secondary-disk-image-disk
 if [[ -e "$DEVICE_NODE-part1" ]]; then
   DEVICE_NODE="$DEVICE_NODE-part1"
@@ -35,15 +35,15 @@ fi
 echo "using device node: $DEVICE_NODE"
 
 # Check if the device exists
-if ! [ -b /dev/disk/by-id/google-secondary-disk-image-disk ]; then
-  echo Device /dev/disk/by-id/google-secondary-disk-image-disk does not exist. Please rerun the tool to try it again.
+if ! [ -b "$DEVICE_NODE" ]; then
+  echo "Device $DEVICE_NODE does not exist. Please rerun the tool to try it again."
   exit 1
 fi
 # Set ext4 as the file system.
-sudo mkfs.ext4 -F -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard /dev/disk/by-id/google-secondary-disk-image-disk
+sudo mkfs.ext4 -F -m 0 -E lazy_itable_init=0,lazy_journal_init=0,discard $DEVICE_NODE
 # Check if the filesystem was created successfully
 if [ $? -ne 0 ]; then
-  echo Failed to create the filesystem on /dev/disk/by-id/google-secondary-disk-image-disk. Please rerun the tool to try it again.
+  echo Failed to create the filesystem on $DEVICE_NODE. Please rerun the tool to try it again.
   exit 1
 fi
 
@@ -141,7 +141,7 @@ function unpack() {
   # Prepare the disk image directories.
   echo Preparing the disk image directories...
   sudo mkdir -p /mnt/disks/container_layers
-  sudo mount -o discard,defaults /dev/disk/by-id/google-secondary-disk-image-disk /mnt/disks/container_layers
+  sudo mount -o discard,defaults $DEVICE_NODE /mnt/disks/container_layers
   # Check if the directory was successfully created
   if [ $? -ne 0 ]; then
     echo Failed to create the view for $snapshot. Please rerun the tool to try it again.


### PR DESCRIPTION
Fixes #124 

Evidently, the device node for hyperdisks is in not in the same location in the filesystem as other disk types (1st one /dev/sdb, 2nd one /dev/sdc, and so on). 

To fix this, we can use the device name explicitly: `/dev/disk/by-id/google-<device name>` (for non-partitioned disks) and `/dev/disk/by-id/google-<device name>-part1` (for partitioned disks).

The changes in this PR use the device name explicitly, as defined [here](https://github.com/GoogleCloudPlatform/ai-on-gke/blob/71ebab897948cbca722c9abf4ec3ff2bc1318b3b/gke-disk-image-builder/imager.go#L111).

I tested these changes manually with the following command and it worked:

`go run ./cli --project-name=$PROJECT_NAME --image-name=triton-2309-py3-hd --zone=$ZONE --gcs-path=gs://$GCS_PATH/ --container-image='nvcr.io/nvidia/tritonserver:23.09-py3' --machine-type=h3-standard-88 --disk-type=hyperdisk-balanced`

