### PR TITLE
gke-platform: add default cluster labels to GKE clusters

### DIFF
--- a/gke-platform/main.tf
+++ b/gke-platform/main.tf
@@ -63,6 +63,7 @@ module "gke_autopilot" {
   project_id       = var.project_id
   region           = var.region
   cluster_name     = var.cluster_name
+  cluster_labels   = var.cluster_labels
   enable_autopilot = var.enable_autopilot
 }
 
@@ -73,6 +74,7 @@ module "gke_standard" {
   project_id                = var.project_id
   region                    = var.region
   cluster_name              = var.cluster_name
+  cluster_labels            = var.cluster_labels
   enable_autopilot          = var.enable_autopilot
   enable_tpu                = var.enable_tpu
   gpu_pool_machine_type     = var.gpu_pool_machine_type

--- a/gke-platform/modules/gke_autopilot/main.tf
+++ b/gke-platform/modules/gke_autopilot/main.tf
@@ -48,5 +48,7 @@ resource "google_container_cluster" "ml_cluster" {
   }
 
   min_master_version = "1.28"
+
+  resource_labels = var.cluster_labels
 }
 

--- a/gke-platform/modules/gke_autopilot/variables.tf
+++ b/gke-platform/modules/gke_autopilot/variables.tf
@@ -30,6 +30,14 @@ variable "cluster_name" {
   default     = "ml-cluster"
 }
 
+variable "cluster_labels" {
+  type        = map
+  description = "GKE cluster labels"
+  default     =  {
+    created-by = "ai-on-gke"
+  }
+}
+
 variable "namespace" {
   type        = string
   description = "Kubernetes namespace where resources are deployed"

--- a/gke-platform/modules/gke_standard/main.tf
+++ b/gke-platform/modules/gke_standard/main.tf
@@ -49,6 +49,8 @@ resource "google_container_cluster" "ml_cluster" {
   release_channel {
     channel = "RAPID"
   }
+
+  resource_labels = var.cluster_labels
 }
 
 resource "google_container_node_pool" "cpu_pool" {

--- a/gke-platform/modules/gke_standard/variables.tf
+++ b/gke-platform/modules/gke_standard/variables.tf
@@ -30,6 +30,14 @@ variable "cluster_name" {
   default     = "ml-cluster"
 }
 
+variable "cluster_labels" {
+  type        = map
+  description = "GKE cluster labels"
+  default     =  {
+    created-by = "ai-on-gke"
+  }
+}
+
 variable "namespace" {
   type        = string
   description = "Kubernetes namespace where resources are deployed"

--- a/gke-platform/variables.tf
+++ b/gke-platform/variables.tf
@@ -30,6 +30,14 @@ variable "cluster_name" {
   default     = "ml-cluster"
 }
 
+variable "cluster_labels" {
+  type        = map
+  description = "GKE cluster labels"
+  default     =  {
+    created-by = "ai-on-gke"
+  }
+}
+
 variable "enable_autopilot" {
   type        = bool
   description = "Set to true to enable GKE Autopilot clusters"


### PR DESCRIPTION
Add default cluster labels so users can easily find clusters created using terraform modules in this repo 