### PR TITLE
Change image used by Jupyterhub

### DIFF
--- a/jupyter-on-gke/jupyter_config/config-selfauth.yaml
+++ b/jupyter-on-gke/jupyter_config/config-selfauth.yaml
@@ -23,7 +23,7 @@
 # Available chart versions: https://jupyterhub.github.io/helm-chart/
 hub:
   image: 
-    name: <Repo name here>
+    name: us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class
     tag: latest
   config:
     JupyterHub:


### PR DESCRIPTION
We now have a public AR repo that hosts our authentication class image. This PR changes the default image used. 