### PR TITLE
Modified username used by jupyterhub

### DIFF
--- a/jupyter-on-gke/authentication/authenticator/gcpiapjwtauthenticator/gcpiapjwtauthenticator.py
+++ b/jupyter-on-gke/authentication/authenticator/gcpiapjwtauthenticator/gcpiapjwtauthenticator.py
@@ -44,7 +44,7 @@ class IAPUserLoginHandler(BaseHandler):
             else:
                 logging.info(f'Successfully validated!')
         
-        username = user_email.lower()
+        username = user_email.lower().split("@")[0]
         user = self.user_from_username(username)
 
         self.set_login_cookie(user)


### PR DESCRIPTION
when logged in, it should show: ![image](https://github.com/GoogleCloudPlatform/ai-on-gke/assets/17622084/824b6b9e-c20b-464f-acae-d5939e9048e4)
and when the notebook starts, it should look like this in the terminal: ![image](https://github.com/GoogleCloudPlatform/ai-on-gke/assets/17622084/830a3565-861a-4ebf-a2bc-0558ea37af8a)