### PR TITLE
[GKE Disk Image Builder] Parameterize network and subnet

### DIFF
--- a/gke-disk-image-builder/README.md
+++ b/gke-disk-image-builder/README.md
@@ -50,6 +50,8 @@ Flag                | Required | Default | Description
 *--disk-size-gb*    | No       | 10      | Size of a disk that will host the unpacked images
 *--image-pull-auth* | No       | 'None'  | Auth mechanism to pull the container image, valid values: [None, ServiceAccountToken]. None means that the images are publically available and no authentication is required to pull them. ServiceAccountToken means the service account oauth token will be used to pull the images. For more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications
 *--timeout*         | No       | '20m'   | Default timeout for each step. Must be set to a proper value if the image is large to account for the pull and image creation time step.
+*--network*         | No       | 'default'   | VPC network used by the GCE resources used for creating the disk image.
+*--subnet*         | No       | 'default'   | Subnet used by the GCE resources used for creating the disk image.
 
 ### Go
 

--- a/gke-disk-image-builder/imager.go
+++ b/gke-disk-image-builder/imager.go
@@ -55,6 +55,8 @@ type Request struct {
 	DiskType        string
 	DiskSizeGB      int64
 	GCPOAuth        string
+	Network         string
+	Subnet          string
 	ContainerImages []string
 	Timeout         time.Duration
 	ImagePullAuth   ImagePullAuthMechanism
@@ -128,6 +130,12 @@ func GenerateDiskImage(ctx context.Context, req Request) error {
 						Instance: compute.Instance{
 							Name:        fmt.Sprintf("%s-instance", name),
 							MachineType: fmt.Sprintf("zones/%s/machineTypes/%s", req.Zone, req.MachineType),
+							NetworkInterfaces: []*compute.NetworkInterface{
+								{
+									Network:    req.Network,
+									Subnetwork: req.Subnet,
+								},
+							},
 							Disks: []*compute.AttachedDisk{
 								&compute.AttachedDisk{
 									AutoDelete: true,


### PR DESCRIPTION
Some users need the VM instance used to build the disk image to exist in a custom VPC network and/or subnet, rather than the default ones.

This change parameterizes the network and subnet fields of the GCE instance creation call and adds two new optional flags the user can specify: `--network` and `--subnet`.