### PR TITLE
Cleanup the dws job example

### DIFF
--- a/gke-dws-examples/job.yaml
+++ b/gke-dws-examples/job.yaml
@@ -11,8 +11,6 @@ spec:
   suspend: true
   template:
     spec:
-      nodeSelector:
-        cloud.google.com/gke-nodepool: dws-nodepool
       tolerations:
       - key: "nvidia.com/gpu"
         operator: "Exists"


### PR DESCRIPTION
I suggest to make the example minimal to reduce the chance of issues in case the node-pool name does not match the label. The node selector is not needed for the example to work, because Cluster Autoscaler (CA) will pick a node pool created with `--enable-queued-provisioning`.

In case there are multiple node-pools, per machine type, the preferred way of choosing the node pool would be using  `cloud.google.com/gke-accelerator` label configured at the Kueue's ResourceFlavor level.

In the current version, the yaml files here assume the DWS node-pool is named consistently, but the node-pool is created based on the docs in https://cloud.google.com/kubernetes-engine/docs/how-to/provisioningrequest, and users of the tutorial may not be aware of the connection, renaming the node-pool (or changing the accelerator type for the node-pool if we switch to  `cloud.google.com/gke-accelerator`). 