### PR TITLE
Allow customizing job name.

### DIFF
--- a/gke-disk-image-builder/README.md
+++ b/gke-disk-image-builder/README.md
@@ -43,6 +43,7 @@ Flag                | Required | Default | Description
 ------------------- | -------- | ------- | -----------
 *--project-name*    | Yes      | nil     | Name of a gcp project where the script will be run
 *--image-name*      | Yes      | nil     | Name of the image that will be generated
+*--job-name*        | No       | secondary-disk-image | Name of the workflow. This name is used to provision some of the intermediate resources (disks, VMs) needed by the workflow. The maximum length is 50 characters
 *--zone*            | Yes      | nil     | Zone where the resources will be used to create the image creator resources
 *--gcs-path*        | Yes      | nil     | GCS path prefix to dump the logs
 *--container-image* | Yes      | nil     | Container image to include in the disk image. This flag can be specified multiple times

--- a/gke-disk-image-builder/cli/main.go
+++ b/gke-disk-image-builder/cli/main.go
@@ -41,6 +41,7 @@ func main() {
 	var containerImages stringSlice
 	projectName := flag.String("project-name", "", "name of a gcp project where the script will be run")
 	imageName := flag.String("image-name", "", "name of the image that will be generated")
+	jobName := flag.String("job-name", "secondary-disk-image", "name of the workflow job; no more than 50 characters")
 	zone := flag.String("zone", "", "zone where the resources will be used to create the image creator resources")
 	gcsPath := flag.String("gcs-path", "", "gcs location to dump the logs")
 	machineType := flag.String("machine-type", "n2-standard-16", "GCE instance machine type to generate the disk image")
@@ -61,6 +62,10 @@ func main() {
 		log.Panicf("invalid argument, timeout: %v, err: %v", timeout, err)
 	}
 
+	if len(*jobName) > 50 {
+		log.Panicf("invalid argument, job-name: %v cannot be longer than 50 characters, got: %v", *jobName, len(*jobName))
+	}
+
 	var auth builder.ImagePullAuthMechanism
 	switch *imagePullAuth {
 	case "":
@@ -76,6 +81,7 @@ func main() {
 	req := builder.Request{
 		ImageName:       *imageName,
 		ProjectName:     *projectName,
+		JobName:         *jobName,
 		Zone:            *zone,
 		GCSPath:         *gcsPath,
 		MachineType:     *machineType,

--- a/gke-disk-image-builder/cli/main.go
+++ b/gke-disk-image-builder/cli/main.go
@@ -62,8 +62,8 @@ func main() {
 		log.Panicf("invalid argument, timeout: %v, err: %v", timeout, err)
 	}
 
-	if len(*jobName) > 50 {
-		log.Panicf("invalid argument, job-name: %v cannot be longer than 50 characters, got: %v", *jobName, len(*jobName))
+	if len(*jobName) >= 50 {
+		log.Panicf("invalid argument, job-name: %v should be less than 50 characters, got: %v", *jobName, len(*jobName))
 	}
 
 	var auth builder.ImagePullAuthMechanism

--- a/gke-disk-image-builder/script/startup.sh
+++ b/gke-disk-image-builder/script/startup.sh
@@ -28,8 +28,8 @@ else
 fi
 
 # Check if disk is partitioned and update device node file path accordingly if so.
-# The disk name prefix is defined here: https://github.com/GoogleCloudPlatform/ai-on-gke/blob/71ebab897948cbca722c9abf4ec3ff2bc1318b3b/gke-disk-image-builder/imager.go#L32
-# The full disk name is then created here: https://github.com/GoogleCloudPlatform/ai-on-gke/blob/71ebab897948cbca722c9abf4ec3ff2bc1318b3b/gke-disk-image-builder/imager.go#L111
+# The device name that maps to the `google-<device_name>` path is defined here: https://github.com/canliu-aha/ai-on-gke/blob/d69a0a5f72217cad2bdeabc83db1274885becfe5/gke-disk-image-builder/imager.go#L32
+# The disk name prefix is constructed here: https://github.com/canliu-aha/ai-on-gke/blob/5292b0f0993c41e6f651c8208c5a4d8209ee1b98/gke-disk-image-builder/imager.go#L115
 DEVICE_NODE=/dev/disk/by-id/google-secondary-disk-image-disk
 if [[ -e "$DEVICE_NODE-part1" ]]; then
   DEVICE_NODE="$DEVICE_NODE-part1"


### PR DESCRIPTION
The job names are used to provision intermediate resources (VMs, disks). When workflows are run concurrently, there would be name collisions. This change allows users to run more than 1 workflow at a time.

b/315384952

TESTED: manually