### PR TITLE
Support customizing image family name.

### DIFF
--- a/gke-disk-image-builder/README.md
+++ b/gke-disk-image-builder/README.md
@@ -43,6 +43,7 @@ Flag                | Required | Default | Description
 ------------------- | -------- | ------- | -----------
 *--project-name*    | Yes      | nil     | Name of a gcp project where the script will be run
 *--image-name*      | Yes      | nil     | Name of the image that will be generated
+*--image-family-name* | No | secondary-disk-image | Name of the image family associated with the created disk image
 *--job-name*        | No       | secondary-disk-image | Name of the workflow. This name is used to provision some of the intermediate resources (disks, VMs) needed by the workflow. The maximum length is 50 characters
 *--zone*            | Yes      | nil     | Zone where the resources will be used to create the image creator resources
 *--gcs-path*        | Yes      | nil     | GCS path prefix to dump the logs

--- a/gke-disk-image-builder/imager.go
+++ b/gke-disk-image-builder/imager.go
@@ -30,7 +30,6 @@ import (
 
 const (
 	deviceName = "secondary-disk-image-disk"
-	imageFamilyName = "secondary-disk-image"
 )
 
 // ImagePullAuthMechanism declares the contract on how to convert a struct into a string that is
@@ -49,6 +48,7 @@ const (
 // Request contains the required input for the disk image generation.
 type Request struct {
 	ImageName       string
+	ImageFamilyName string
 	ProjectName     string
 	JobName         string
 	Zone            string
@@ -200,7 +200,7 @@ func GenerateDiskImage(ctx context.Context, req Request) error {
 						Image: compute.Image{
 							Name:       req.ImageName,
 							SourceDisk: fmt.Sprintf("%s-disk", req.JobName),
-							Family:     imageFamilyName,
+							Family:     req.ImageFamilyName,
 						},
 					},
 				},


### PR DESCRIPTION
b/315387164

TESTED: manually run with --image-family-name flag.
<img width="1397" alt="Screenshot 2024-01-09 at 5 56 26 PM" src="https://github.com/GoogleCloudPlatform/ai-on-gke/assets/140208917/9ee54a6e-43a0-47fb-aca5-4fa1b62a85e0">
