### PR TITLE
Write image info when generating secondary boot disk image

### DIFF
--- a/gke-disk-image-builder/script/startup.sh
+++ b/gke-disk-image-builder/script/startup.sh
@@ -86,6 +86,12 @@ function pull_images() {
   done
 }
 
+function write_image_info() {
+  echo Writing image info to disk image...
+  images=$(ctr -n k8s.io images ls)
+  sudo echo "$images" >> "/mnt/disks/container_layers/images.metadata"
+}
+
 function process_snapshots() {
   echo Processing the snapshots...
   snapshots=($(sudo ctr -n k8s.io snapshot list | grep "Committed" | cut -d ' ' -f1))
@@ -162,6 +168,9 @@ function unpack() {
   shift
   # Pull all the given images.
   pull_images $@
+
+  # Write image info to disk image.
+  write_image_info $@
 
   # Process the snapshots.
   process_snapshots


### PR DESCRIPTION
Tested by creating a secondary boot disk node pool and verifying images.metadata is there:

```
gke-riptide-cluster-np2-64966d83-9dlk /home/ruiwen # cat /mnt/disks/gke-secondary-disks/gke-nginx-latest-test-disk/images.metadata
REF                                                                     TYPE                                    DIGEST                                                                  SIZE     PLATFORMS                                                                                                               LABELS
docker.io/library/nginx:latest                                          application/vnd.oci.image.index.v1+json sha256:ea97e6aace270d82c73da382ea1a8c42d44b9dc11b55159104e21c49c687e7fb 67.3 MiB linux/386,linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64/v8,linux/mips64le,linux/ppc64le,linux/s390x,unknown/unknown io.cri-containerd.image=managed
sha256:247f7abff9f7097bbdab57df76fedd124d1e24a6ec4944fb5ef0ad128997ce05 application/vnd.oci.image.index.v1+json sha256:ea97e6aace270d82c73da382ea1a8c42d44b9dc11b55159104e21c49c687e7fb 67.3 MiB linux/386,linux/amd64,linux/arm/v5,linux/arm/v7,linux/arm64/v8,linux/mips64le,linux/ppc64le,linux/s390x,unknown/unknown io.cri-containerd.image=managed
```