### PR TITLE
Add --service-account flag to gke-disk-image-builder cli

### DIFF
--- a/gke-disk-image-builder/README.md
+++ b/gke-disk-image-builder/README.md
@@ -55,7 +55,7 @@ Flag                | Required | Default | Description
 *--timeout*         | No       | '20m'   | Default timeout for each step. Must be set to a proper value if the image is large to account for the pull and image creation time step.
 *--network*         | No       | 'default'   | VPC network used by the GCE resources used for creating the disk image.
 *--subnet*          | No       | 'default'   | Subnet used by the GCE resources used for creating the disk image.
-*--service-account* | No       | 'default'   | Service Account assigned to the GCE instance used for creating the disk image.
+*--service-account* | No       | 'default'   | Service Account email assigned to the GCE instance used for creating the disk image.
 
 ### Go
 

--- a/gke-disk-image-builder/README.md
+++ b/gke-disk-image-builder/README.md
@@ -54,7 +54,8 @@ Flag                | Required | Default | Description
 *--image-pull-auth* | No       | 'None'  | Auth mechanism to pull the container image, valid values: [None, ServiceAccountToken]. None means that the images are publically available and no authentication is required to pull them. ServiceAccountToken means the service account oauth token will be used to pull the images. For more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications
 *--timeout*         | No       | '20m'   | Default timeout for each step. Must be set to a proper value if the image is large to account for the pull and image creation time step.
 *--network*         | No       | 'default'   | VPC network used by the GCE resources used for creating the disk image.
-*--subnet*         | No       | 'default'   | Subnet used by the GCE resources used for creating the disk image.
+*--subnet*          | No       | 'default'   | Subnet used by the GCE resources used for creating the disk image.
+*--service-account* | No       | 'default'   | Service Account assigned to the GCE instance used for creating the disk image.
 
 ### Go
 

--- a/gke-disk-image-builder/cli/main.go
+++ b/gke-disk-image-builder/cli/main.go
@@ -52,7 +52,7 @@ func main() {
 	zone := flag.String("zone", "", "zone where the resources will be used to create the image creator resources")
 	gcsPath := flag.String("gcs-path", "", "gcs location to dump the logs")
 	machineType := flag.String("machine-type", "n2-standard-16", "GCE instance machine type to generate the disk image")
-	serviceAccount := flag.String("service-account", "default", "service account to run the image creator")
+	serviceAccount := flag.String("service-account", "default", "Service Account email assigned to the GCE instance used for creating the disk image.")
 	diskType := flag.String("disk-type", "pd-ssd", "disk type to generate the disk image")
 	diskSizeGb := flag.Int64("disk-size-gb", 60, "disk size to unpack container images")
 	gcpOAuth := flag.String("gcp-oauth", "", "path to GCP service account credential file")

--- a/gke-disk-image-builder/cli/main.go
+++ b/gke-disk-image-builder/cli/main.go
@@ -52,6 +52,7 @@ func main() {
 	zone := flag.String("zone", "", "zone where the resources will be used to create the image creator resources")
 	gcsPath := flag.String("gcs-path", "", "gcs location to dump the logs")
 	machineType := flag.String("machine-type", "n2-standard-16", "GCE instance machine type to generate the disk image")
+	serviceAccount := flag.String("service-account", "default", "service account to run the image creator")
 	diskType := flag.String("disk-type", "pd-ssd", "disk type to generate the disk image")
 	diskSizeGb := flag.Int64("disk-size-gb", 60, "disk size to unpack container images")
 	gcpOAuth := flag.String("gcp-oauth", "", "path to GCP service account credential file")
@@ -104,6 +105,7 @@ func main() {
 		Zone:            *zone,
 		GCSPath:         *gcsPath,
 		MachineType:     *machineType,
+		ServiceAccount:  *serviceAccount,
 		DiskType:        *diskType,
 		DiskSizeGB:      *diskSizeGb,
 		GCPOAuth:        *gcpOAuth,

--- a/gke-disk-image-builder/imager.go
+++ b/gke-disk-image-builder/imager.go
@@ -154,13 +154,7 @@ func GenerateDiskImage(ctx context.Context, req Request) error {
 								&compute.ServiceAccount{
 									Email: req.ServiceAccount,
 									Scopes: []string{
-										"https://www.googleapis.com/auth/devstorage.read_only",
-										"https://www.googleapis.com/auth/logging.write",
-										"https://www.googleapis.com/auth/monitoring.write",
-										"https://www.googleapis.com/auth/pubsub",
-										"https://www.googleapis.com/auth/service.management.readonly",
-										"https://www.googleapis.com/auth/servicecontrol",
-										"https://www.googleapis.com/auth/trace.append",
+										"https://www.googleapis.com/auth/cloud-platform",
 									},
 								},
 							},

--- a/gke-disk-image-builder/imager.go
+++ b/gke-disk-image-builder/imager.go
@@ -63,6 +63,7 @@ type Request struct {
 	Timeout         time.Duration
 	ImagePullAuth   ImagePullAuthMechanism
 	ImageLabels     []string
+	ServiceAccount  string
 }
 
 func generateStartupScript(req Request) (*os.File, error) {
@@ -149,6 +150,20 @@ func GenerateDiskImage(ctx context.Context, req Request) error {
 						Instance: compute.Instance{
 							Name:        fmt.Sprintf("%s-instance", req.JobName),
 							MachineType: fmt.Sprintf("zones/%s/machineTypes/%s", req.Zone, req.MachineType),
+							ServiceAccounts: []*compute.ServiceAccount{
+								&compute.ServiceAccount{
+									Email: req.ServiceAccount,
+									Scopes: []string{
+										"https://www.googleapis.com/auth/devstorage.read_only",
+										"https://www.googleapis.com/auth/logging.write",
+										"https://www.googleapis.com/auth/monitoring.write",
+										"https://www.googleapis.com/auth/pubsub",
+										"https://www.googleapis.com/auth/service.management.readonly",
+										"https://www.googleapis.com/auth/servicecontrol",
+										"https://www.googleapis.com/auth/trace.append",
+									},
+								},
+							},
 							NetworkInterfaces: []*compute.NetworkInterface{
 								{
 									Network:    req.Network,


### PR DESCRIPTION
Fixes #166 

Made sure it still works with no `--service-account` flag as well:

```bash
go run ./cli \
    --project-name=$PROJECT_NAME --machine-type=n2-standard-4 \
    --image-name=$IMAGE_NAME \
    --zone=$ZONE \
    --gcs-path=gs://$GCS_PATH/ \
    --disk-size-gb=$DISK_SIZE_GB \
    --container-image=docker.io/library/python:3.8

# ...

[secondary-disk-image]: 2024-02-16T15:22:27-05:00 Step "create-image" (CreateImages) successfully finished.
[secondary-disk-image]: 2024-02-16T15:22:27-05:00 Workflow "secondary-disk-image" cleaning up (this may take up to 2 minutes).
[secondary-disk-image]: 2024-02-16T15:23:17-05:00 Workflow "secondary-disk-image" finished cleanup.
Image has successfully been created at: projects/REDACTED/global/images/test-img-build
```