### PR TITLE
re-add created-by: ray-on-gke label for ray modules

### DIFF
--- a/applications/ray/raytrain-examples/raytrain-with-gcsfusecsi/kuberaytf/user/modules/kuberay/kuberay-values.yaml
+++ b/applications/ray/raytrain-examples/raytrain-with-gcsfusecsi/kuberaytf/user/modules/kuberay/kuberay-values.yaml
@@ -56,6 +56,7 @@ head:
     #     memory: "512Mi"
   labels:
     cloud.google.com/gke-ray-node-type: head
+    created-by: ray-on-gke
   serviceAccountName: my-ksa
   rayStartParams:
     dashboard-host: '0.0.0.0'
@@ -130,6 +131,7 @@ worker:
   type: worker
   labels:
     cloud.google.com/gke-ray-node-type: worker
+    created-by: ray-on-gke
   serviceAccountName: my-ksa
   rayStartParams:
     block: 'true'

--- a/modules/kuberay-cluster/kuberay-autopilot-values.yaml
+++ b/modules/kuberay-cluster/kuberay-autopilot-values.yaml
@@ -56,6 +56,7 @@ head:
         memory: "512Mi"
   labels:
     cloud.google.com/gke-ray-node-type: head
+    created-by: ray-on-gke
   serviceAccountName: ${k8s_service_account}
   rayStartParams:
     dashboard-host: '0.0.0.0'
@@ -160,6 +161,7 @@ worker:
   type: worker
   labels:
     cloud.google.com/gke-ray-node-type: worker
+    created-by: ray-on-gke
   serviceAccountName: ${k8s_service_account}
   rayStartParams:
     block: 'true'

--- a/modules/kuberay-cluster/kuberay-tpu-values.yaml
+++ b/modules/kuberay-cluster/kuberay-tpu-values.yaml
@@ -50,6 +50,7 @@ head:
     #     memory: "512Mi"
   labels:
     cloud.google.com/gke-ray-node-type: head
+    created-by: ray-on-gke
   rayStartParams:
     dashboard-host: '0.0.0.0'
     block: 'true'
@@ -144,6 +145,7 @@ worker:
   type: worker
   labels:
     cloud.google.com/gke-ray-node-type: worker
+    created-by: ray-on-gke
   rayStartParams:
     block: 'true'
     resources: '"{\"google.com/tpu\": 4}"'

--- a/modules/kuberay-cluster/kuberay-values.yaml
+++ b/modules/kuberay-cluster/kuberay-values.yaml
@@ -50,6 +50,7 @@ head:
     #     memory: "512Mi"
   labels:
     cloud.google.com/gke-ray-node-type: head
+    created-by: ray-on-gke
   serviceAccountName: ${k8s_service_account}
   rayStartParams:
     dashboard-host: '0.0.0.0'
@@ -153,6 +154,7 @@ worker:
   type: worker
   labels:
     cloud.google.com/gke-ray-node-type: worker
+    created-by: ray-on-gke
   serviceAccountName: ${k8s_service_account}
   rayStartParams:
     block: 'true'


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/ai-on-gke/pull/182 we introduced a `created-by: ray-on-gke` label. When the `applications/ray/` folder was introduced, these labels were removed. 

This PR adds them back to the new `applications/ray` modules