### PR TITLE
[TPU Provisioner] Bump node pool deletion check interval

### DIFF
--- a/tpu-provisioner/internal/controller/deletion_controller.go
+++ b/tpu-provisioner/internal/controller/deletion_controller.go
@@ -28,7 +28,7 @@ import (
 // has passed twice, the node pool can be safely deleted. This second
 // check is ensure the node pool is not prematurely deleted, in the case
 // where a JobSet is restarted, but no pods have been created yet.
-var nodePoolDeletionCheckInterval = 4 * time.Second
+var nodePoolDeletionCheckInterval = 30 * time.Second
 
 // DeletionReconciler watches Pods and Nodes and deletes Node Pools.
 type DeletionReconciler struct {


### PR DESCRIPTION
This is needed to allow for more time for Jobs (and pods) to be recreated upon JobSet restart, since JobSet now uses foreground deletion to avoid [other issues](https://github.com/kubernetes-sigs/jobset/issues/392), so Job recreation is blocked until all of the pods from the previous Job are completely deleted. This means it may take longer than 4 seconds for the pods to begin rescheduling during failure recovery, so we should bump the interval to 60 seconds.