### PR TITLE
Update Ray TPU Webhook Image Tags to v1.0

### DIFF
--- a/applications/ray/kuberay-tpu-webhook/Makefile
+++ b/applications/ray/kuberay-tpu-webhook/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets  
-IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/kuberay-tpu-webhook:latest
+IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/kuberay-tpu-webhook:v1.0
   
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)  
 ifeq (,$(shell go env GOBIN))  

--- a/applications/ray/kuberay-tpu-webhook/deployments/deployment.yaml
+++ b/applications/ray/kuberay-tpu-webhook/deployments/deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: kuberay-tpu-webhook
     spec:
       containers:
-        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/kuberay-tpu-webhook:latest
+        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/kuberay-tpu-webhook:v1.0
           imagePullPolicy: Always
           name: kuberay-tpu-webhook
           ports:


### PR DESCRIPTION
This PR changes the image tags to `v1.0` rather than `latest` for webhook for the branch release cut. Manually tested to ensure webhook could deploy correctly and successfully pull the image.