### PR TITLE
Configure CloudSQL instance name

### DIFF
--- a/applications/rag/frontend/main.tf
+++ b/applications/rag/frontend/main.tf
@@ -31,7 +31,7 @@ data "kubernetes_secret" "db_secret" {
 }
 
 locals {
-  instance_connection_name = format("%s:%s:%s", var.project_id, var.region, "pgvector-instance")
+  instance_connection_name = format("%s:%s:%s", var.project_id, var.region, var.cloudsql_instance)
 }
 
 # IAP Section: Enabled the IAP service
@@ -99,7 +99,7 @@ resource "kubernetes_service" "rag_frontend_service" {
       target_port = 8080
     }
 
-    type = var.add_auth ? "NodePort" : "ClientIP"
+    type = var.add_auth ? "NodePort" : "ClusterIP"
   }
 }
 

--- a/applications/rag/frontend/variables.tf
+++ b/applications/rag/frontend/variables.tf
@@ -29,6 +29,12 @@ variable "region" {
   default     = "us-central1"
 }
 
+variable "cloudsql_instance" {
+  type        = string
+  description = "Name of the CloudSQL instance for RAG VectorDB"
+  default     = "pgvector-instance"
+}
+
 variable "db_secret_name" {
   type        = string
   description = "CloudSQL user"

--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -113,11 +113,12 @@ module "gcs" {
 }
 
 module "cloudsql" {
-  source     = "../../modules/cloudsql"
-  providers  = { kubernetes = kubernetes.rag }
-  project_id = var.project_id
-  namespace  = var.kubernetes_namespace
-  depends_on = [module.kuberay-operator]
+  source          = "../../modules/cloudsql"
+  providers       = { kubernetes = kubernetes.rag }
+  project_id      = var.project_id
+  instance_name   = var.cloudsql_instance
+  namespace       = var.kubernetes_namespace
+  depends_on      = [module.kuberay-operator]
 }
 
 module "jupyterhub" {

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -263,6 +263,12 @@ variable "autopilot_cluster" {
   default = false
 }
 
+variable "cloudsql_instance" {
+  type    = string
+  description = "Name of the CloudSQL instance for RAG VectorDB"
+  default = "pgvector-instance"
+}
+
 variable "cpu_pools" {
   type = list(object({
     name                   = string

--- a/applications/ray/raytrain-examples/raytrain-with-gcsfusecsi/kuberaytf/user/modules/service_accounts/versions.tf
+++ b/applications/ray/raytrain-examples/raytrain-with-gcsfusecsi/kuberaytf/user/modules/service_accounts/versions.tf
@@ -16,7 +16,6 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.56.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/applications/ray/versions.tf
+++ b/applications/ray/versions.tf
@@ -16,11 +16,9 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "4.56.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 4.8"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -22,7 +22,7 @@ resource "google_project_service" "project_service" {
 }
 
 resource "google_sql_database_instance" "main" {
-  name             = "pgvector-instance"
+  name             = var.instance_name
   database_version = "POSTGRES_15"
   region           = var.region
   settings {
@@ -36,7 +36,7 @@ resource "google_sql_database_instance" "main" {
 
 resource "google_sql_database" "database" {
   name     = "pgvector-database"
-  instance = "pgvector-instance"
+  instance = var.instance_name
 
   depends_on = [google_sql_database_instance.main]
 }

--- a/modules/cloudsql/variables.tf
+++ b/modules/cloudsql/variables.tf
@@ -34,3 +34,9 @@ variable "db_user" {
   description = "Cloud SQL instance user"
   default     = "rag-user"
 }
+
+variable "instance_name" {
+  type        = string
+  description = "Name of the CloudSQL instance for RAG VectorDB"
+  default     = "pgvector-instance"
+}


### PR DESCRIPTION
Modified variables & related code to accept cloudsql instance name as a variable. 
This doesn't change user experience (Readme / Notebooks) however enables cloudbuild to set unique instance names. 