### PR TITLE
Update dependents and fix frontend issues

### DIFF
--- a/applications/jupyter/main.tf
+++ b/applications/jupyter/main.tf
@@ -70,6 +70,13 @@ module "gcs" {
   bucket_name = var.gcs_bucket
 }
 
+# create namespace
+module "namespace" {
+  source           = "../../modules/kubernetes-namespace"
+  namespace        = var.namespace
+  create_namespace = true
+}
+
 # Creates jupyterhub
 module "jupyterhub" {
   source                            = "../../modules/jupyter"
@@ -94,5 +101,5 @@ module "jupyterhub" {
   url_domain_addr          = var.url_domain_addr
   url_domain_name          = var.url_domain_name
   members_allowlist        = var.members_allowlist
-  depends_on               = [module.gcs]
+  depends_on               = [module.gcs, module.namespace]
 }

--- a/applications/rag/frontend/main.tf
+++ b/applications/rag/frontend/main.tf
@@ -16,20 +16,6 @@ data "google_project" "project" {
 }
 
 
-data "kubernetes_service" "inference_service" {
-  metadata {
-    name      = var.inference_service_name
-    namespace = var.inference_service_namespace
-  }
-}
-
-data "kubernetes_secret" "db_secret" {
-  metadata {
-    name      = var.db_secret_name
-    namespace = var.db_secret_namespace
-  }
-}
-
 locals {
   instance_connection_name = format("%s:%s:%s", var.project_id, var.region, var.cloudsql_instance)
 }
@@ -149,7 +135,7 @@ resource "kubernetes_deployment" "rag_frontend_deployment" {
 
           env {
             name  = "INFERENCE_ENDPOINT"
-            value = data.kubernetes_service.inference_service.status.0.load_balancer.0.ingress.0.ip
+            value = var.inference_service_endpoint
           }
 
           env {
@@ -161,7 +147,7 @@ resource "kubernetes_deployment" "rag_frontend_deployment" {
             name = "DB_USER"
             value_from {
               secret_key_ref {
-                name = data.kubernetes_secret.db_secret.metadata.0.name
+                name = var.db_secret_name
                 key  = "username"
               }
             }
@@ -171,7 +157,7 @@ resource "kubernetes_deployment" "rag_frontend_deployment" {
             name = "DB_PASSWORD"
             value_from {
               secret_key_ref {
-                name = data.kubernetes_secret.db_secret.metadata.0.name
+                name = var.db_secret_name
                 key  = "password"
               }
             }
@@ -181,7 +167,7 @@ resource "kubernetes_deployment" "rag_frontend_deployment" {
             name = "DB_NAME"
             value_from {
               secret_key_ref {
-                name = data.kubernetes_secret.db_secret.metadata.0.name
+                name = var.db_secret_name
                 key  = "database"
               }
             }

--- a/applications/rag/frontend/variables.tf
+++ b/applications/rag/frontend/variables.tf
@@ -51,15 +51,9 @@ variable "dataset_embeddings_table_name" {
   description = "Name of the table that stores vector embeddings for input dataset"
 }
 
-variable "inference_service_name" {
-  type        = string
-  description = "Model inference k8s service name"
-}
-
-variable "inference_service_namespace" {
+variable "inference_service_endpoint" {
   type        = string
   description = "Model inference k8s service endpoint"
-  default     = "rag"
 }
 
 variable "create_service_account" {

--- a/applications/rag/frontend/versions.tf
+++ b/applications/rag/frontend/versions.tf
@@ -20,5 +20,8 @@ terraform {
     kubernetes = {
       source = "hashicorp/kubernetes"
     }
+    helm = {
+      source = "hashicorp/helm"
+    }
   }
 }

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -346,7 +346,7 @@ variable "gpu_pools" {
     {
       name               = "gpu-pool-l4"
       machine_type       = "g2-standard-24"
-      node_locations     = "us-central1-a,us-central1-b"
+      node_locations     = "us-central1-a"
       autoscaling        = true
       min_count          = 1
       max_count          = 3

--- a/applications/rag/workloads.tfvars
+++ b/applications/rag/workloads.tfvars
@@ -24,6 +24,7 @@ kubernetes_namespace = "rag"
 create_gcs_bucket    = true
 gcs_bucket           = "rag-data-xyzu" # Choose a globally unique bucket name.
 
+cloudsql_instance = "pgvector-instance"
 ## Service accounts
 # Creates a google service account & k8s service account & configures workload identity with appropriate permissions.
 # Set to false & update the variable `ray_service_account` to use an existing IAM service account.
@@ -46,7 +47,7 @@ dataset_embeddings_table_name = "googlemaps_reviews_db"
 brand = "projects/<prj-number>/brands/<prj-number>"
 
 ## Jupyter IAP Settings
-jupyter_add_auth                 = true # Set to true when using auth with IAP
+jupyter_add_auth                 = false # Set to true when using auth with IAP
 jupyter_support_email            = "<email>"
 jupyter_k8s_ingress_name         = "jupyter-ingress"
 jupyter_k8s_managed_cert_name    = "jupyter-managed-cert"
@@ -62,7 +63,7 @@ jupyter_client_secret     = ""
 jupyter_members_allowlist = ["allAuthenticatedUsers", "user:<email>"]
 
 ## Frontend IAP Settings
-frontend_add_auth                 = true # Set to true when using auth with IAP
+frontend_add_auth                 = false # Set to true when using auth with IAP
 frontend_support_email            = "<email>"
 frontend_k8s_ingress_name         = "frontend-ingress"
 frontend_k8s_managed_cert_name    = "frontend-managed-cert"

--- a/modules/jupyter/main.tf
+++ b/modules/jupyter/main.tf
@@ -16,13 +16,6 @@ data "google_project" "project" {
   project_id = var.project_id
 }
 
-# create namespace
-module "namespace" {
-  source           = "../../modules/kubernetes-namespace"
-  namespace        = var.namespace
-  create_namespace = true
-}
-
 # Creates a "Brand", equivalent to the OAuth consent screen on Cloud console
 resource "google_iap_brand" "project_brand" {
   count             = var.add_auth && var.brand == "" ? 1 : 0

--- a/modules/kuberay-monitoring/main.tf
+++ b/modules/kuberay-monitoring/main.tf
@@ -47,6 +47,7 @@ resource "helm_release" "grafana" {
 }
 
 data "kubernetes_service" "example" {
+  count       = var.enable_grafana_on_ray_dashboard ? 1 : 0
   metadata {
     name      = "grafana"
     namespace = var.namespace

--- a/modules/kuberay-monitoring/outputs.tf
+++ b/modules/kuberay-monitoring/outputs.tf
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 output "grafana_uri" {
-  value = data.kubernetes_service.example.status != null ? (data.kubernetes_service.example.status[0].load_balancer != null ? "${data.kubernetes_service.example.status[0].load_balancer[0].ingress[0].ip}" : "") : ""
+  value = var.enable_grafana_on_ray_dashboard ? (data.kubernetes_service.example[0].status != null ? (data.kubernetes_service.example[0].status[0].load_balancer != null ? "${data.kubernetes_service.example[0].status[0].load_balancer[0].ingress[0].ip}" : "") : "") : ""
 }
 

--- a/modules/kubernetes-namespace/main.tf
+++ b/modules/kubernetes-namespace/main.tf
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 # Helm Chart 
-resource "helm_release" "namespace" {
-  name             = "namespace"
+resource "helm_release" "app-namespace" {
+  name             = "app-namespace"
   chart            = "${path.module}/charts/namespace/"
   namespace        = var.namespace
   create_namespace = var.create_namespace

--- a/tutorials/hf-tgi/outputs.tf
+++ b/tutorials/hf-tgi/outputs.tf
@@ -21,3 +21,8 @@ output "inference_service_namespace" {
   description = "Namespace of model inference service"
   value       = kubernetes_service.inference_service.metadata[0].namespace
 }
+
+output "inference_service_endpoint" {
+  description = "Endpoint of model inference service"
+  value = kubernetes_service.inference_service.status != null ? (kubernetes_service.inference_service.status[0].load_balancer != null ? "${kubernetes_service.inference_service.status[0].load_balancer[0].ingress[0].ip}" : "") : ""
+}


### PR DESCRIPTION
- introduce namespace helm module to prepare namespace before actual module, earlier this was done using depends_on = kuberay_operator
- optmise frontend module to read endpoint from module output and remove addtional data sources.
- set l4 node-locations default to us-central1-a for less quota or stockout issues.
- disable IAP as default option. 
- tf plan reduced to 40s to 8s