### PR TITLE
kuberay-tpu-webhook: remove webhook as pre-requisite target of docker-build

### DIFF
--- a/applications/ray/kuberay-tpu-webhook/Makefile
+++ b/applications/ray/kuberay-tpu-webhook/Makefile
@@ -25,7 +25,7 @@ deploy:
 	kubectl apply -f deployments/  
   
 # Build the docker image  
-docker-build: webhook  
+docker-build:
 	docker build . -t ${IMG} 
   
 # Push the docker image  


### PR DESCRIPTION
So contributors don't have to build the Go binary locally in order to build the docker image.