### PR TITLE
Fix regression for kuberay-operator token mounting

### DIFF
--- a/modules/kuberay-operator/kuberay.tf
+++ b/modules/kuberay-operator/kuberay.tf
@@ -31,7 +31,10 @@ module "kuberay-workload-identity" {
   namespace           = var.namespace
   project_id          = var.project_id
   roles               = ["roles/cloudsql.client", "roles/monitoring.viewer"]
-  depends_on          = [helm_release.kuberay-operator]
+
+  automount_service_account_token = true
+
+  depends_on = [helm_release.kuberay-operator]
 }
 
 resource "kubernetes_secret_v1" "service_account_token" {


### PR DESCRIPTION
This token mounting is required for Ray Autoscaler.

Introduced in https://github.com/GoogleCloudPlatform/ai-on-gke/pull/303