### PR TITLE
locust close connections for each request

### DIFF
--- a/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/tasks.py
+++ b/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/tasks.py
@@ -107,7 +107,7 @@ class BenchmarkUser(FastHttpUser):
         prompt = test_data[random.randrange(0, len(test_data))]
 
         request = generate_request(model_params, prompt)
-        headers = {"User-Agent": "Benchmark Client"}
+        headers = {"User-Agent": "Benchmark Client", "Connection": "close"}
         logging.info(f"Sending request: {request}")
         with self.client.post("/generate", headers=headers, json=request, catch_response=True) as resp:
             if resp.status_code != 200:


### PR DESCRIPTION
Locust user task uses requests library as underlying infra.

To ensure Locust loadbalances across new TGI pods with autoscaling, close the connection for each request so a new one is opened.