### PR TITLE
Increase locust user task and connection timeout

### DIFF
--- a/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/run.sh
+++ b/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/run.sh
@@ -19,7 +19,12 @@ LOCUS_OPTS="-f /locust-tasks/tasks.py --host=$TARGET_HOST"
 LOCUST_MODE=${LOCUST_MODE:-standalone}
 
 if [[ "$LOCUST_MODE" = "master" ]]; then
-    LOCUS_OPTS="$LOCUS_OPTS --master --stop-timeout 300"
+    # Locust stop-timeout default is 0s. Only used in distributed mode.
+    # Master will wait $stop-timout amount of time for the User to complete it's task.
+    # For inferencing workloads with large payload having no wait time is unreasonable.
+    # This timeout is set to large amount to avoid user tasks being killed too early.
+    # TODO: turn timeout into a variable.
+    LOCUS_OPTS="$LOCUS_OPTS --master --stop-timeout 10800"
 elif [[ "$LOCUST_MODE" = "worker" ]]; then
     huggingface-cli login --token $HUGGINGFACE_TOKEN
     FILTER_PROMPTS="python /locust-tasks/load_data.py"


### PR DESCRIPTION
Increase locust user task and connection timeout to handle long-running requests.

Currently defaults are:
user_task -> 5 min before master kills the user task
http requests connection timeout -> 60 seconds before connection timeout error (explains the 0 return from locust)

Setting extremely high default for now (3 hrs)

Will turn into tfvars variable if possible (only unknown in that is that http request connection_timeout is a user class variable, and have to confirm that it will respect arguments piped through to tasks.py file before it's instantiated.)