### PR TITLE
Fix SQL name and region

### DIFF
--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -129,8 +129,9 @@ module "cloudsql" {
   project_id    = var.project_id
   instance_name = var.cloudsql_instance
   namespace     = var.kubernetes_namespace
-  region        = var.cloudsql_instance_region
-  depends_on    = [module.namespace]
+  ## if cloudsql_instance_region not specified, then default to cluster_location region
+  region     = var.cloudsql_instance_region != "" ? var.cloudsql_instance_region : (length(split("-", var.cluster_location)) == 2 ? var.cluster_location : join("-", slice(split("-", var.cluster_location), 0, 2)))
+  depends_on = [module.namespace]
 }
 
 # IAP Section: Enabled the IAP service
@@ -189,6 +190,7 @@ module "kuberay-cluster" {
   enable_tpu             = false
   autopilot_cluster      = local.enable_autopilot
   db_secret_name         = module.cloudsql.db_secret_name
+  cloudsql_instance_name = var.cloudsql_instance
   db_region              = var.cloudsql_instance_region
   google_service_account = local.ray_service_account
   grafana_host           = module.kuberay-monitoring.grafana_uri

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -273,7 +273,7 @@ variable "cloudsql_instance" {
 variable "cloudsql_instance_region" {
   type        = string
   description = "GCP region for CloudSQL instance"
-  default     = "us-central1"
+  default     = ""
 }
 
 variable "cpu_pools" {

--- a/applications/rag/workloads.tfvars
+++ b/applications/rag/workloads.tfvars
@@ -25,7 +25,7 @@ create_gcs_bucket    = true
 gcs_bucket           = "rag-data-xyzu" # Choose a globally unique bucket name.
 
 cloudsql_instance        = "pgvector-instance"
-cloudsql_instance_region = "us-central1"
+cloudsql_instance_region = "us-central1" # defaults to cluster_location, if not specified
 ## Service accounts
 # Creates a google service account & k8s service account & configures workload identity with appropriate permissions.
 # Set to false & update the variable `ray_service_account` to use an existing IAM service account.


### PR DESCRIPTION
- Pass SQL instance name to module
- Use cluster_location as sql instance region, if not specified.