### PR TITLE
fix issue with big images for gke-disk-image-builder

### DIFF
--- a/gke-disk-image-builder/README.md
+++ b/gke-disk-image-builder/README.md
@@ -51,6 +51,7 @@ Flag                | Required | Default | Description
 *--container-image* | Yes      | nil     | Container image to include in the disk image. This flag can be specified multiple times
 *--gcp-oauth*       | No       | nil     | Path to GCP service account credential file
 *--disk-size-gb*    | No       | 10      | Size of a disk that will host the unpacked images
+*--instance-disk-size-gb*| No  | 100     | Size of the disk attached to the instance used for creating the disk image
 *--image-pull-auth* | No       | 'None'  | Auth mechanism to pull the container image, valid values: [None, ServiceAccountToken]. None means that the images are publically available and no authentication is required to pull them. ServiceAccountToken means the service account oauth token will be used to pull the images. For more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications
 *--timeout*         | No       | '20m'   | Default timeout for each step. Must be set to a proper value if the image is large to account for the pull and image creation time step.
 *--network*         | No       | 'default'   | VPC network used by the GCE resources used for creating the disk image.

--- a/gke-disk-image-builder/cli/main.go
+++ b/gke-disk-image-builder/cli/main.go
@@ -55,6 +55,7 @@ func main() {
 	serviceAccount := flag.String("service-account", "default", "Service Account email assigned to the GCE instance used for creating the disk image.")
 	diskType := flag.String("disk-type", "pd-ssd", "disk type to generate the disk image")
 	diskSizeGb := flag.Int64("disk-size-gb", 60, "disk size to unpack container images")
+	instanceDiskSizeGb := flag.Int64("instance-disk-size-gb", 100, "disk size of the GCE instance used for disk image creation")
 	gcpOAuth := flag.String("gcp-oauth", "", "path to GCP service account credential file")
 	imagePullAuth := flag.String("image-pull-auth", "None", "auth mechanism to pull the container image, valid values: [None, ServiceAccountToken].\nNone means that the images are publically available and no authentication is required to pull them.\nServiceAccountToken means the service account oauth token will be used to pull the images.\nFor more information refer to https://cloud.google.com/compute/docs/access/authenticate-workloads#applications")
 	timeout := flag.String("timeout", "20m", "Default timout for each step, defaults to 20m")
@@ -110,6 +111,7 @@ func main() {
 		ServiceAccount:        *serviceAccount,
 		DiskType:              *diskType,
 		DiskSizeGB:            *diskSizeGb,
+		InstanceDiskSizeGB:    *instanceDiskSizeGb,
 		GCPOAuth:              *gcpOAuth,
 		Network:               fmt.Sprintf("projects/%s/global/networks/%s", *projectName, *network),
 		Subnet:                fmt.Sprintf("projects/%s/regions/%s/subnetworks/%s", *projectName, regionForZone(*zone), *subnet),

--- a/gke-disk-image-builder/imager.go
+++ b/gke-disk-image-builder/imager.go
@@ -56,6 +56,7 @@ type Request struct {
 	MachineType           string
 	DiskType              string
 	DiskSizeGB            int64
+	InstanceDiskSizeGB    int64
 	GCPOAuth              string
 	Network               string
 	Subnet                string
@@ -195,7 +196,7 @@ func GenerateDiskImage(ctx context.Context, req Request) error {
 									DeviceName: fmt.Sprintf("%s-bootable-disk", req.JobName),
 									Mode:       "READ_WRITE",
 									InitializeParams: &compute.AttachedDiskInitializeParams{
-										DiskSizeGb:  req.DiskSizeGB,
+										DiskSizeGb:  req.InstanceDiskSizeGB,
 										DiskType:    fmt.Sprintf("projects/%s/zones/%s/diskTypes/%s", req.ProjectName, req.Zone, req.DiskType),
 										SourceImage: "projects/debian-cloud/global/images/debian-11-bullseye-v20230912",
 									},

--- a/gke-disk-image-builder/script/startup.sh
+++ b/gke-disk-image-builder/script/startup.sh
@@ -72,9 +72,9 @@ function pull_images() {
   for param in "$@"; do
     echo Start pulling $param ...
     if [ "$OAUTH_MECHANISM" == "none" ]; then
-      sudo ctr -n k8s.io image pull $param > /dev/null
+      sudo ctr -n k8s.io image pull $param | (head -n 2; echo "Skipping long output from ctr pull..."; cat > /dev/null)
     elif [ "$OAUTH_MECHANISM" == "serviceaccounttoken" ]; then
-      sudo ctr -n k8s.io image pull --user "oauth2accesstoken:$ACCESS_TOKEN" $param > /dev/null
+      sudo ctr -n k8s.io image pull --user "oauth2accesstoken:$ACCESS_TOKEN" $param | (head -n 2; echo "Skipping long output from ctr pull..."; cat > /dev/null)
     else
       echo "Unknown OAuth mechanism, expected 'None' or 'ServiceAccountToken' but got '$OAUTH_MECHANISM'".
       exit 1

--- a/gke-disk-image-builder/script/startup.sh
+++ b/gke-disk-image-builder/script/startup.sh
@@ -72,9 +72,9 @@ function pull_images() {
   for param in "$@"; do
     echo Start pulling $param ...
     if [ "$OAUTH_MECHANISM" == "none" ]; then
-      sudo ctr -n k8s.io image pull $param
+      sudo ctr -n k8s.io image pull $param > /dev/null
     elif [ "$OAUTH_MECHANISM" == "serviceaccounttoken" ]; then
-      sudo ctr -n k8s.io image pull --user "oauth2accesstoken:$ACCESS_TOKEN" $param
+      sudo ctr -n k8s.io image pull --user "oauth2accesstoken:$ACCESS_TOKEN" $param > /dev/null
     else
       echo "Unknown OAuth mechanism, expected 'None' or 'ServiceAccountToken' but got '$OAUTH_MECHANISM'".
       exit 1


### PR DESCRIPTION
We tried to create a disk image for a big docker image (>50GB) and faced issues. 

The main problem is that output to the serial console is super verbose and too slow, so we disabled logs from the docker pull command. 

The second problem is that we need much more space for the host system to pull the image and unpack it. For that, we introduced an additional option. 