### PR TITLE
support additional labels for rag, ray and jupyter

### DIFF
--- a/applications/jupyter/main.tf
+++ b/applications/jupyter/main.tf
@@ -121,6 +121,7 @@ module "jupyterhub" {
   providers                         = { helm = helm.jupyter, kubernetes = kubernetes.jupyter }
   project_id                        = var.project_id
   namespace                         = var.kubernetes_namespace
+  additional_labels                 = var.additional_labels
   workload_identity_service_account = local.workload_identity_service_account
   gcs_bucket                        = var.gcs_bucket
   autopilot_cluster                 = local.enable_autopilot

--- a/applications/jupyter/metadata.display.yaml
+++ b/applications/jupyter/metadata.display.yaml
@@ -139,6 +139,11 @@ spec:
           name: members_allowlist
           title: Members Allowlist
           section: iap_auth
+        additional_labels:
+          name: additional_labels
+          title: Additional Labels
+          section: cluster_details
+          invisible: true
         private_cluster:
           name: private_cluster
           title: Private Cluster

--- a/applications/jupyter/metadata.yaml
+++ b/applications/jupyter/metadata.yaml
@@ -106,6 +106,10 @@ spec:
         varType: string
         required: true
         defaultValue: ai-on-gke
+      - name: additional_labels
+        description: Additional labels to apply to Kubenetes resources
+        varType: list(string)
+        defaultValue: ["created-by=jupyter-on-gke-qss"]
       - name: members_allowlist
         description: "For example - user:example@google.com,serviceAccount:serviceAccount@google.com,group:group@google.com,domain:google.com"
         varType: string

--- a/applications/jupyter/variables.tf
+++ b/applications/jupyter/variables.tf
@@ -31,6 +31,14 @@ variable "kubernetes_namespace" {
   description = "Kubernetes namespace where resources are deployed"
 }
 
+variable "additional_labels" {
+  type        = map(string)
+  description = "Additional Kubernetes labels to add to Kubernetes resources."
+  default = {
+    created-by = "jupyter-on-gke"
+  }
+}
+
 variable "gcs_bucket" {
   type        = string
   description = "Bucket name to store the dataset"

--- a/applications/jupyter/variables.tf
+++ b/applications/jupyter/variables.tf
@@ -32,11 +32,10 @@ variable "kubernetes_namespace" {
 }
 
 variable "additional_labels" {
-  type        = map(string)
-  description = "Additional Kubernetes labels to add to Kubernetes resources."
-  default = {
-    created-by = "jupyter-on-gke"
-  }
+  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
+  type        = list(string)
+  description = "Additional labels to add to Kubernetes resources."
+  default     = ["created-by=jupyter-on-gke"]
 }
 
 variable "gcs_bucket" {

--- a/applications/rag/frontend/main.tf
+++ b/applications/rag/frontend/main.tf
@@ -103,24 +103,24 @@ resource "kubernetes_deployment" "rag_frontend_deployment" {
   metadata {
     name      = "rag-frontend"
     namespace = var.namespace
-    labels = {
+    labels = merge({
       app = "rag-frontend"
-    }
+    }, var.additional_labels)
   }
 
   spec {
     replicas = 3
     selector {
-      match_labels = {
+      match_labels = merge({
         app = "rag-frontend"
-      }
+      }, var.additional_labels)
     }
 
     template {
       metadata {
-        labels = {
+        labels = merge({
           app = "rag-frontend"
-        }
+        }, var.additional_labels)
       }
 
       spec {

--- a/applications/rag/frontend/main.tf
+++ b/applications/rag/frontend/main.tf
@@ -35,6 +35,10 @@ resource "google_project_service" "nature_language_api" {
 
 locals {
   instance_connection_name = format("%s:%s:%s", var.project_id, var.cloudsql_instance_region, var.cloudsql_instance)
+  additional_labels = tomap({
+    for item in var.additional_labels :
+    split("=", item)[0] => split("=", item)[1]
+  })
 }
 
 # IAP Section: Creates the GKE components
@@ -105,7 +109,7 @@ resource "kubernetes_deployment" "rag_frontend_deployment" {
     namespace = var.namespace
     labels = merge({
       app = "rag-frontend"
-    }, var.additional_labels)
+    }, local.additional_labels)
   }
 
   spec {
@@ -113,14 +117,14 @@ resource "kubernetes_deployment" "rag_frontend_deployment" {
     selector {
       match_labels = merge({
         app = "rag-frontend"
-      }, var.additional_labels)
+      }, local.additional_labels)
     }
 
     template {
       metadata {
         labels = merge({
           app = "rag-frontend"
-        }, var.additional_labels)
+        }, local.additional_labels)
       }
 
       spec {

--- a/applications/rag/frontend/variables.tf
+++ b/applications/rag/frontend/variables.tf
@@ -23,6 +23,12 @@ variable "namespace" {
   default     = "rag"
 }
 
+variable "additional_labels" {
+  type        = map(string)
+  description = "Additional Kubernetes labels to add to Kubernetes resources."
+  default     = {}
+}
+
 variable "region" {
   type        = string
   description = "GCP project region"

--- a/applications/rag/frontend/variables.tf
+++ b/applications/rag/frontend/variables.tf
@@ -24,9 +24,10 @@ variable "namespace" {
 }
 
 variable "additional_labels" {
-  type        = map(string)
-  description = "Additional Kubernetes labels to add to Kubernetes resources."
-  default     = {}
+  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
+  type        = list(string)
+  description = "Additional labels to add to Kubernetes resources."
+  default     = []
 }
 
 variable "region" {

--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -212,6 +212,7 @@ module "inference-server" {
   source            = "../../tutorials-and-examples/hf-tgi"
   providers         = { kubernetes = kubernetes.rag }
   namespace         = var.kubernetes_namespace
+  additional_labels = var.additional_labels
   autopilot_cluster = local.enable_autopilot
   depends_on        = [module.namespace]
 }
@@ -223,6 +224,7 @@ module "frontend" {
   create_service_account        = var.create_rag_service_account
   google_service_account        = local.rag_service_account
   namespace                     = var.kubernetes_namespace
+  additional_labels             = var.additional_labels
   inference_service_endpoint    = module.inference-server.inference_service_endpoint
   cloudsql_instance             = module.cloudsql.instance
   cloudsql_instance_region      = local.cloudsql_instance_region

--- a/applications/rag/metadata.display.yaml
+++ b/applications/rag/metadata.display.yaml
@@ -225,6 +225,11 @@ spec:
           name: kubernetes_namespace
           title: Kubernetes Namespace
           section: cluster_details
+        additional_labels:
+          name: additional_labels
+          title: Additional Labels
+          section: cluster_details
+          invisible: true
         private_cluster:
           name: private_cluster
           title: Private Cluster

--- a/applications/rag/metadata.yaml
+++ b/applications/rag/metadata.yaml
@@ -168,6 +168,10 @@ spec:
         description: Kubernetes namespace where resources are deployed
         varType: string
         defaultValue: rag
+      - name: additional_labels
+        description: Additional labels to apply to Kubenetes resources
+        varType: list(string)
+        defaultValue: ["created-by=rag-on-gke-qss"]
       - name: private_cluster
         varType: bool
         defaultValue: false

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -38,11 +38,10 @@ variable "kubernetes_namespace" {
 }
 
 variable "additional_labels" {
-  type        = map(string)
-  description = "Additional Kubernetes labels to add to Kubernetes resources."
-  default = {
-    created-by = "rag-on-gke"
-  }
+  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
+  type        = list(string)
+  description = "Additional labels to add to Kubernetes resources."
+  default     = ["created-by=rag-on-gke"]
 }
 
 variable "jupyter_service_account" {

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -37,6 +37,14 @@ variable "kubernetes_namespace" {
   default     = "rag"
 }
 
+variable "additional_labels" {
+  type        = map(string)
+  description = "Additional Kubernetes labels to add to Kubernetes resources."
+  default = {
+    created-by = "rag-on-gke"
+  }
+}
+
 variable "jupyter_service_account" {
   type        = string
   description = "Google Cloud IAM service account for authenticating with GCP services"

--- a/applications/ray/metadata.display.yaml
+++ b/applications/ray/metadata.display.yaml
@@ -56,6 +56,11 @@ spec:
           name: kubernetes_namespace
           title: Kubernetes Namespace
           section: cluster_details
+        additional_labels:
+          name: additional_labels
+          title: Additional Labels
+          section: cluster_details
+          invisible: true
         private_cluster:
           name: private_cluster
           title: Private Cluster

--- a/applications/ray/metadata.yaml
+++ b/applications/ray/metadata.yaml
@@ -75,6 +75,10 @@ spec:
         description: Kubernetes namespace where resources are deployed
         varType: string
         defaultValue: ai-on-gke
+      - name: additional_labels
+        description: Additional labels to apply to Kubenetes resources
+        varType: list(string)
+        defaultValue: ["created-by=ray-on-gke-qss"]
       - name: ray_version
         varType: string
         defaultValue: v2.9.3

--- a/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
@@ -26,7 +26,7 @@ hub:
     name: us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class
     tag: latest
   labels:
-    ${indent(4, chomp(yamlencode(additional_labels)))}
+    ${indent(4, chomp(jsonencode(additional_labels)))}
   config:
     JupyterHub:
       authenticator_class: ${authenticator_class}
@@ -51,6 +51,8 @@ prePuller:
     enabled: false
 
 proxy:
+  labels:
+    ${indent(4, chomp(jsonencode(additional_labels)))}
   chp:
     networkPolicy:
       enabled: false
@@ -86,7 +88,7 @@ singleuser:
     # Used for GCSFuse to set the ephemeral storage as the home directory. If not set, it will show a permission error on the pod log when using GCSFuse.
     JUPYTER_ALLOW_INSECURE_WRITES: "true"
   extraLabels:
-    ${indent(4, chomp(yamlencode(additional_labels)))}
+    ${indent(4, chomp(jsonencode(additional_labels)))}
   image:
     name: jupyter/tensorflow-notebook
     tag: python-3.10

--- a/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
@@ -25,6 +25,8 @@ hub:
   image:
     name: us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class
     tag: latest
+  labels:
+    ${indent(4, chomp(yamlencode(additional_labels)))}
   config:
     JupyterHub:
       authenticator_class: ${authenticator_class}
@@ -84,7 +86,7 @@ singleuser:
     # Used for GCSFuse to set the ephemeral storage as the home directory. If not set, it will show a permission error on the pod log when using GCSFuse.
     JUPYTER_ALLOW_INSECURE_WRITES: "true"
   extraLabels:
-    created-by: "jupyter-on-gke"
+    ${indent(4, chomp(yamlencode(additional_labels)))}
   image:
     name: jupyter/tensorflow-notebook
     tag: python-3.10

--- a/modules/jupyter/jupyter_config/config-selfauth.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth.yaml
@@ -25,6 +25,8 @@ hub:
   image:
     name: us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class
     tag: latest
+  labels:
+    ${indent(4, chomp(yamlencode(additional_labels)))}
   config:
     JupyterHub:
       authenticator_class: ${authenticator_class}
@@ -82,7 +84,7 @@ singleuser:
     # Used for GCSFuse to set the ephemeral storage as the home directory. If not set, it will show a permission error on the pod log when using GCSFuse.
     JUPYTER_ALLOW_INSECURE_WRITES: "true"
   extraLabels:
-    created-by: "jupyter-on-gke"
+    ${indent(4, chomp(yamlencode(additional_labels)))}
   image:
     name: jupyter/tensorflow-notebook
     tag: python-3.10

--- a/modules/jupyter/jupyter_config/config-selfauth.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth.yaml
@@ -26,7 +26,7 @@ hub:
     name: us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class
     tag: latest
   labels:
-    ${indent(4, chomp(yamlencode(additional_labels)))}
+    ${indent(4, chomp(jsonencode(additional_labels)))}
   config:
     JupyterHub:
       authenticator_class: ${authenticator_class}
@@ -51,6 +51,8 @@ prePuller:
     enabled: false
 
 proxy:
+  labels:
+    ${indent(4, chomp(jsonencode(additional_labels)))}
   chp:
     networkPolicy:
       enabled: false
@@ -84,7 +86,7 @@ singleuser:
     # Used for GCSFuse to set the ephemeral storage as the home directory. If not set, it will show a permission error on the pod log when using GCSFuse.
     JUPYTER_ALLOW_INSECURE_WRITES: "true"
   extraLabels:
-    ${indent(4, chomp(yamlencode(additional_labels)))}
+    ${indent(4, chomp(jsonencode(additional_labels)))}
   image:
     name: jupyter/tensorflow-notebook
     tag: python-3.10

--- a/modules/jupyter/main.tf
+++ b/modules/jupyter/main.tf
@@ -106,6 +106,7 @@ resource "helm_release" "jupyterhub" {
     project_id          = var.project_id
     project_number      = data.google_project.project.number
     namespace           = var.namespace
+    additional_labels   = var.additional_labels
     backend_config      = var.k8s_backend_config_name
     service_name        = var.k8s_backend_service_name
     authenticator_class = var.add_auth ? "'gcpiapjwtauthenticator.GCPIAPAuthenticator'" : "dummy"
@@ -119,6 +120,7 @@ resource "helm_release" "jupyterhub" {
       project_id          = var.project_id
       project_number      = data.google_project.project.number
       namespace           = var.namespace
+      additional_labels   = var.additional_labels
       backend_config      = var.k8s_backend_config_name
       service_name        = var.k8s_backend_service_name
       authenticator_class = var.add_auth ? "'gcpiapjwtauthenticator.GCPIAPAuthenticator'" : "dummy"

--- a/modules/jupyter/main.tf
+++ b/modules/jupyter/main.tf
@@ -16,6 +16,13 @@ data "google_project" "project" {
   project_id = var.project_id
 }
 
+locals {
+  additional_labels = tomap({
+    for item in var.additional_labels :
+    split("=", item)[0] => split("=", item)[1]
+  })
+}
+
 # IAP Section: Creates the GKE components
 module "iap_auth" {
   count  = var.add_auth ? 1 : 0
@@ -106,7 +113,7 @@ resource "helm_release" "jupyterhub" {
     project_id          = var.project_id
     project_number      = data.google_project.project.number
     namespace           = var.namespace
-    additional_labels   = var.additional_labels
+    additional_labels   = local.additional_labels
     backend_config      = var.k8s_backend_config_name
     service_name        = var.k8s_backend_service_name
     authenticator_class = var.add_auth ? "'gcpiapjwtauthenticator.GCPIAPAuthenticator'" : "dummy"
@@ -120,7 +127,7 @@ resource "helm_release" "jupyterhub" {
       project_id          = var.project_id
       project_number      = data.google_project.project.number
       namespace           = var.namespace
-      additional_labels   = var.additional_labels
+      additional_labels   = local.additional_labels
       backend_config      = var.k8s_backend_config_name
       service_name        = var.k8s_backend_service_name
       authenticator_class = var.add_auth ? "'gcpiapjwtauthenticator.GCPIAPAuthenticator'" : "dummy"

--- a/modules/jupyter/variables.tf
+++ b/modules/jupyter/variables.tf
@@ -33,6 +33,14 @@ variable "gcs_bucket" {
   description = "GCS bucket to mount on the notebook via GCSFuse and CSI"
 }
 
+variable "additional_labels" {
+  type        = map(string)
+  description = "Additional Kubernetes labels to add to Kubernetes resources."
+  default = {
+    created-by = "jupyter-on-gke"
+  }
+}
+
 variable "workload_identity_service_account" {
   type        = string
   description = "workload identity service account"

--- a/modules/jupyter/variables.tf
+++ b/modules/jupyter/variables.tf
@@ -34,11 +34,10 @@ variable "gcs_bucket" {
 }
 
 variable "additional_labels" {
-  type        = map(string)
-  description = "Additional Kubernetes labels to add to Kubernetes resources."
-  default = {
-    created-by = "jupyter-on-gke"
-  }
+  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
+  type        = list(string)
+  description = "Additional labels to add to Kubernetes resources."
+  default     = ["created-by=jupyter-on-gke"]
 }
 
 variable "workload_identity_service_account" {

--- a/modules/kuberay-cluster/main.tf
+++ b/modules/kuberay-cluster/main.tf
@@ -21,6 +21,10 @@ resource "google_storage_bucket_iam_member" "gcs-bucket-iam" {
 locals {
   security_context                  = { for k, v in var.security_context : k => v if v != null }
   cloudsql_instance_connection_name = format("%s:%s:%s", var.project_id, var.db_region, var.cloudsql_instance_name)
+  additional_labels = tomap({
+    for item in var.additional_labels :
+    split("=", item)[0] => split("=", item)[1]
+  })
 }
 
 resource "helm_release" "ray-cluster" {
@@ -35,7 +39,7 @@ resource "helm_release" "ray-cluster" {
     templatefile("${path.module}/values.yaml", {
       gcs_bucket                        = var.gcs_bucket
       k8s_service_account               = var.google_service_account
-      additional_labels                 = var.additional_labels
+      additional_labels                 = local.additional_labels
       grafana_host                      = var.grafana_host
       security_context                  = local.security_context
       secret_name                       = var.db_secret_name

--- a/modules/kuberay-cluster/main.tf
+++ b/modules/kuberay-cluster/main.tf
@@ -35,6 +35,7 @@ resource "helm_release" "ray-cluster" {
     templatefile("${path.module}/values.yaml", {
       gcs_bucket                        = var.gcs_bucket
       k8s_service_account               = var.google_service_account
+      additional_labels                 = var.additional_labels
       grafana_host                      = var.grafana_host
       security_context                  = local.security_context
       secret_name                       = var.db_secret_name

--- a/modules/kuberay-cluster/values.yaml
+++ b/modules/kuberay-cluster/values.yaml
@@ -56,7 +56,7 @@ head:
     #     memory: "512Mi"
   labels:
     cloud.google.com/gke-ray-node-type: head
-    created-by: ray-on-gke
+    ${indent(4, chomp(yamlencode(additional_labels)))}
   serviceAccountName: ${k8s_service_account}
   rayStartParams:
     dashboard-host: '0.0.0.0'
@@ -169,7 +169,7 @@ worker:
   type: worker
   labels:
     cloud.google.com/gke-ray-node-type: worker
-    created-by: ray-on-gke
+    ${indent(4, chomp(yamlencode(additional_labels)))}
   serviceAccountName: ${k8s_service_account}
   rayStartParams:
     block: 'true'

--- a/modules/kuberay-cluster/variables.tf
+++ b/modules/kuberay-cluster/variables.tf
@@ -29,6 +29,7 @@ variable "db_region" {
   default     = "us-central1"
 }
 
+
 variable "cloudsql_instance_name" {
   type        = string
   description = "Cloud SQL instance name"
@@ -39,6 +40,14 @@ variable "namespace" {
   type        = string
   description = "Kubernetes namespace where resources are deployed"
   default     = "ray-system"
+}
+
+variable "additional_labels" {
+  type        = map(string)
+  description = "Additional Kubernetes labels to add to Kubernetes resources."
+  default = {
+    created-by = "ray-on-gke"
+  }
 }
 
 variable "enable_tpu" {

--- a/modules/kuberay-cluster/variables.tf
+++ b/modules/kuberay-cluster/variables.tf
@@ -43,11 +43,10 @@ variable "namespace" {
 }
 
 variable "additional_labels" {
-  type        = map(string)
-  description = "Additional Kubernetes labels to add to Kubernetes resources."
-  default = {
-    created-by = "ray-on-gke"
-  }
+  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
+  type        = list(string)
+  description = "Additional labels to add to Kubernetes resources."
+  default     = ["created-by=ray-on-gke"]
 }
 
 variable "enable_tpu" {

--- a/tutorials-and-examples/hf-tgi/main.tf
+++ b/tutorials-and-examples/hf-tgi/main.tf
@@ -43,22 +43,25 @@ resource "kubernetes_deployment" "inference_deployment" {
   metadata {
     name      = "mistral-7b-instruct"
     namespace = var.namespace
+    labels = merge({
+      app = "mistral-7b-instruct"
+    }, var.additional_labels)
   }
 
   spec {
     replicas = 1
 
     selector {
-      match_labels = {
+      match_labels = merge({
         app = "mistral-7b-instruct"
-      }
+      }, var.additional_labels)
     }
 
     template {
       metadata {
-        labels = {
+        labels = merge({
           app = "mistral-7b-instruct"
-        }
+        }, var.additional_labels)
       }
 
       spec {

--- a/tutorials-and-examples/hf-tgi/main.tf
+++ b/tutorials-and-examples/hf-tgi/main.tf
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  additional_labels = tomap({
+    for item in var.additional_labels :
+    split("=", item)[0] => split("=", item)[1]
+  })
+}
+
 resource "kubernetes_service" "inference_service" {
   metadata {
     name = "mistral-7b-instruct-service"
@@ -45,7 +52,7 @@ resource "kubernetes_deployment" "inference_deployment" {
     namespace = var.namespace
     labels = merge({
       app = "mistral-7b-instruct"
-    }, var.additional_labels)
+    }, local.additional_labels)
   }
 
   spec {
@@ -54,14 +61,14 @@ resource "kubernetes_deployment" "inference_deployment" {
     selector {
       match_labels = merge({
         app = "mistral-7b-instruct"
-      }, var.additional_labels)
+      }, local.additional_labels)
     }
 
     template {
       metadata {
         labels = merge({
           app = "mistral-7b-instruct"
-        }, var.additional_labels)
+        }, local.additional_labels)
       }
 
       spec {

--- a/tutorials-and-examples/hf-tgi/variables.tf
+++ b/tutorials-and-examples/hf-tgi/variables.tf
@@ -18,6 +18,12 @@ variable "namespace" {
   default     = "default"
 }
 
+variable "additional_labels" {
+  type        = map(string)
+  description = "Additional Kubernetes labels to add to Kubernetes resources."
+  default     = {}
+}
+
 variable "autopilot_cluster" {
   type = bool
 }

--- a/tutorials-and-examples/hf-tgi/variables.tf
+++ b/tutorials-and-examples/hf-tgi/variables.tf
@@ -19,9 +19,10 @@ variable "namespace" {
 }
 
 variable "additional_labels" {
-  type        = map(string)
-  description = "Additional Kubernetes labels to add to Kubernetes resources."
-  default     = {}
+  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
+  type        = list(string)
+  description = "Additional labels to add to Kubernetes resources."
+  default     = []
 }
 
 variable "autopilot_cluster" {


### PR DESCRIPTION
Adds a new variable `additional_labels` for rag, ray and jupyter.
