### PR TITLE
Single-Host TPU Webhook Fix

### DIFF
--- a/applications/ray/kuberay-tpu-webhook/main.go
+++ b/applications/ray/kuberay-tpu-webhook/main.go
@@ -439,8 +439,10 @@ func mutatePod(admissionReview *admissionv1.AdmissionReview) (*admissionv1.Admis
 			container := containers[i]
 			if containerRequestingTPUs(container) {
 				path := fmt.Sprintf("/spec/containers/%d/env", i)
-				// inject TPU_WORKER_HOSTNAMES set during RayCluster interception
-				injectHostnames(sliceToHostnames[podSlice], path, container, &patches)
+				if isMultiHost {
+					// inject TPU_WORKER_HOSTNAMES set during RayCluster interception
+					injectHostnames(sliceToHostnames[podSlice], path, container, &patches)
+				}
 				// inject TPU_WORKER_ID
 				if getEnvironmentVariable("TPU_WORKER_ID", container) == "" {
 					workerID := corev1.EnvVar{

--- a/applications/ray/kuberay-tpu-webhook/main.go
+++ b/applications/ray/kuberay-tpu-webhook/main.go
@@ -413,10 +413,13 @@ func mutatePod(admissionReview *admissionv1.AdmissionReview) (*admissionv1.Admis
 		numOfHosts, _ := getNumTPUHostsFromTopology(topology, acceleratorType) // ignore error here because topology may not be set yet
 		replicaIndex := getReplicaIndex(clusterName)
 		podSlice := slice{clusterName, groupName, replicaIndex, numOfHosts}
-		tpuWorkerID := getNextWorkerID(podSlice, replicaIndex)
+		tpuWorkerID := 0 // defaults to 0 for single-host
 
 		isMultiHost, _ := isTPUMultiHost(topology, acceleratorType) // ignore error here because topology may not be set yet
 		if isMultiHost {
+			// get next unique TPU_WORKER_ID for multi-host slice
+			tpuWorkerID = getNextWorkerID(podSlice, replicaIndex)
+
 			// inject hostname into pod spec for DNS records
 			hostname := fmt.Sprintf(groupName+"-%d-%d", replicaIndex, tpuWorkerID)
 			hostnamePatch := patch{"op": "add"}


### PR DESCRIPTION
This PR defaults the single-host Pod `TPU_WORKER_ID` to 0 to fix a bug that was incrementing the ID upon deletion and re-creation. This PR also updates the code to only inject `TPU_WORKER_HOSTNAMES` for multi-host podslices (previously an empty string would be injected). This PR was manually tested by creating both single-host and multi-host RayClusters using this template: https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.tpu-v4-singlehost.yaml and verifying that the env vars were set correctly even after multiple creations and deletions of the RayCluster.