### PR TITLE
revert default GKE cluster labels to created-by: ai-on-gke

### DIFF
--- a/infrastructure/tfvars_examples/platform.complete.tfvars
+++ b/infrastructure/tfvars_examples/platform.complete.tfvars
@@ -171,11 +171,11 @@ all_node_pools_oauth_scopes = [
 
 
 cluster_labels = {
-  "gke-profile" = "ai-on-gke"
+  "created-by" = "ai-on-gke"
 }
 
 all_node_pools_labels = {
-  "gke-profile" = "ai-on-gke"
+  "created-by" = "ai-on-gke"
 }
 
 all_node_pools_metadata = {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -89,7 +89,7 @@ variable "cluster_labels" {
   type        = map(any)
   description = "GKE cluster labels"
   default = {
-    "gke-profile" = "ai-on-gke"
+    "created-by" = "ai-on-gke"
   }
 }
 
@@ -154,7 +154,7 @@ variable "all_node_pools_oauth_scopes" {
 variable "all_node_pools_labels" {
   type = map(string)
   default = {
-    "gke-profile" = "ai-on-gke"
+    "created-by" = "ai-on-gke"
   }
 }
 variable "all_node_pools_metadata" {


### PR DESCRIPTION
Since a few months back we used the cluster label `created-by: ai-on-gke` by default. However, recently it was changed to `gke-profile: ai-on-gke`. This PR reverts the cluster label back to `created-by: ai-on-gke`. 