### PR TITLE
Update batch/v1 Job definition to contain maxRunDurationSeconds annotation

### DIFF
--- a/tutorials-and-examples/workflow-orchestration/dws-examples/job.yaml
+++ b/tutorials-and-examples/workflow-orchestration/dws-examples/job.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: default
   labels:
     kueue.x-k8s.io/queue-name: dws-local-queue
+  annotations:
+    provreq.kueue.x-k8s.io/maxRunDurationSeconds : "600"
 spec:
   parallelism: 1
   completions: 1


### PR DESCRIPTION
The mechanism handling this annotation has been described in [this KEP](https://github.com/kubernetes-sigs/kueue/pull/1793). This example illustrates how a user can set maxRunDurationSeconds for ProvisioningRequest in a job definition.