### PR TITLE
Add More Informative Logging Throughout Ray TPU Webhook

### DIFF
--- a/applications/ray/kuberay-tpu-webhook/Makefile
+++ b/applications/ray/kuberay-tpu-webhook/Makefile
@@ -24,6 +24,10 @@ uninstall:
 # Deploy the webhook in-cluster
 deploy:
 	kubectl apply -f deployments/
+
+# Deploy the webhook with verbose logging
+deploy-verbose:
+	kubectl apply -f deployments/ --v 1
   
 # Build the docker image  
 docker-build:

--- a/applications/ray/kuberay-tpu-webhook/Makefile
+++ b/applications/ray/kuberay-tpu-webhook/Makefile
@@ -24,10 +24,6 @@ uninstall:
 # Deploy the webhook in-cluster
 deploy:
 	kubectl apply -f deployments/
-
-# Deploy the webhook with verbose logging
-deploy-verbose:
-	kubectl apply -f deployments/ --v 1
   
 # Build the docker image  
 docker-build:

--- a/applications/ray/kuberay-tpu-webhook/certs/cert.yaml
+++ b/applications/ray/kuberay-tpu-webhook/certs/cert.yaml
@@ -18,7 +18,3 @@ spec:
     - kuberay-tpu-webhook.ray-system.svc.cluster.local
   issuerRef:
     name: selfsigned-issuer
-  secretTemplate:
-    annotations:
-      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"

--- a/applications/ray/kuberay-tpu-webhook/deployments/deployment.yaml
+++ b/applications/ray/kuberay-tpu-webhook/deployments/deployment.yaml
@@ -24,6 +24,8 @@ spec:
         - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/kuberay-tpu-webhook:v1.1
           imagePullPolicy: Always
           name: kuberay-tpu-webhook
+          args:
+          - --v=0 # change this value to 1 for verbose logging 
           ports:
           - name: https
             containerPort: 443

--- a/applications/ray/kuberay-tpu-webhook/main.go
+++ b/applications/ray/kuberay-tpu-webhook/main.go
@@ -624,7 +624,7 @@ func main() {
 		}
 
 		if admissionReview.Request.Kind.Kind == "Pod" {
-			klog.Info("Received review for Pod creation")
+			klog.V(0).Info("Received review for Pod creation")
 			response, err := mutatePod(admissionReview)
 			if err != nil {
 				klog.Errorf("Failed to mutate pod: %s", err)
@@ -664,7 +664,7 @@ func main() {
 		}
 
 		if admissionReview.Request.Kind.Kind == "RayCluster" {
-			klog.Info("Received review for RayCluster")
+			klog.V(0).Info("Received review for RayCluster")
 			response, err := validateRayCluster(admissionReview)
 			if err != nil {
 				klog.Errorf("Failed to validate ray cluster: %s", err)
@@ -696,7 +696,7 @@ func main() {
 
 	if err := srv.ListenAndServeTLS(certPath, keyPath); err != nil {
 		if err == http.ErrServerClosed {
-			klog.Info("Server closed")
+			klog.V(0).Info("Server closed")
 			return
 		}
 		klog.Error("Failed to start server")


### PR DESCRIPTION
This PR adds more `klog` logging statements to the webhook with more informative messages, viewable using `kubectl logs` when the webhook pod is running. This PR was tested by deploying a RayCluster with the webhook running, viewing the `kubectl logs` printed out, and verifying that all mutation operations occurred succesfully.