### PR TITLE
Wait for gmp-operator rollout before applying kuberay podmonitorings (obsolete)

### DIFF
--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -201,6 +201,7 @@ module "kuberay-monitoring" {
   source                          = "../../modules/kuberay-monitoring"
   providers                       = { helm = helm.rag, kubernetes = kubernetes.rag }
   project_id                      = var.project_id
+  autopilot_cluster               = local.enable_autopilot
   namespace                       = var.kubernetes_namespace
   create_namespace                = true
   enable_grafana_on_ray_dashboard = var.enable_grafana_on_ray_dashboard

--- a/applications/ray/README.md
+++ b/applications/ray/README.md
@@ -6,6 +6,7 @@ See the [Ray on GKE](/ray-on-gke/) directory to see additional guides and refere
 ## Installation
 
 Preinstall the following on your computer:
+* Kubectl
 * Terraform
 * Gcloud
 

--- a/applications/ray/main.tf
+++ b/applications/ray/main.tf
@@ -127,6 +127,7 @@ module "kuberay-monitoring" {
   source                          = "../../modules/kuberay-monitoring"
   providers                       = { helm = helm.ray, kubernetes = kubernetes.ray }
   project_id                      = var.project_id
+  autopilot_cluster               = local.enable_autopilot
   namespace                       = var.kubernetes_namespace
   create_namespace                = true
   enable_grafana_on_ray_dashboard = var.enable_grafana_on_ray_dashboard

--- a/modules/kuberay-monitoring/variables.tf
+++ b/modules/kuberay-monitoring/variables.tf
@@ -17,6 +17,10 @@ variable "project_id" {
   description = "GCP project id"
 }
 
+variable "autopilot_cluster" {
+  type = bool
+}
+
 variable "namespace" {
   type        = string
   description = "Kubernetes namespace where resources are deployed"


### PR DESCRIPTION
`kuberay-operator` appears to be deployed faster than the `gmp-operator`, causing `kuberay-monitoring` to create a `PodMonitorings` object before the GMP webhook server is ready to validate it.

With the dependency in place, Terraform waits for the `gmp-operator` (external data source) to be rolled out prior to deploying `gmp-engine`:

```
Plan: 2 to add, 0 to change, 0 to destroy.
module.kuberay-monitoring.null_resource.wait_for_gmp: Creating...
module.kuberay-monitoring.null_resource.wait_for_gmp: Provisioning with 'local-exec'...
module.kuberay-monitoring.null_resource.wait_for_gmp (local-exec): Executing: ["/bin/sh" "-c" "while ! kubectl rollout status -n gke-gmp-system deploy/gmp-operator; do sleep 5; done"]
module.kuberay-monitoring.null_resource.wait_for_gmp (local-exec): deployment "gmp-operator" successfully rolled out
module.kuberay-monitoring.null_resource.wait_for_gmp: Creation complete after 0s [id=6180172337812646967]
module.kuberay-monitoring.helm_release.gmp-engine: Creating...
module.kuberay-monitoring.helm_release.gmp-engine: Creation complete after 6s [id=gmp-engine]
```

Fixes https://github.com/GoogleCloudPlatform/ai-on-gke/issues/402