### PR TITLE
Wait for gmp-operator rollout before applying kuberay podmonitorings

### DIFF
--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -19,6 +19,8 @@ provider "google-beta" {
   project = var.project_id
 }
 
+provider "time" {}
+
 data "google_client_config" "default" {}
 
 data "google_project" "project" {

--- a/applications/rag/versions.tf
+++ b/applications/rag/versions.tf
@@ -28,5 +28,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "2.18.1"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "0.11.1"
+    }
   }
 }

--- a/applications/ray/main.tf
+++ b/applications/ray/main.tf
@@ -20,6 +20,8 @@ provider "google" {
   project = var.project_id
 }
 
+provider "time" {}
+
 data "google_client_config" "default" {}
 
 data "google_project" "project" {

--- a/applications/ray/versions.tf
+++ b/applications/ray/versions.tf
@@ -28,5 +28,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "2.18.1"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "0.11.1"
+    }
   }
 }

--- a/modules/kuberay-monitoring/main.tf
+++ b/modules/kuberay-monitoring/main.tf
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Temporary workaround to ensure the GMP webhook is installed before applying PodMonitorings.
+resource "time_sleep" "wait_for_gmp_operator" {
+  create_duration = "10s"
+}
+
 # google managed prometheus engine
 resource "helm_release" "gmp-engine" {
   name             = "gmp-engine"
@@ -29,6 +34,8 @@ resource "helm_release" "gmp-engine" {
     name  = "serviceAccount"
     value = var.k8s_service_account
   }
+
+  depends_on = [time_sleep.wait_for_gmp_operator]
 }
 
 # grafana

--- a/modules/kuberay-monitoring/versions.tf
+++ b/modules/kuberay-monitoring/versions.tf
@@ -22,5 +22,9 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "2.18.1"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = "0.11.1"
+    }
   }
 }


### PR DESCRIPTION
`kuberay-operator` appears to be deployed faster than the `gmp-operator`, causing `kuberay-monitoring` to create a `PodMonitorings` object before the GMP webhook server is ready to validate it.

Implement a delay between `kuberay-operator` startup and `kuberay-monitoring` deployment to ensure `gmp-operator` has time to start up. This delay can be adjusted based on perceived flakiness.

Fixes https://github.com/GoogleCloudPlatform/ai-on-gke/issues/402
Replaces https://github.com/GoogleCloudPlatform/ai-on-gke/pull/407

This lightweight solution is meant as a stop-gap, to be replaced with either of the two proper solutions:
1. Ensure gmp-operator is always running in the GKE CP.
2. Implement retry on the provider (https://github.com/hashicorp/terraform-provider-helm/issues/1058).