### PR TITLE
have Jupyterhub use tagged image instead of 'latest'

### DIFF
--- a/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
@@ -24,7 +24,8 @@
 hub:
   image:
     name: us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class
-    tag: latest
+    # This is the timestamp of the image, we should avoid using 'latest'
+    tag: '1710974014'
   labels:
     ${indent(4, chomp(jsonencode(additional_labels)))}
   config:

--- a/modules/jupyter/jupyter_config/config-selfauth.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth.yaml
@@ -24,7 +24,8 @@
 hub:
   image:
     name: us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class
-    tag: latest
+    # This is the timestamp of the image, we should avoid using 'latest'
+    tag: '1710974014'
   labels:
     ${indent(4, chomp(jsonencode(additional_labels)))}
   config:


### PR DESCRIPTION
Jupyterhub image will use a tagged image instead of 'latest'. Tagged image should have less vulns.