### PR TITLE
tpu-provisioner - Dedup NP creations on job-key and reduce noisy node pool deletion reconciles

### DIFF
--- a/tpu-provisioner/internal/cloud/gke.go
+++ b/tpu-provisioner/internal/cloud/gke.go
@@ -326,7 +326,8 @@ func sumTPURequests(p *corev1.Pod) (int, error) {
 }
 
 func podToNodePoolName(p *corev1.Pod, prefix, suffix string) string {
-	// Use the UID of the Pod as the unique identifier for the node pool.
+	// Use the UID of the Pod's owner (falling back to the Pod UID if it has
+	// no owner) as the unique identifier for the node pool.
 	// It is necessary to use something that is unique to the Pod not the Job/JobSet
 	// because the scheduler is not guaranteed to place Pods on the same
 	// node pools that were created for them. This commonly happens when

--- a/tpu-provisioner/internal/controller/creation_controller.go
+++ b/tpu-provisioner/internal/controller/creation_controller.go
@@ -78,7 +78,7 @@ func (r *CreationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	lg.Info("Ensuring node pool for unschedulable pod")
 	if err := r.Provider.EnsureNodePoolForPod(&pod, "pod is currently unschedulable"); err != nil {
 		if errors.Is(err, cloud.ErrDuplicateRequest) {
-			lg.Info("Ignoring duplicate request to create node pool")
+			lg.V(3).Info("Ignoring duplicate request to create node pool", "message", err.Error())
 		} else if errors.Is(err, cloud.ErrNodePoolStopping) {
 			wait := 5 * time.Second
 			lg.Info("Attempted to create a node pool that is currently undergoing deletion, retrying soon",


### PR DESCRIPTION
Rapid JobSet restarts can trigger concurrent node pool creations for the same logical Job. This PR adds in-memory de-duplication of those scenarios.

Also: Reduce some noisy reconciles that occur when node pools are deleting.