### PR TITLE
Improvements to Marketplace experience for RAG (auto generate network and namespace)

### DIFF
--- a/applications/jupyter/metadata.yaml
+++ b/applications/jupyter/metadata.yaml
@@ -71,7 +71,7 @@ spec:
       - name: domain
         description: Domain used for SSL certificate. If it's empty, *.nip.io DNS is used.
         varType: string
-        defaultValue: ""
+        defaultValue: "jupyter.example.com"
       - name: gcs_bucket
         description: Bucket name to store the dataset. The bucket name must be globally unique across google cloud projects
         varType: string

--- a/applications/rag/metadata.display.yaml
+++ b/applications/rag/metadata.display.yaml
@@ -22,6 +22,11 @@ spec:
           enumValueLabels:
             - label: "Confirm that all prerequisites have been met."
               value: "true"
+        additional_labels:
+          name: additional_labels
+          title: Additional Labels
+          invisible: true
+          section: cluster_details
         autopilot_cluster:
           name: autopilot_cluster
           title: GKE Cluster Type
@@ -38,8 +43,8 @@ spec:
         cloudsql_instance_region:
           name: cloudsql_instance_region
           title: Cloudsql Instance Region
-          section: rag
           invisible: true
+          section: rag
         cluster_location:
           name: cluster_location
           title: Cluster Location
@@ -82,6 +87,11 @@ spec:
           title: Create Jupyter Service Account
           invisible: true
           section: rag
+        create_network:
+          name: create_network
+          title: Create Network
+          invisible: true
+          section: cluster_details
         create_rag_service_account:
           name: create_rag_service_account
           title: Create Rag Service Account
@@ -114,13 +124,13 @@ spec:
         frontend_client_id:
           name: frontend_client_id
           title: Frontend Client Id
-          section: rag_iap_auth
           invisible: true
+          section: rag_iap_auth
         frontend_client_secret:
           name: frontend_client_secret
           title: Frontend Client Secret
-          section: rag_iap_auth
           invisible: true
+          section: rag_iap_auth
         frontend_domain:
           name: frontend_domain
           title: Frontend Domain
@@ -128,33 +138,33 @@ spec:
         frontend_k8s_backend_config_name:
           name: frontend_k8s_backend_config_name
           title: Frontend K8s Backend Config Name
-          section: rag_iap_auth
           invisible: true
+          section: rag_iap_auth
         frontend_k8s_backend_service_name:
           name: frontend_k8s_backend_service_name
           title: Frontend K8s Backend Service Name
-          section: rag_iap_auth
           invisible: true
+          section: rag_iap_auth
         frontend_k8s_backend_service_port:
           name: frontend_k8s_backend_service_port
           title: Frontend K8s Backend Service Port
-          section: rag_iap_auth
           invisible: true
+          section: rag_iap_auth
         frontend_k8s_iap_secret_name:
           name: frontend_k8s_iap_secret_name
           title: Frontend K8s Iap Secret Name
-          section: rag_iap_auth
           invisible: true
+          section: rag_iap_auth
         frontend_k8s_ingress_name:
           name: frontend_k8s_ingress_name
           title: Frontend K8s Ingress Name
-          section: rag_iap_auth
           invisible: true
+          section: rag_iap_auth
         frontend_k8s_managed_cert_name:
           name: frontend_k8s_managed_cert_name
           title: Frontend K8s Managed Cert Name
-          section: rag_iap_auth
           invisible: true
+          section: rag_iap_auth
         frontend_members_allowlist:
           name: frontend_members_allowlist
           title: Frontend Members Allowlist
@@ -226,13 +236,13 @@ spec:
         jupyter_client_id:
           name: jupyter_client_id
           title: Jupyter Client Id
-          section: jupyter_iap_auth
           invisible: true
+          section: jupyter_iap_auth
         jupyter_client_secret:
           name: jupyter_client_secret
           title: Jupyter Client Secret
-          section: jupyter_iap_auth
           invisible: true
+          section: jupyter_iap_auth
         jupyter_domain:
           name: jupyter_domain
           title: Jupyter Domain
@@ -240,33 +250,33 @@ spec:
         jupyter_k8s_backend_config_name:
           name: jupyter_k8s_backend_config_name
           title: Jupyter K8s Backend Config Name
-          section: jupyter_iap_auth
           invisible: true
+          section: jupyter_iap_auth
         jupyter_k8s_backend_service_name:
           name: jupyter_k8s_backend_service_name
           title: Jupyter K8s Backend Service Name
-          section: jupyter_iap_auth
           invisible: true
+          section: jupyter_iap_auth
         jupyter_k8s_backend_service_port:
           name: jupyter_k8s_backend_service_port
           title: Jupyter K8s Backend Service Port
-          section: jupyter_iap_auth
           invisible: true
+          section: jupyter_iap_auth
         jupyter_k8s_iap_secret_name:
           name: jupyter_k8s_iap_secret_name
           title: Jupyter K8s Iap Secret Name
-          section: jupyter_iap_auth
           invisible: true
+          section: jupyter_iap_auth
         jupyter_k8s_ingress_name:
           name: jupyter_k8s_ingress_name
           title: Jupyter K8s Ingress Name
-          section: jupyter_iap_auth
           invisible: true
+          section: jupyter_iap_auth
         jupyter_k8s_managed_cert_name:
           name: jupyter_k8s_managed_cert_name
           title: Jupyter K8s Managed Cert Name
-          section: jupyter_iap_auth
           invisible: true
+          section: jupyter_iap_auth
         jupyter_members_allowlist:
           name: jupyter_members_allowlist
           title: Jupyter Members Allowlist
@@ -279,12 +289,13 @@ spec:
         kubernetes_namespace:
           name: kubernetes_namespace
           title: Kubernetes Namespace
-          section: cluster_details
-        additional_labels:
-          name: additional_labels
-          title: Additional Labels
-          section: cluster_details
           invisible: true
+          section: cluster_details
+        network_name:
+          name: network_name
+          title: Network Name
+          invisible: true
+          section: cluster_details
         private_cluster:
           name: private_cluster
           title: Private Cluster
@@ -304,6 +315,11 @@ spec:
           title: Ray Service Account
           invisible: true
           section: rag
+        subnetwork_cidr:
+          name: subnetwork_cidr
+          title: Subnetwork Cidr
+          invisible: true
+          section: cluster_details
         support_email:
           name: support_email
           title: Support Email
@@ -324,19 +340,18 @@ spec:
           subtext: Make sure the <a href="https://developers.google.com/workspace/guides/configure-oauth-consent#configure_oauth_consent"><i>OAuth Consent Screen</i></a> is configured for your project. Ensure <b>User type</b> is set to <i>Internal</i>. Note that by default, only users within your organization can be allowlisted. To add external users, change the <b>User type</b> to <i>External</i> after the application is deployed.
 
         - name: jupyter_iap_auth
-          title:  Configure Authenticated Access for JupyterHub
+          title: Configure Authenticated Access for JupyterHub
           subtext: Make sure the <a href="https://developers.google.com/workspace/guides/configure-oauth-consent#configure_oauth_consent"><i>OAuth Consent Screen</i></a> is configured for your project. Ensure <b>User type</b> is set to <i>Internal</i>. Note that by default, only users within your organization can be allowlisted. To add external users, change the <b>User type</b> to <i>External</i> after the application is deployed.
     runtime:
       outputMessage: Deployment can take several minutes to complete.
       suggestedActions:
         - heading: "Step 1: Create DNS A Records for JupyterHub and Frontend Domains"
-          description: |-
-              If using custom domains for JupyterHub or Frontend, create DNS A record sets for them (<a href="https://cloud.google.com/dns/docs/records#add_a_record">Google DNS Record Set</a>). Propagation takes 10-15 minutes and logging in won’t succeed until it’s done.
+          description: If using custom domains for JupyterHub or Frontend, create DNS A record sets for them (<a href="https://cloud.google.com/dns/docs/records#add_a_record">Google DNS Record Set</a>). Propagation takes 10-15 minutes and logging in won’t succeed until it’s done.
         - heading: "Step 2: Go to JupyterHub Application"
           description: |-
-             <li>If IAP is enabled, log in with your organization's credentials. SSL or cert errors indicate the cert is provisioning which takes up to 20 minutes.</li>
-             <li>If IAP is disabled, scroll to <i>Ports</i> section and initiate <b>PORT FORWARDING</b> (Run in Cloud Shell) to the front end application. Launch JupyterHub app via <b>OPEN IN WEB PREVIEW</b> button. Log in with <i>Jupyterhub User</i> and <i>Jupyterhub Password</i> (from the Outputs section).</li>
-             <li> Once logged in, choose the <b>CPU</b> preset.</li>
+            <li>If IAP is enabled, log in with your organization's credentials. SSL or cert errors indicate the cert is provisioning which takes up to 20 minutes.</li>
+            <li>If IAP is disabled, scroll to <i>Ports</i> section and initiate <b>PORT FORWARDING</b> (Run in Cloud Shell) to the front end application. Launch JupyterHub app via <b>OPEN IN WEB PREVIEW</b> button. Log in with <i>Jupyterhub User</i> and <i>Jupyterhub Password</i> (from the Outputs section).</li>
+            <li> Once logged in, choose the <b>CPU</b> preset.</li>
         - heading: "Step 3: Generate Vector Embeddings for the Dataset"
           description: |-
             Go to File -> Open From URL & upload and execute the notebook 
@@ -349,19 +364,21 @@ spec:
             <li>If IAP is disabled, scroll to <i>Ports</i> section and initiate <b>PORT FORWARDING</b> (Run in Cloud Shell) to the front end application. Launch Fronted Chat app via <b>OPEN IN WEB PREVIEW</b> button. </li>
             <li>Prompt the LLM. This will fetch context related to your prompt from the generated vector embeddings, augment the original prompt with the context & query the inference model (mistral-7b) with the augmented prompt.</li>
       outputs:
+        frontend_ip_address: {}
         frontend_uri:
           openInNewTab: true
           showInNotification: true
-          label: Go to RAG Frontend Application
+          label: Go to Frontend Application
         ray_dashboard_uri:
           openInNewTab: true
           showInNotification: true
           label: Go to RAY Dashboard Application
+        gcp_network: {}
+        jupyterhub_ip_address: {}
         jupyterhub_password: {}
         jupyterhub_uri:
           openInNewTab: true
           showInNotification: true
           label: Go to JupyterHub Application
         jupyterhub_user: {}
-        jupyterhub_ip_address: {}
-        frontend_ip_address: {}
+        kubernetes_namespace: {}

--- a/applications/rag/metadata.yaml
+++ b/applications/rag/metadata.yaml
@@ -20,6 +20,12 @@ spec:
       - name: acknowledge
         varType: bool
         required: true
+      - name: additional_labels
+        description: Additional labels to add to Kubernetes resources.
+        varType: list(string)
+        defaultValue:
+          - created-by=ai-on-gke
+          - ai.gke.io=rag
       - name: autopilot_cluster
         varType: string
         defaultValue: true
@@ -52,6 +58,10 @@ spec:
         description: Enable flag to create gcs_bucket
         varType: bool
         defaultValue: false
+      - name: create_network
+        description: Create the VPC specified by network_name/subnetwork_name
+        varType: bool
+        defaultValue: true
       - name: create_rag_service_account
         description: Creates a google IAM service account & k8s service account & configures workload identity
         varType: bool
@@ -73,6 +83,7 @@ spec:
         varType: bool
         defaultValue: false
       - name: frontend_add_auth
+        description: Enable iap authentication on frontend
         varType: bool
         defaultValue: false
       - name: frontend_client_id
@@ -160,6 +171,7 @@ spec:
         varType: string
         defaultValue: ""
       - name: jupyter_add_auth
+        description: Enable iap authentication on jupyterhub
         varType: bool
         defaultValue: false
       - name: jupyter_client_id
@@ -209,10 +221,10 @@ spec:
         description: Kubernetes namespace where resources are deployed
         varType: string
         defaultValue: rag
-      - name: additional_labels
-        description: Additional labels to apply to Kubenetes resources
-        varType: list(string)
-        defaultValue: ["created-by=gke-ai-quick-start-solutions", "ai.gke.io=rag"]
+      - name: network_name
+        description: Network name of VPC
+        varType: string
+        defaultValue: net
       - name: private_cluster
         varType: bool
         defaultValue: false
@@ -228,20 +240,27 @@ spec:
         description: Google Cloud IAM service account for authenticating with GCP services
         varType: string
         defaultValue: ray-sa
+      - name: subnetwork_cidr
+        varType: string
+        defaultValue: 10.128.0.0/20
       - name: support_email
         description: Email for users to contact with questions about their consent
         varType: string
         defaultValue: ""
     outputs:
+      - name: frontend_ip_address
+        description: Frontend gloabl IP address
       - name: frontend_uri
         description: RAG Frontend Endpoint to access user interface. In case of private IP, consider port-forwarding.
+      - name: gcp_network
+        description: Provisioned GCP Network Name
+      - name: jupyterhub_ip_address
+        description: JupyterHub gloabl IP address
       - name: jupyterhub_password
         description: JupyterHub password is only required for standard authentication. Ignore, in case of IAP authentication
       - name: jupyterhub_uri
         description: JupyterHub Endpoint to access user interface. In case of private IP, consider port-forwarding.
       - name: jupyterhub_user
         description: JupyterHub user is only required for standard authentication. Ignore, in case of IAP authentication
-      - name: frontend_ip_address
-        description: Frontend global IP address
-      - name: jupyterhub_ip_address
-        description: JupyterHub global IP address
+      - name: kubernetes_namespace
+        description: Kubernetes namespace

--- a/applications/rag/metadata.yaml
+++ b/applications/rag/metadata.yaml
@@ -97,7 +97,7 @@ spec:
       - name: frontend_domain
         description: Domain used for application and SSL certificate. 
         varType: string
-        defaultValue: "example.com"
+        defaultValue: "rag.example.com"
       - name: frontend_k8s_backend_config_name
         description: Name of the Kubernetes Backend Config
         varType: string
@@ -185,7 +185,7 @@ spec:
       - name: jupyter_domain
         description: Domain used for application and SSL certificate.
         varType: string
-        defaultValue: "example.com"
+        defaultValue: "jupyter.example.com"
       - name: jupyter_k8s_backend_config_name
         description: Name of the Kubernetes Backend Config
         varType: string

--- a/applications/rag/outputs.tf
+++ b/applications/rag/outputs.tf
@@ -47,3 +47,13 @@ output "ray_dashboard_uri" {
   description = "RAY Dashboard Endpoint to access user interface. In case of private IP, consider port-forwarding."
   value       = module.kuberay-cluster.ray_dashboard_uri != "" ? "http://${module.kuberay-cluster.ray_dashboard_uri}" : ""
 }
+
+output "kubernetes_namespace" {
+  value       = local.kubernetes_namespace
+  description = "Kubernetes namespace"
+}
+
+output "gcp_network" {
+  value       = local.network_name
+  description = "Provisioned GCP Network Name"
+}

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -426,8 +426,7 @@ variable "network_name" {
   default     = "default"
 }
 
-variable "subnetwork_name" {
-  description = "Subnetwork name of VPC"
-  type        = string
-  default     = "default"
+variable "subnetwork_cidr" {
+  type    = string
+  default = "10.128.0.0/20"
 }

--- a/applications/rag/workloads.tfvars
+++ b/applications/rag/workloads.tfvars
@@ -15,10 +15,13 @@
 project_id = "<your project ID>"
 
 ## this is required for terraform to connect to GKE master and deploy workloads
-create_cluster    = true # Create a GKE cluster in the default network.
+create_cluster    = true # Create a GKE cluster in the specified network.
 autopilot_cluster = true
 cluster_name      = "<cluster_name>"
 cluster_location  = "us-central1"
+create_network    = true
+network_name      = "ml-network"
+subnetwork_cidr   = "10.100.0.0/16"
 
 ## GKE environment variables
 kubernetes_namespace = "rag"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -202,6 +202,7 @@ steps:
         cd /workspace/applications/rag/
         terraform apply \
         -var-file=workloads.tfvars \
+        -var=network_name=default \
         -var=create_cluster=false \
         -var=jupyter_add_auth=false \
         -var=frontend_add_auth=false \
@@ -260,6 +261,7 @@ steps:
         cd /workspace/applications/rag/
         terraform destroy \
         -var-file=workloads.tfvars \
+        -var=network_name=default \
         -var=create_cluster=false \
         -var=jupyter_add_auth=false \
         -var=frontend_add_auth=false \

--- a/infrastructure/platform.tfvars
+++ b/infrastructure/platform.tfvars
@@ -19,8 +19,8 @@ project_id = "ai-on-gke-jss-sandbox"
 #######################################################
 ## network values
 create_network    = true
-network_name      = "ml-network99"
-subnetwork_name   = "ml-subnet99"
+network_name      = "ml-network"
+subnetwork_name   = "ml-network"
 subnetwork_cidr   = "10.100.0.0/16"
 subnetwork_region = "us-central1"
 


### PR DESCRIPTION
- Auto-generate namespace for marketplace without user input, prefixed with the IM deployment name. This helps prevent issues with multiple RAG deployments landing on the same namespace.
- For RAG marketplace solution, always generate a new network with PSC enabled prefixed with the IM deployment_name