### PR TITLE
use single namespace installation for kuberay-operator

### DIFF
--- a/modules/kuberay-operator/kuberay-operator-autopilot-values.yaml
+++ b/modules/kuberay-operator/kuberay-operator-autopilot-values.yaml
@@ -88,7 +88,7 @@ crNamespacedRbacEnable: true
 #   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
 # - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen
 #   to resource events within its own namespace.
-singleNamespaceInstall: false
+singleNamespaceInstall: true
 
 # The KubeRay operator will watch the custom resources in the namespaces listed in the "watchNamespace" parameter.
 # watchNamespace:

--- a/modules/kuberay-operator/kuberay-operator-values.yaml
+++ b/modules/kuberay-operator/kuberay-operator-values.yaml
@@ -88,7 +88,7 @@ crNamespacedRbacEnable: true
 #   (Please note that this excludes the CRDs, which can only be installed at the cluster scope.)
 # - If "watchNamespace" is not set, the KubeRay operator will, by default, only listen
 #   to resource events within its own namespace.
-singleNamespaceInstall: false
+singleNamespaceInstall: true
 
 # The KubeRay operator will watch the custom resources in the namespaces listed in the "watchNamespace" parameter.
 # watchNamespace:


### PR DESCRIPTION
So that kuberay resources are scoped to only the namespaced used in the terraform deployment