### PR TITLE
Downgrade RAG to 1.28; bump GMP resource creation delay; increase Ray worker creation timeout

### DIFF
--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -64,20 +64,21 @@ module "infra" {
   source = "../../infrastructure"
   count  = var.create_cluster ? 1 : 0
 
-  project_id        = var.project_id
-  cluster_name      = var.cluster_name
-  cluster_location  = var.cluster_location
-  region            = local.cluster_location_region
-  autopilot_cluster = var.autopilot_cluster
-  private_cluster   = var.private_cluster
-  create_network    = var.create_network
-  network_name      = local.network_name
-  subnetwork_name   = local.network_name
-  subnetwork_cidr   = var.subnetwork_cidr
-  subnetwork_region = local.cluster_location_region
-  cpu_pools         = var.cpu_pools
-  enable_gpu        = true
-  gpu_pools         = var.gpu_pools
+  project_id         = var.project_id
+  cluster_name       = var.cluster_name
+  cluster_location   = var.cluster_location
+  region             = local.cluster_location_region
+  autopilot_cluster  = var.autopilot_cluster
+  private_cluster    = var.private_cluster
+  create_network     = var.create_network
+  network_name       = local.network_name
+  subnetwork_name    = local.network_name
+  subnetwork_cidr    = var.subnetwork_cidr
+  subnetwork_region  = local.cluster_location_region
+  cpu_pools          = var.cpu_pools
+  enable_gpu         = true
+  gpu_pools          = var.gpu_pools
+  kubernetes_version = var.kubernetes_version
 }
 
 data "google_container_cluster" "default" {
@@ -249,6 +250,7 @@ module "kuberay-monitoring" {
   source                          = "../../modules/kuberay-monitoring"
   providers                       = { helm = helm.rag, kubernetes = kubernetes.rag }
   project_id                      = var.project_id
+  autopilot_cluster               = local.enable_autopilot
   namespace                       = local.kubernetes_namespace
   create_namespace                = true
   enable_grafana_on_ray_dashboard = var.enable_grafana_on_ray_dashboard

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -31,6 +31,11 @@ variable "cluster_location" {
   type = string
 }
 
+variable "kubernetes_version" {
+  type    = string
+  default = "1.28"
+}
+
 variable "kubernetes_namespace" {
   type        = string
   description = "Kubernetes namespace where resources are deployed"

--- a/applications/ray/main.tf
+++ b/applications/ray/main.tf
@@ -156,6 +156,7 @@ module "kuberay-monitoring" {
   source                          = "../../modules/kuberay-monitoring"
   providers                       = { helm = helm.ray, kubernetes = kubernetes.ray }
   project_id                      = var.project_id
+  autopilot_cluster               = var.autopilot_cluster
   namespace                       = local.kubernetes_namespace
   create_namespace                = true
   enable_grafana_on_ray_dashboard = var.enable_grafana_on_ray_dashboard

--- a/modules/iap/iap.tf
+++ b/modules/iap/iap.tf
@@ -55,7 +55,7 @@ resource "helm_release" "iap" {
   chart            = "${path.module}/charts/iap/"
   namespace        = var.namespace
   create_namespace = true
-  # timeout increased to support autopilot scaling resources, and give enough time to complete the deployment
+  # Timeout is increased to guarantee sufficient scale-up time for Autopilot nodes.
   timeout = 1200
   set {
     name  = "iap.backendConfig.name"

--- a/modules/kuberay-cluster/main.tf
+++ b/modules/kuberay-cluster/main.tf
@@ -34,6 +34,9 @@ resource "helm_release" "ray-cluster" {
   namespace        = var.namespace
   create_namespace = true
   version          = "1.0.0"
+  # Timeout is increased to guarantee sufficient scale-up time for Autopilot nodes.
+  timeout = 1200
+  wait    = true
 
   values = [
     templatefile("${path.module}/values.yaml", {

--- a/modules/kuberay-monitoring/main.tf
+++ b/modules/kuberay-monitoring/main.tf
@@ -14,7 +14,8 @@
 
 # Temporary workaround to ensure the GMP webhook is installed before applying PodMonitorings.
 resource "time_sleep" "wait_for_gmp_operator" {
-  create_duration = "10s"
+  count           = var.autopilot_cluster ? 1 : 0
+  create_duration = "30s"
 }
 
 # google managed prometheus engine
@@ -23,7 +24,7 @@ resource "helm_release" "gmp-engine" {
   chart            = "${path.module}/charts/gmp-engine/"
   namespace        = var.namespace
   create_namespace = var.create_namespace
-  # timeout increased to support autopilot scaling resources, and give enough time to complete the deployment 
+  # Timeout is increased to guarantee sufficient scale-up time for Autopilot nodes.
   timeout = 1200
   set {
     name  = "projectID"

--- a/modules/kuberay-monitoring/variables.tf
+++ b/modules/kuberay-monitoring/variables.tf
@@ -17,6 +17,10 @@ variable "project_id" {
   description = "GCP project id"
 }
 
+variable "autopilot_cluster" {
+  type = bool
+}
+
 variable "namespace" {
   type        = string
   description = "Kubernetes namespace where resources are deployed"


### PR DESCRIPTION
We are still seeing flakiness.

Pip installs are experiencing intermittent failures. Downgrading to 1.28 to rule out possibility of k8s or GKE regressions.

For the GMP operator, one explanation is that there are multiple system pods all starting up simultaneously and competing for resources, delaying `gmp-operator` startup. Bumping this to 60s to rule out this issue entirely. This shouldn't affect E2E creation, because the long tail is still CloudSQL instance creation.

Context: https://github.com/GoogleCloudPlatform/ai-on-gke/pull/418

Additionally, increase the Ray worker timeout to 1200s (from 300s). Although, for some reason the `kuberay-cluster` helm chart release is not waiting for all resources to be ready:

```
...
module.kuberay-cluster.helm_release.ray-cluster: Creation complete after 2s
...
error: timed out waiting for the condition on pods/ray-cluster-kuberay-worker-workergroup-8ljp7
...
```

It can't possibly be provisioning a GPU node for the worker in 2 seconds. Adding an explicit `wait` to rule out a defaulting issue.

This is an open issue since 2021: https://github.com/hashicorp/terraform-provider-helm/issues/672