### PR TITLE
Support for Multiple Separate TPU Worker Groups per RayCluster

### DIFF
--- a/applications/ray/kuberay-tpu-webhook/go.mod
+++ b/applications/ray/kuberay-tpu-webhook/go.mod
@@ -4,6 +4,7 @@ go 1.21
 
 require (
 	github.com/ray-project/kuberay/ray-operator v1.1.0-rc.0
+	github.com/stretchr/testify v1.8.4
 	k8s.io/api v0.29.1
 	k8s.io/apimachinery v0.29.1
 	k8s.io/klog/v2 v2.120.1
@@ -37,6 +38,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect

--- a/applications/ray/kuberay-tpu-webhook/go.sum
+++ b/applications/ray/kuberay-tpu-webhook/go.sum
@@ -53,6 +53,8 @@ github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
+github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bwwc=
+github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/applications/ray/kuberay-tpu-webhook/main.go
+++ b/applications/ray/kuberay-tpu-webhook/main.go
@@ -77,7 +77,7 @@ func containerRequestingTPUs(containers ...corev1.Container) bool {
 	return false
 }
 
-func getNumTPUHostsFromTopology(clusterName string, namespace string, topology string, acceleratorType string) (int32, error) {
+func getNumTPUHostsFromTopology(clusterName string, groupName string, namespace string, topology string, acceleratorType string) (int32, error) {
 	if topology == "" {
 		return 0, errors.New("TPU topology not specified")
 	}
@@ -86,7 +86,7 @@ func getNumTPUHostsFromTopology(clusterName string, namespace string, topology s
 	for i := 0; i < len(topologyVals); i++ {
 		dim, err := strconv.Atoi(topologyVals[i])
 		if err != nil {
-			klog.ErrorS(err, "RayCluster", namespace+"/"+clusterName, "gke-tpu-topology", topology)
+			klog.ErrorS(err, "RayCluster", namespace+"/"+clusterName, "Worker Group", groupName, "gke-tpu-topology", topology)
 			return 0, err
 		}
 		chips *= dim
@@ -98,19 +98,19 @@ func getNumTPUHostsFromTopology(clusterName string, namespace string, topology s
 		// v5e TPU VMs can have 1, 4 or 8 chips
 		chipsPerHost, err := strconv.Atoi(acceleratorTypeValues[1])
 		if err != nil {
-			klog.ErrorS(err, "RayCluster", namespace+"/"+clusterName, "gke-tpu-accelerator", acceleratorType)
+			klog.ErrorS(err, "RayCluster", namespace+"/"+clusterName, "Worker Group", groupName, "gke-tpu-accelerator", acceleratorType)
 			return 0, err
 		}
 		chipsPerHost = min(chipsPerHost, 8) // max of 8 chips per host
 	}
 	hosts := int32(max(chips/chipsPerHost, 1))
-	klog.V(1).InfoS("getNumTPUHostsFromTopology", "RayCluster", namespace+"/"+clusterName, "hosts", hosts)
+	klog.V(1).InfoS("getNumTPUHostsFromTopology", "RayCluster", namespace+"/"+clusterName, "Worker Group", groupName, "hosts", hosts)
 	return hosts, nil
 }
 
 // check if request is for TPU multi-host
-func isTPUMultiHost(clusterName string, namespace string, topology string, acceleratorType string) (bool, error) {
-	vms, err := getNumTPUHostsFromTopology(clusterName, namespace, topology, acceleratorType)
+func isTPUMultiHost(clusterName string, groupName string, namespace string, topology string, acceleratorType string) (bool, error) {
+	vms, err := getNumTPUHostsFromTopology(clusterName, groupName, namespace, topology, acceleratorType)
 	if err != nil {
 		return false, err
 	}
@@ -133,7 +133,7 @@ func extractRayCluster(admissionReview *admissionv1.AdmissionReview) (*ray.RayCl
 	return &rayCluster, nil
 }
 
-func genDNSHostnames(workerGroupSpec ray.WorkerGroupSpec, replicaIndex int) (string, error) {
+func genDNSHostnames(workerGroupSpec ray.WorkerGroupSpec, clusterName string, namespace string, replicaIndex int) (string, error) {
 	numHosts := workerGroupSpec.NumOfHosts
 	if numHosts == 0 {
 		return "", errors.New("workerGroupSpec NumOfHosts not set")
@@ -144,6 +144,7 @@ func genDNSHostnames(workerGroupSpec ray.WorkerGroupSpec, replicaIndex int) (str
 	for j := 0; j < int(numHosts); j++ {
 		hostNames[j] = fmt.Sprintf("%s-%d-%d.%s", workerGroupName, replicaIndex, j, headlessServiceName)
 	}
+	klog.V(1).InfoS("genDNSHostnames", "RayCluster", namespace+"/"+clusterName, "NumOfHosts", numHosts, "Replica Index", replicaIndex)
 	return strings.Join(hostNames, ","), nil
 }
 
@@ -218,6 +219,7 @@ func checkWorkersMatchTopology(clusterName string, namespace string, workerGroup
 	if numHosts == 0 {
 		return false, errors.New("workerGroupSpec NumOfHosts not set")
 	}
+	groupName := workerGroupSpec.GroupName
 	containers := workerGroupSpec.Template.Spec.Containers
 	if containers == nil {
 		return false, errors.New("Container path not specified")
@@ -227,12 +229,12 @@ func checkWorkersMatchTopology(clusterName string, namespace string, workerGroup
 		acceleratorType := workerGroupSpec.Template.Spec.NodeSelector["cloud.google.com/gke-tpu-accelerator"]
 		klog.V(1).InfoS("checkWorkersMatchTopology", "RayCluster", namespace+"/"+clusterName, "topology", topology, "AcceleratorType", acceleratorType, "NumOfHosts", numHosts)
 		if topology == "" {
-			klog.ErrorS(errors.New("TPU topology not specified"), "RayCluster", namespace+"/"+clusterName, "gke-tpu-topology", topology)
+			klog.ErrorS(errors.New("TPU topology not specified"), "checkWorkersMatchTopology", "RayCluster", namespace+"/"+clusterName, "gke-tpu-topology", topology)
 		}
 		if acceleratorType == "" {
-			klog.ErrorS(errors.New("TPU accelerator not specified"), "RayCluster", namespace+"/"+clusterName, "gke-tpu-accelerator", acceleratorType)
+			klog.ErrorS(errors.New("TPU accelerator not specified"), "checkWorkersMatchTopology", "RayCluster", namespace+"/"+clusterName, "gke-tpu-accelerator", acceleratorType)
 		}
-		expectedHosts, err := getNumTPUHostsFromTopology(clusterName, namespace, topology, acceleratorType)
+		expectedHosts, err := getNumTPUHostsFromTopology(clusterName, groupName, namespace, topology, acceleratorType)
 		if err != nil {
 			return false, err
 		}
@@ -263,22 +265,24 @@ func validateRayCluster(admissionReview *admissionv1.AdmissionReview) (*admissio
 	}
 	for i := 0; i < len(workerGroupSpecs); i++ {
 		workerGroupSpec := workerGroupSpecs[i]
-		// create mapping for pod slices -> TPU_WORKER_HOSTNAMES in cluster
-		replicas := int(*workerGroupSpec.Replicas)
-		numOfHosts := workerGroupSpec.NumOfHosts
-		for replicaIndex := 0; replicaIndex < replicas; replicaIndex++ {
-			// reset past sliceToWorkers and sliceToHostnames entries for slice in ray cluster
-			groupName := workerGroupSpec.GroupName
-			podSlice := slice{clusterName, groupName, replicaIndex, numOfHosts}
-			sliceToWorkers[podSlice] = nil
-			sliceToHostnames[podSlice] = ""
-			// generate TPU_WORKER_HOSTNAMES
-			if numOfHosts > 1 {
-				joinedHostNames, err := genDNSHostnames(workerGroupSpec, replicaIndex)
-				if err != nil {
-					klog.Error("Failed to generate DNS Hostnames")
+		if containerRequestingTPUs(workerGroupSpec.Template.Spec.Containers...) {
+			// create mapping for pod slices -> TPU_WORKER_HOSTNAMES in cluster
+			replicas := int(*workerGroupSpec.Replicas)
+			numOfHosts := workerGroupSpec.NumOfHosts
+			for replicaIndex := 0; replicaIndex < replicas; replicaIndex++ {
+				// reset past sliceToWorkers and sliceToHostnames entries for slice in ray cluster
+				groupName := workerGroupSpec.GroupName
+				podSlice := slice{clusterName, groupName, replicaIndex, numOfHosts}
+				sliceToWorkers[podSlice] = nil
+				sliceToHostnames[podSlice] = ""
+				// generate TPU_WORKER_HOSTNAMES
+				if numOfHosts > 1 {
+					joinedHostNames, err := genDNSHostnames(workerGroupSpec, clusterName, namespace, replicaIndex)
+					if err != nil {
+						klog.Error("Failed to generate DNS Hostnames")
+					}
+					sliceToHostnames[podSlice] = joinedHostNames
 				}
-				sliceToHostnames[podSlice] = joinedHostNames
 			}
 		}
 		// validate NumOfHosts for worker group matches topology nodeSelector
@@ -291,8 +295,8 @@ func validateRayCluster(admissionReview *admissionv1.AdmissionReview) (*admissio
 			admit = false
 			status = "Failure"
 			message = "Number of workers in worker group not equal to specified topology"
+			break
 		}
-		break
 	}
 
 	// Create AdmissionResponse
@@ -320,13 +324,16 @@ func getEnvironmentVariable(varName string, container corev1.Container) string {
 
 // get next lowest-index pod slice to assign a pod to in the RayCluster
 // this will be the first pod slice with # created pods < NumOfHosts
-func getReplicaIndex(clusterName string, namespace string) int {
+func getReplicaIndex(clusterName string, groupName string, namespace string) int {
+	// first pod created in cluster
 	if sliceToWorkers == nil {
 		return 0
 	}
 	nextLowestId := math.MaxInt32
+	numSlices := 0 // tracks # of slices in worker group created so far
 	for slice, workerList := range sliceToWorkers {
-		if slice.clusterName == clusterName {
+		if slice.clusterName == clusterName && slice.groupName == groupName {
+			numSlices++
 			createdPods := 0
 			for _, worker := range workerList {
 				if worker.isCreated {
@@ -340,10 +347,11 @@ func getReplicaIndex(clusterName string, namespace string) int {
 			}
 		}
 	}
+	// first pod of new slice in cluster
 	if nextLowestId == math.MaxInt32 {
-		klog.ErrorS(errors.New("Replica Index never set"), "RayCluster", namespace+"/"+clusterName, "Replica Index", nextLowestId)
+		nextLowestId = numSlices
 	}
-	klog.V(0).InfoS("getReplicaIndex", "RayCluster", namespace+"/"+clusterName, "Replica Index", nextLowestId)
+	klog.V(0).InfoS("getReplicaIndex", "RayCluster", namespace+"/"+clusterName, "Worker Group", groupName, "Replica Index", nextLowestId)
 	return nextLowestId
 }
 
@@ -379,7 +387,7 @@ func getNextWorkerID(podSlice slice, namespace string, replicaIndex int) int {
 		}
 		tpuWorkerID = nextLowestID
 	}
-	klog.V(0).InfoS("getNextWorkerID", "RayCluster", namespace+"/"+podSlice.clusterName, "TPU_WORKER_ID", tpuWorkerID)
+	klog.V(0).InfoS("getNextWorkerID", "RayCluster", namespace+"/"+podSlice.clusterName, "Worker Group", podSlice.groupName, "TPU_WORKER_ID", tpuWorkerID)
 	return tpuWorkerID
 }
 
@@ -417,31 +425,31 @@ func mutatePod(admissionReview *admissionv1.AdmissionReview) (*admissionv1.Admis
 	if clusterName == "" {
 		return nil, errors.New("Kuberay Pod missing RayCluster label")
 	}
-	namespace := pod.Namespace
-	groupName := pod.Labels["ray.io/group"]
-	topology := pod.Spec.NodeSelector["cloud.google.com/gke-tpu-topology"]
-	acceleratorType := pod.Spec.NodeSelector["cloud.google.com/gke-tpu-accelerator"]
-	if topology == "" {
-		klog.ErrorS(errors.New("TPU topology not specified"), "RayCluster", namespace+"/"+clusterName, "gke-tpu-topology", topology)
-	}
-	if acceleratorType == "" {
-		klog.ErrorS(errors.New("TPU accelerator not specified"), "RayCluster", namespace+"/"+clusterName, "gke-tpu-accelerator", acceleratorType)
-	}
 	containers := pod.Spec.Containers
 	if containers == nil {
 		return nil, errors.New("Container path not specified")
 	}
 	if containerRequestingTPUs(containers...) {
+		namespace := pod.Namespace
+		groupName := pod.Labels["ray.io/group"]
+		topology := pod.Spec.NodeSelector["cloud.google.com/gke-tpu-topology"]
+		acceleratorType := pod.Spec.NodeSelector["cloud.google.com/gke-tpu-accelerator"]
+		if topology == "" {
+			klog.ErrorS(errors.New("TPU topology not specified"), "mutatePod", "RayCluster", namespace+"/"+clusterName, "gke-tpu-topology", topology)
+		}
+		if acceleratorType == "" {
+			klog.ErrorS(errors.New("TPU accelerator not specified"), "mutatePod", "RayCluster", namespace+"/"+clusterName, "gke-tpu-accelerator", acceleratorType)
+		}
 		// assign worker to the next unique ID in the pod slice and update map
-		numOfHosts, _ := getNumTPUHostsFromTopology(clusterName, namespace, topology, acceleratorType) // ignore error here because topology may not be set yet
-		replicaIndex := getReplicaIndex(clusterName, namespace)
+		numOfHosts, _ := getNumTPUHostsFromTopology(clusterName, groupName, namespace, topology, acceleratorType) // ignore error here because topology may not be set yet
+		replicaIndex := getReplicaIndex(clusterName, groupName, namespace)
 		podSlice := slice{clusterName, groupName, replicaIndex, numOfHosts}
 		tpuWorkerID := getNextWorkerID(podSlice, namespace, replicaIndex) // defaults to 0 for single-host
 
 		// inject replica index label
 		injectReplicaLabel(clusterName, namespace, replicaIndex, groupName, &patches)
 
-		isMultiHost, _ := isTPUMultiHost(clusterName, namespace, topology, acceleratorType) // ignore error here because topology may not be set yet
+		isMultiHost, _ := isTPUMultiHost(clusterName, groupName, namespace, topology, acceleratorType) // ignore error here because topology may not be set yet
 		if isMultiHost {
 			// inject hostname into pod spec for DNS records
 			hostname := fmt.Sprintf(groupName+"-%d-%d", replicaIndex, tpuWorkerID)
@@ -545,7 +553,7 @@ func deletePod(admissionReview *admissionv1.AdmissionReview) (*admissionv1.Admis
 	if replicaIndexLabel != "" {
 		replicaIndexLabelValues := strings.Split(replicaIndexLabel, "-")
 		replicaIndex, _ := strconv.Atoi(replicaIndexLabelValues[1]) // ignore error here since must be set
-		
+
 		containers := pod.Spec.Containers
 		if containers == nil {
 			return nil, errors.New("Pod spec missing containers")

--- a/applications/ray/kuberay-tpu-webhook/webhook_main_test.go
+++ b/applications/ray/kuberay-tpu-webhook/webhook_main_test.go
@@ -1,0 +1,554 @@
+package main
+
+import (
+	"testing"
+
+	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	"github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+
+	"github.com/stretchr/testify/assert"
+	// "github.com/GoogleCloudPlatform/kuberay-tpu-webhook"
+)
+
+var (
+	namespaceStr                  string
+	instanceName                  string
+	groupNameStr                  string
+	headGroupNameStr              string
+	testPodAdmissionReviews       *admissionv1.AdmissionReview
+	testCPUPods                   []runtime.Object
+	testTPUPods                   []runtime.Object
+	testRayClusterAdmissionReview *admissionv1.AdmissionReview
+	testRayClusterNoTPUs          *rayv1.RayCluster
+	testRayClusterSingleHostTPU   *rayv1.RayCluster
+	testRayClusterMultiHostTPU    *rayv1.RayCluster
+	testServices                  []runtime.Object
+	workerSelector                labels.Selector
+	headNodeIP                    string
+	// sliceToWorkers				  map[slice][]worker
+	numOfHosts  int32
+	numReplicas int
+)
+
+func setupTest(t *testing.T) {
+	namespaceStr = "default"
+	instanceName = "raycluster-sample"
+	headNodeIP = "1.2.3.4"
+	groupNameStr = "workergroup"
+	headlessServiceSuffix = "headless-worker-svc"
+
+	// 1 CPU head pod + 1 worker - doesn't request TPUs
+	testCPUPods = []runtime.Object{
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "headNode",
+				Namespace: namespaceStr,
+				Labels: map[string]string{
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
+					utils.RayNodeGroupLabelKey: headGroupNameStr,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "ray-head",
+						Image:   "rayproject/autoscaler",
+						Command: []string{"python"},
+						Args:    []string{"/opt/code.py"},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				PodIP: headNodeIP,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "ray-head",
+						State: corev1.ContainerState{},
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod1",
+				Namespace: namespaceStr,
+				Labels: map[string]string{
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeGroupLabelKey: groupNameStr,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "ray-worker",
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "ray-worker",
+						State: corev1.ContainerState{},
+					},
+				},
+			},
+		},
+	}
+
+	// 1 CPU head pod + 4 TPU pods
+	testTPUPods = []runtime.Object{
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "headNode",
+				Namespace: namespaceStr,
+				Labels: map[string]string{
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeTypeLabelKey:  string(rayv1.HeadNode),
+					utils.RayNodeGroupLabelKey: headGroupNameStr,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "ray-head",
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				PodIP: headNodeIP,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "ray-head",
+						State: corev1.ContainerState{},
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod1",
+				Namespace: namespaceStr,
+				Labels: map[string]string{
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeGroupLabelKey: groupNameStr,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "ray-worker",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"cpu":               resource.MustParse("1"),
+								"google.com/tpu":    resource.MustParse("4"),
+								"memory":            resource.MustParse("40G"),
+								"ephemeral-storage": resource.MustParse("20Gi"),
+							},
+							Requests: corev1.ResourceList{
+								"cpu":               resource.MustParse("1"),
+								"google.com/tpu":    resource.MustParse("4"),
+								"memory":            resource.MustParse("40G"),
+								"ephemeral-storage": resource.MustParse("20Gi"),
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "ray-worker",
+						State: corev1.ContainerState{},
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod2",
+				Namespace: namespaceStr,
+				Labels: map[string]string{
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeGroupLabelKey: groupNameStr,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "ray-worker",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"cpu":               resource.MustParse("1"),
+								"google.com/tpu":    resource.MustParse("4"),
+								"memory":            resource.MustParse("40G"),
+								"ephemeral-storage": resource.MustParse("20Gi"),
+							},
+							Requests: corev1.ResourceList{
+								"cpu":               resource.MustParse("1"),
+								"google.com/tpu":    resource.MustParse("4"),
+								"memory":            resource.MustParse("40G"),
+								"ephemeral-storage": resource.MustParse("20Gi"),
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "ray-worker",
+						State: corev1.ContainerState{},
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod3",
+				Namespace: namespaceStr,
+				Labels: map[string]string{
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeGroupLabelKey: groupNameStr,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "ray-worker",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"cpu":               resource.MustParse("1"),
+								"google.com/tpu":    resource.MustParse("4"),
+								"memory":            resource.MustParse("40G"),
+								"ephemeral-storage": resource.MustParse("20Gi"),
+							},
+							Requests: corev1.ResourceList{
+								"cpu":               resource.MustParse("1"),
+								"google.com/tpu":    resource.MustParse("4"),
+								"memory":            resource.MustParse("40G"),
+								"ephemeral-storage": resource.MustParse("20Gi"),
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "ray-worker",
+						State: corev1.ContainerState{},
+					},
+				},
+			},
+		},
+		&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod4",
+				Namespace: namespaceStr,
+				Labels: map[string]string{
+					utils.RayNodeLabelKey:      "yes",
+					utils.RayClusterLabelKey:   instanceName,
+					utils.RayNodeGroupLabelKey: groupNameStr,
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "ray-worker",
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"cpu":               resource.MustParse("1"),
+								"google.com/tpu":    resource.MustParse("4"),
+								"memory":            resource.MustParse("40G"),
+								"ephemeral-storage": resource.MustParse("20Gi"),
+							},
+							Requests: corev1.ResourceList{
+								"cpu":               resource.MustParse("1"),
+								"google.com/tpu":    resource.MustParse("4"),
+								"memory":            resource.MustParse("40G"),
+								"ephemeral-storage": resource.MustParse("20Gi"),
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{
+				Phase: corev1.PodRunning,
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:  "ray-worker",
+						State: corev1.ContainerState{},
+					},
+				},
+			},
+		},
+	}
+
+	// RayCluster requesting no TPU resources - pass-through
+	testRayClusterNoTPUs = &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instanceName,
+			Namespace: namespaceStr,
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "ray-head",
+							},
+						},
+					},
+				},
+			},
+			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+				{
+					Replicas:    pointer.Int32(1),
+					MinReplicas: pointer.Int32(0),
+					MaxReplicas: pointer.Int32(10000),
+					NumOfHosts:  1,
+					GroupName:   groupNameStr,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "ray-worker",
+									Env: []corev1.EnvVar{
+										{
+											Name: "MY_POD_IP",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "status.podIP",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// RayCluster with 2x2x1 TPU topology worker group
+	testRayClusterSingleHostTPU = &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instanceName,
+			Namespace: namespaceStr,
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "ray-head",
+							},
+						},
+					},
+				},
+			},
+			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+				{
+					Replicas:    pointer.Int32(1),
+					MinReplicas: pointer.Int32(0),
+					MaxReplicas: pointer.Int32(10000),
+					NumOfHosts:  1,
+					GroupName:   groupNameStr,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "ray-worker",
+									Env: []corev1.EnvVar{
+										{
+											Name: "MY_POD_IP",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "status.podIP",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// RayCluster with 2x2x4 TPU topology worker group
+	testRayClusterMultiHostTPU = &rayv1.RayCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      instanceName,
+			Namespace: namespaceStr,
+		},
+		Spec: rayv1.RayClusterSpec{
+			HeadGroupSpec: rayv1.HeadGroupSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name: "ray-head",
+							},
+						},
+					},
+				},
+			},
+			WorkerGroupSpecs: []rayv1.WorkerGroupSpec{
+				{
+					Replicas:    pointer.Int32(1),
+					MinReplicas: pointer.Int32(0),
+					MaxReplicas: pointer.Int32(10000),
+					NumOfHosts:  4,
+					GroupName:   groupNameStr,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name: "ray-worker",
+									Env: []corev1.EnvVar{
+										{
+											Name: "MY_POD_IP",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "status.podIP",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func Test_GetReplicaIndex(t *testing.T) {
+	setupTest(t)
+
+	tests := map[string]struct {
+		sliceToWorkers map[slice][]worker
+		numOfHosts     int32
+		numReplicas    int
+	}{
+		"single-host, single-slice worker group": {
+			// single-slice, replicaIndex should always be 0
+			numOfHosts:  1,
+			numReplicas: 1,
+		},
+		"single-host, multi-slice worker group": {
+			// multi-slice, replicaIndex should always be 0-numReplicas
+			numOfHosts:  1,
+			numReplicas: 4,
+		},
+		"multi-host, single-slice worker group": {
+			// single-slice, replicaIndex should always be 0
+			numOfHosts:  4,
+			numReplicas: 1,
+		},
+		"multi-host, multi-slice worker group": {
+			// multi-slice, replicaIndex should always be 0-numReplicas for 0-numOfHosts pods
+			numOfHosts:  4,
+			numReplicas: 4,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sliceToWorkers = make(map[slice][]worker)
+			for i := 0; i < tc.numReplicas; i++ {
+				testPodSlice := slice{instanceName, groupNameStr, namespaceStr, i, tc.numOfHosts}
+				for j := 0; j < int(tc.numOfHosts); j++ {
+					replicaIndex := getReplicaIndex(instanceName, groupNameStr, namespaceStr)
+					assert.Equal(t, i, replicaIndex)
+
+					// add the worker to sliceToWorkers - this would happen in getNextWorkerID
+					testWorker := worker{j, replicaIndex, true}
+					if sliceToWorkers[testPodSlice] == nil {
+						sliceToWorkers[testPodSlice] = []worker{testWorker}
+					} else {
+						sliceToWorkers[testPodSlice] = append(sliceToWorkers[testPodSlice], testWorker)
+					}
+				}
+			}
+			assert.Equal(t, tc.numReplicas, len(sliceToWorkers))
+		})
+	}
+}
+
+func Test_GetNextWorkerID(t *testing.T) {
+	setupTest(t)
+
+	tests := map[string]struct {
+		numOfHosts  int32
+		numReplicas int
+	}{
+		"single-host, single-slice worker group": {
+			// single-slice, replicaIndex should always be 0
+			numOfHosts:  1,
+			numReplicas: 1,
+		},
+		"single-host, multi-slice worker group": {
+			// multi-slice, replicaIndex should always be 0-numReplicas
+			numOfHosts:  1,
+			numReplicas: 4,
+		},
+		"multi-host, single-slice worker group": {
+			// single-slice, replicaIndex should always be 0
+			numOfHosts:  4,
+			numReplicas: 1,
+		},
+		"multi-host, multi-slice worker group": {
+			// multi-slice, replicaIndex should always be 0-numReplicas for 0-numOfHosts pods
+			numOfHosts:  4,
+			numReplicas: 4,
+		},
+		"multi-host, worker pod has been deleted": {
+			// worker should be re-assigned deleted pod TPU_WORKER_ID
+			numOfHosts:  4,
+			numReplicas: 1,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			sliceToWorkers = make(map[slice][]worker)
+			for i := 0; i < tc.numReplicas; i++ {
+				testPodSlice := slice{instanceName, groupNameStr, namespaceStr, i, tc.numOfHosts}
+				for j := 0; j < int(tc.numOfHosts); j++ {
+					workerID := getNextWorkerID(testPodSlice, namespaceStr, i)
+					assert.Equal(t, j, workerID)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for multiple worker groups that request TPUs (both single-host and multi-host) in the same Ray Cluster. This PR was tested by manually creating a RayCluster with single-host, multi-host, single-slice, and multi-slice worker groups and verifying that all were injected with the correct `TPU_NAME`, `TPU_WORKER_ID`, `replicaIndex`, and `TPU_WORKER_HOSTNAMES`.

This PR also adds unit tests for `getReplicaIndex` and `getNextWorkerID`, these tests can be run using `go test` from the applications/ray/kuberay-tpu-webhook folder.