### PR TITLE
concat private network intead of retrieving the data

### DIFF
--- a/modules/cloudsql/main.tf
+++ b/modules/cloudsql/main.tf
@@ -26,11 +26,6 @@ resource "random_password" "pwd" {
   special = false
 }
 
-data "google_compute_network" "main" {
-  name    = var.network_name
-  project = var.project_id
-}
-
 module "cloudsql" {
   source              = "terraform-google-modules/sql-db/google//modules/postgresql"
   project_id          = var.project_id
@@ -47,7 +42,7 @@ module "cloudsql" {
   ip_configuration = {
     # Disable public IP
     ipv4_enabled                                  = false
-    private_network                               = data.google_compute_network.main.id
+    private_network                               = "projects/${var.project_id}/global/networks/${var.network_name}"
     enable_private_path_for_google_cloud_services = true
   }
 


### PR DESCRIPTION
based on https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network#attributes-reference 
compute_network.id will always be projects/{{project}}/global/networks/{{name}}
if we use data "google_compute_network" to retrieve the resource, it will trigger cloudsql re-creation while the network is not changed.

test:
before: run terraform re-apply immediate after first time apply
- result https://paste.googleplex.com/5737676939984896#l=542
> Plan: 1 to add, 4 to change, 1 to destroy.

after: run terraform re-apply immediate after first time apply
- result https://paste.googleplex.com/6438789280432128
> Plan: 0 to add, 4 to change, 0 to destroy

