### PR TITLE
[WIP] Delay GMP installation until the end

### DIFF
--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -19,8 +19,6 @@ provider "google-beta" {
   project = var.project_id
 }
 
-provider "time" {}
-
 data "google_client_config" "default" {}
 
 data "google_project" "project" {
@@ -255,8 +253,10 @@ module "kuberay-monitoring" {
   create_namespace                = true
   enable_grafana_on_ray_dashboard = var.enable_grafana_on_ray_dashboard
   k8s_service_account             = local.ray_service_account
-  # TODO(umeshkumhar): remove kuberay-operator depends, figure out service account dependency
-  depends_on = [module.namespace, module.kuberay-operator]
+  # Add a dependency to module.frontend such that GMP resource is installed at the very end of the installation.
+  # Installing GMP earlier could result in issues in clusters with NAP enabled.
+  # TODO(andrewsy): remove dependency to module.frontend after resolving GMP race conditions.
+  depends_on = [module.namespace, module.frontend]
 }
 
 module "inference-server" {

--- a/applications/ray/versions.tf
+++ b/applications/ray/versions.tf
@@ -28,9 +28,5 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "2.18.1"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = "0.11.1"
-    }
   }
 }

--- a/modules/kuberay-monitoring/main.tf
+++ b/modules/kuberay-monitoring/main.tf
@@ -12,12 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Temporary workaround to ensure the GMP webhook is installed before applying PodMonitorings.
-resource "time_sleep" "wait_for_gmp_operator" {
-  count           = var.autopilot_cluster ? 1 : 0
-  create_duration = "30s"
-}
-
 # google managed prometheus engine
 resource "helm_release" "gmp-engine" {
   name             = "gmp-engine"
@@ -35,8 +29,6 @@ resource "helm_release" "gmp-engine" {
     name  = "serviceAccount"
     value = var.k8s_service_account
   }
-
-  depends_on = [time_sleep.wait_for_gmp_operator]
 }
 
 # grafana

--- a/modules/kuberay-monitoring/versions.tf
+++ b/modules/kuberay-monitoring/versions.tf
@@ -22,9 +22,5 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "2.18.1"
     }
-    time = {
-      source  = "hashicorp/time"
-      version = "0.11.1"
-    }
   }
 }


### PR DESCRIPTION
We've been seeing issues issues with GMP installations on Autopilot. See https://github.com/GoogleCloudPlatform/ai-on-gke/pull/418 for more details.

This PR delays the installation of GMP until after the RAG frontend is fully provisioned. This makes it more likely for nodes to be available to run GMP operator. 

I do not know if this fix actually works, but seeing if CI passes with this change