### PR TITLE
Use default Kubernetes version in REGULAR channel

### DIFF
--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -64,21 +64,20 @@ module "infra" {
   source = "../../infrastructure"
   count  = var.create_cluster ? 1 : 0
 
-  project_id         = var.project_id
-  cluster_name       = var.cluster_name
-  cluster_location   = var.cluster_location
-  region             = local.cluster_location_region
-  autopilot_cluster  = var.autopilot_cluster
-  private_cluster    = var.private_cluster
-  create_network     = var.create_network
-  network_name       = local.network_name
-  subnetwork_name    = local.network_name
-  subnetwork_cidr    = var.subnetwork_cidr
-  subnetwork_region  = local.cluster_location_region
-  cpu_pools          = var.cpu_pools
-  enable_gpu         = true
-  gpu_pools          = var.gpu_pools
-  kubernetes_version = var.kubernetes_version
+  project_id        = var.project_id
+  cluster_name      = var.cluster_name
+  cluster_location  = var.cluster_location
+  region            = local.cluster_location_region
+  autopilot_cluster = var.autopilot_cluster
+  private_cluster   = var.private_cluster
+  create_network    = var.create_network
+  network_name      = local.network_name
+  subnetwork_name   = local.network_name
+  subnetwork_cidr   = var.subnetwork_cidr
+  subnetwork_region = local.cluster_location_region
+  cpu_pools         = var.cpu_pools
+  enable_gpu        = true
+  gpu_pools         = var.gpu_pools
 }
 
 data "google_container_cluster" "default" {

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -31,11 +31,6 @@ variable "cluster_location" {
   type = string
 }
 
-variable "kubernetes_version" {
-  type    = string
-  default = "1.28"
-}
-
 variable "kubernetes_namespace" {
   type        = string
   description = "Kubernetes namespace where resources are deployed"


### PR DESCRIPTION
In https://github.com/GoogleCloudPlatform/ai-on-gke/pull/466 the Kubernetes version was pinned to v1.28. This PR removes the version override and uses whatever is the default in REGULAR channel