### PR TITLE
Increase ray head node memory and CPU

### DIFF
--- a/modules/kuberay-cluster/values.yaml
+++ b/modules/kuberay-cluster/values.yaml
@@ -90,16 +90,16 @@ head:
   # for further guidance.
   resources:
     limits:
-      cpu: "4"
+      cpu: "8"
       # To avoid out-of-memory issues, never allocate less than 2G memory for the Ray head.
       # Ray recommends at least 8G memory for production workloads.
-      memory: "8G"
+      memory: "20G"
       # Sum of ephemeral storage requests must be max 10Gi on Autopilot default class.
       # This includes, ray-head, gcsfuse-sidecar, and fluent-bit.
       ephemeral-storage: 4Gi
     requests:
-      cpu: "4"
-      memory: "8G"
+      cpu: "8"
+      memory: "20G"
       ephemeral-storage: 4Gi
   annotations:
     gke-gcsfuse/volumes: "true"


### PR DESCRIPTION
- The ray job in the notebook takes 10-20 minutes to run right now because the ray head is doing a lot. Increasing the CPU/mem should help.
- Job runs in ~5 mins now: 
![image](https://github.com/GoogleCloudPlatform/ai-on-gke/assets/132504814/1fd8b74c-965b-44b4-8b15-ba69190082e1)
