### PR TITLE
fix timeout request issue in locust benchmark

### DIFF
--- a/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/tasks.py
+++ b/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/tasks.py
@@ -129,10 +129,11 @@ def get_token_count(prompt, resp):
 
 class BenchmarkUser(FastHttpUser):
     weight = 1
-    # Connection_timeout default is 60s. For inferencing workloads with a large payload
-    # this timeout can be too short. Increasing timeout to large amount.
+    # Connection_timeout and network_timeout default is 60s. For inferencing workloads with
+    # a large payload this timeout can be too short. Increasing timeouts to large amount.
     # TODO: turn timeout into a variable.
     connection_timeout = 10800
+    network_timeout = 10800
 
     @task
     def lm_generate(self):


### PR DESCRIPTION
I noticed 99th% request time was 60s in locust metrics.

Discovered there's an additional timeout variable we have to set, the network_connection timeout.

Related docs show this timeout is also default 60s
https://docs.locust.io/en/stable/increase-performance.html#fasthttpuser-class

Upped this to be the same as connection_timeout. Validated that locust max percentile goes beyond 60s.