### PR TITLE
remove csv file write

### DIFF
--- a/benchmarks/benchmark/tools/locust-load-inference/README.md
+++ b/benchmarks/benchmark/tools/locust-load-inference/README.md
@@ -10,14 +10,14 @@
     - [Step 4: create and give service account access to write to output gcs bucket](#step-4-create-and-give-service-account-access-to-write-to-output-gcs-bucket)
     - [Step 5: create artifact repository for automated Locust docker build](#step-5-create-artifact-repository-for-automated-locust-docker-build)
     - [Step 6: create and configure terraform.tfvars](#step-6-create-and-configure-terraformtfvars)
-      - [optional: set-up credentials config with kubeconfig](#optional-set-up-credentials-config-with-kubeconfig)
-      - [optional: set up secret token in secret manager](#optional-set-up-secret-token-in-secret-manager)
+      - [\[optional\] set-up credentials config with kubeconfig](#optional-set-up-credentials-config-with-kubeconfig)
+      - [\[optional\] set up secret token in Secret Manager](#optional-set-up-secret-token-in-secret-manager)
     - [Step 7: login to gcloud](#step-7-login-to-gcloud)
     - [Step 8: terraform initialize, plan and apply](#step-8-terraform-initialize-plan-and-apply)
     - [Step 9: start an end to end benchmark](#step-9-start-an-end-to-end-benchmark)
       - [option 1: initiate a single end to end Locust benchmark run via curl command](#option-1-initiate-a-single-end-to-end-locust-benchmark-run-via-curl-command)
       - [option 2: interactive benchmark with locust web ui](#option-2-interactive-benchmark-with-locust-web-ui)
-      - [writing custom metrics](#writing-custom-metrics)
+    - [Step 10: viewing metrics](#step-10-viewing-metrics)
     - [Additional Tips](#additional-tips)
   - [Variables](#variables)
 <!-- END TOC -->
@@ -222,17 +222,15 @@ In a web browser, visit the following website:
 ```
 http://$LOCUST_SERVICE_IP:8089
 ```
-#### writing custom metrics
 
-If the variable `enable_custom_metrics` is set to `true` then  custom metrics collected by the locust master is available at the following endpoints:
-* While the test is running
-```
-http://$LOCUST_SERVICE_IP:8089/custom_metrics/custom_metrics.csv
-```
-* After a test ends:
-```
-http://$LOCUST_SERVICE_IP:8089/custom_metrics/custom_metrics_final.csv
-```
+### Step 10: viewing metrics
+
+Locust and custom inferencing metrics calculated by locust are exported to cloud monitoring. Metrics are stored in the prometheus namespace, eg:
+
+resource.type="prometheus_target"
+metric.type="prometheus.googleapis.com/locust_*"
+
+You can use the cloud monitoring dashboard to view charts of these metrics.
 
 ### Additional Tips
 
@@ -262,6 +260,5 @@ To change the benchmark configuration, you will have to rerun terraform destroy 
 | <a name="input_sax_model"></a> [sax\_model](#input\_sax\_model)                                                      | Benchmark server configuration for sax model. Only required if framework is sax.                                            | `string`                                                                                                                                                                                                    | `""`                 |    no    |
 | <a name="input_tokenizer"></a> [tokenizer](#input\_tokenizer)                                                        | Benchmark server configuration for tokenizer.                                                                               | `string`                                                                                                                                                                                                    | `"tiiuae/falcon-7b"` |   yes    |
 | <a name="input_use_beam_search"></a> [use\_beam\_search](#input\_use\_beam\_search)                                  | Benchmark server configuration for use beam search.                                                                         | `bool`                                                                                                                                                                                                      | `false`              |    no    |
- <a name="enable_custom_metrics"></a> [enable\_custom\_metric](#input\_enable\_custom\_metrics)                                  | To collect custom metrics like number of tokens sent and received                                                                          | `bool`                                                                                                                                                                                                      | `false`              |    no    |
   <a name="huggingface_secret"></a> [huggingface_secret](#input\_huggingface_secret)                                  | Name of the kubectl huggingface secret token                                                                          | `string`                                                                                                                                                                                                      | `huggingface-secret`              |    no   |
 <!-- END_TF_DOCS -->

--- a/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/custom_metric_aggregator.py
+++ b/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/custom_metric_aggregator.py
@@ -56,17 +56,3 @@ class TokenMetricCollector:
         }
         return json.dumps(stats)
 
-    def write_to_csv(self, file_path='custom_metrics.csv'):
-        import csv
-        avg_sent, avg_received, avg_test_time, avg_output_token_latency = self.calculate_average_tokens()
-        with open(file_path, mode='w', newline='') as file:
-            writer = csv.writer(file)
-            writer.writerow(['Metric', 'Average Value'])
-            writer.writerow(['# of Successful Req', self.success_count])
-            writer.writerow(['# of Failed Req', self.failure_count])
-            writer.writerow(['Avg Tokens Sent Per Req', avg_sent])
-            writer.writerow(['Avg Tokens Received Per Req', avg_received])
-            writer.writerow(['Avg Test Time', avg_test_time])
-            writer.writerow(['Avg Output Tokens Latency',
-                            avg_output_token_latency])
-            writer.writerow(['Timestamp', datetime.datetime.now()])

--- a/benchmarks/benchmark/tools/locust-load-inference/main.tf
+++ b/benchmarks/benchmark/tools/locust-load-inference/main.tf
@@ -41,9 +41,7 @@ locals {
       sax_model                  = var.sax_model
       tokenizer                  = var.tokenizer
       use_beam_search            = var.use_beam_search
-      enable_custom_metrics      = var.enable_custom_metrics
       huggingface_secret         = var.huggingface_secret
-      csv_upload_frequency       = var.csv_upload_frequency
     })) : data]
   ])
 }

--- a/benchmarks/benchmark/tools/locust-load-inference/manifest-templates/locust-master-controller.yaml.tpl
+++ b/benchmarks/benchmark/tools/locust-load-inference/manifest-templates/locust-master-controller.yaml.tpl
@@ -26,8 +26,6 @@ spec:
               value: http://${inference_server_service}
             - name: BACKEND
               value: ${inference_server_framework}
-            - name: ENABLE_CUSTOM_METRICS
-              value: ${enable_custom_metrics}
           ports:
             - name: loc-master-web
               containerPort: 8089

--- a/benchmarks/benchmark/tools/locust-load-inference/manifest-templates/locust-worker-controller.yaml.tpl
+++ b/benchmarks/benchmark/tools/locust-load-inference/manifest-templates/locust-worker-controller.yaml.tpl
@@ -44,10 +44,6 @@ spec:
               value: ${tokenizer}
             - name: USE_BEAM_SEARCH
               value: ${use_beam_search}
-            - name: ENABLE_CUSTOM_METRICS
-              value: ${enable_custom_metrics}
-            - name: CSV_UPLOAD_FREQUENCY
-              value: ${csv_upload_frequency}
             - name: HUGGINGFACE_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/benchmarks/benchmark/tools/locust-load-inference/variables.tf
+++ b/benchmarks/benchmark/tools/locust-load-inference/variables.tf
@@ -191,22 +191,9 @@ variable "run_test_automatically" {
   default     = false
 }
 
-variable "enable_custom_metrics" {
-  description = "enable custom metric output in Locust"
-  type        = bool
-  default     = false
-}
-
 variable "huggingface_secret" {
   description = "name of the kubectl huggingface secret token"
   type        = string
   nullable    = true
   default     = "huggingface-secret"
-}
-
-variable "csv_upload_frequency" {
-  description = "how frequently, in seconds, to upload csv if custom metrics is turned on"
-  type        = number
-  nullable    = true
-  default     = 10
 }


### PR DESCRIPTION
custom_messages has bug that causes locust worker restarts. https://github.com/locustio/locust/issues/2608

We rely on custom messages for our custom metrics csv file periodic writes.

Since we've added in exporting the custom metrics to prometheus, I don't think we need the csv file write. The locust runner includes these metrics in its final report. And metrics are viewable via custom dashboards in cloud monitoring.

Rather than trying to make the heartbeat work, I think we should remove the csv file support and migrate to improving the total report that includes locust and GPU metrics as well.

This change also enables custom metrics for all workloads.