### PR TITLE
default all clusters to use v1.28

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -95,7 +95,7 @@ variable "cluster_labels" {
 
 variable "kubernetes_version" {
   type    = string
-  default = "latest"
+  default = "1.28"
 }
 
 variable "release_channel" {


### PR DESCRIPTION
Because Autopilot doesn't support L4 GPUs in 1.27