### PR TITLE
Fix spelling of default_nodepool

### DIFF
--- a/benchmarks/infra/stage-1/modules/gke-infra/cluster.tf
+++ b/benchmarks/infra/stage-1/modules/gke-infra/cluster.tf
@@ -84,7 +84,7 @@ module "cluster-standard" {
     master_authorized_ranges = var.cluster_create.master_authorized_ranges
     master_ipv4_cidr_block   = var.cluster_create.master_ipv4_cidr_block
   }
-  default_node_pool = {
+  default_nodepool = {
     remove_pool        = false
     initial_node_count = 1
   }


### PR DESCRIPTION
Was broken by https://github.com/GoogleCloudPlatform/cloud-foundation-fabric/commit/f487b27aa9f424c005d1d2177eea1487770cc235