### PR TITLE
Remove GCSFuse storage profile for JupyterHub notebook servers

### DIFF
--- a/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
@@ -134,19 +134,6 @@ singleuser:
               display_name: "Local (SSD)"
               kubespawner_override:
                 default: true
-            GCSFuse:
-              display_name: "GCSFuse"
-              kubespawner_override:
-                volume_mounts:
-                - name: gcs-fuse-csi-ephemeral
-                  mountPath: /home/jovyan
-                volumes:
-                - name: gcs-fuse-csi-ephemeral
-                  csi:
-                    driver: gcsfuse.csi.storage.gke.io
-                    volumeAttributes:
-                      bucketName: ${gcs_bucket}
-                      mountOptions: "uid=1000,gid=100,o=noexec,implicit-dirs,dir-mode=777,file-mode=777,only-dir=notebooks/{username}"
       kubespawner_override:
         node_selector:
           cloud.google.com/compute-class: "Performance"
@@ -163,19 +150,6 @@ singleuser:
               display_name: "Local (SSD)"
               kubespawner_override:
                 default: true
-            GCSFuse:
-              display_name: "GCSFuse"
-              kubespawner_override:
-                volume_mounts:
-                - name: gcs-fuse-csi-ephemeral
-                  mountPath: /home/jovyan
-                volumes:
-                - name: gcs-fuse-csi-ephemeral
-                  csi:
-                    driver: gcsfuse.csi.storage.gke.io
-                    volumeAttributes:
-                      bucketName: ${gcs_bucket}
-                      mountOptions: "uid=1000,gid=100,o=noexec,implicit-dirs,dir-mode=777,file-mode=777,only-dir=notebooks/{username}"
       kubespawner_override:
         image: ${notebook_image}:${notebook_image_tag}
         extra_resource_limits:

--- a/modules/jupyter/jupyter_config/config-selfauth.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth.yaml
@@ -149,19 +149,6 @@ singleuser:
               display_name: "DefaultStorage"
               kubespawner_override:
                 default: true
-            GCSFuse:
-              display_name: "GCSFuse"
-              kubespawner_override:
-                volume_mounts:
-                - name: gcs-fuse-csi-ephemeral
-                  mountPath: /home/jovyan
-                volumes:
-                - name: gcs-fuse-csi-ephemeral
-                  csi:
-                    driver: gcsfuse.csi.storage.gke.io
-                    volumeAttributes:
-                      bucketName: ${gcs_bucket}
-                      mountOptions: "uid=1000,gid=100,o=noexec,implicit-dirs,dir-mode=777,file-mode=777,only-dir=notebooks/{username}"
       default: true
   cmd: null
   cloudMetadata:


### PR DESCRIPTION
This storage profile has a bunch of issues at the moment and not widely used. Removing for now to avoid confusion