### PR TITLE
Update main.tf

### DIFF
--- a/modules/kuberay-monitoring/main.tf
+++ b/modules/kuberay-monitoring/main.tf
@@ -14,8 +14,6 @@
 
 # Temporary workaround to ensure the GMP webhook is installed before applying PodMonitorings.
 resource "time_sleep" "wait_for_gmp_operator" {
-  ## Temporary workaroud, This is impacting for the standard cluster dependency graph
-  #count           = var.autopilot_cluster ? 1 : 0
   create_duration = "30s"
 }
 


### PR DESCRIPTION
The `count` parameters is calculated when generating helm resource dependency. Therefore, it cannot depend on values that are unknown at apply time (e.g. on a data source field for a cluster which is not yet created).