### PR TITLE
Update domain to support wildcard DNS

### DIFF
--- a/applications/jupyter/variables.tf
+++ b/applications/jupyter/variables.tf
@@ -108,8 +108,8 @@ variable "create_brand" {
 
 variable "domain" {
   type        = string
-  description = "Provide domain for ingress resource and ssl certificate. If it's empty, it will use nip.io wildcard dns"
-  default     = ""
+  description = "Provide domain for ingress resource and ssl certificate."
+  default     = "jupyter.example.com"
 }
 
 variable "support_email" {

--- a/applications/jupyter/workloads-auto-create-brand.example.tfvars
+++ b/applications/jupyter/workloads-auto-create-brand.example.tfvars
@@ -42,8 +42,7 @@ k8s_backend_config_name  = "jupyter-iap-config"
 k8s_backend_service_name = "proxy-public"
 k8s_backend_service_port = 80
 
-url_domain_addr   = ""
-url_domain_name   = ""
+domain            = "jupyter.example.com"
 client_id         = ""
 client_secret     = ""
 members_allowlist = "user:<email>,group:<email>,serviceAccount:<email>,domain:google.com"

--- a/applications/jupyter/workloads-existing-brand-auto-create-client.example.tfvars
+++ b/applications/jupyter/workloads-existing-brand-auto-create-client.example.tfvars
@@ -41,8 +41,7 @@ k8s_backend_config_name  = "jupyter-iap-config"
 k8s_backend_service_name = "proxy-public"
 k8s_backend_service_port = 80
 
-url_domain_addr   = ""
-url_domain_name   = ""
+domain            = "jupyter.example.com"
 client_id         = ""
 client_secret     = ""
 members_allowlist = "user:<email>,group:<email>,serviceAccount:<email>,domain:google.com"

--- a/applications/jupyter/workloads-existing-brand-existing-client.example.tfvars
+++ b/applications/jupyter/workloads-existing-brand-existing-client.example.tfvars
@@ -42,8 +42,7 @@ k8s_backend_config_name  = "jupyter-iap-config"
 k8s_backend_service_name = "proxy-public"
 k8s_backend_service_port = 80
 
-url_domain_addr   = ""
-url_domain_name   = ""
+domain            = "jupyter.example.com"
 client_id         = "<client_id>"
 client_secret     = "<client_secret>"
 members_allowlist = "user:<email>,group:<email>,serviceAccount:<email>,domain:google.com"

--- a/applications/jupyter/workloads.tfvars
+++ b/applications/jupyter/workloads.tfvars
@@ -45,8 +45,8 @@ k8s_backend_config_name  = "jupyter-iap-config"
 k8s_backend_service_name = "proxy-public"
 k8s_backend_service_port = 80
 
-domain            = "" ## Provide domain for ingress resource and ssl certificate. If it's empty, it will use nip.io wildcard dns
-client_id         = "" ## Ensure brand is Internal, to autogenerate client credentials
+domain            = "jupyter.example.com" ## Provide domain for ingress resource and ssl certificate. 
+client_id         = ""                    ## Ensure brand is Internal, to autogenerate client credentials
 client_secret     = ""
 members_allowlist = "user:<email>,group:<email>,serviceAccount:<email>,domain:google.com"
 

--- a/applications/rag/README.md
+++ b/applications/rag/README.md
@@ -99,7 +99,7 @@ gcloud container clusters get-credentials ${CLUSTER_NAME} --location=${CLUSTER_L
             * password: use `terraform output jupyterhub_password` to fetch the password value
    * If IAP is enabled (`jupyter_add_auth = true`):
         - Fetch the domain: `terraform output jupyterhub_uri`
-        - If you used a custom domain, ensure you configured your DNS as described above. This can be skipped if using `nip.io`.
+        - If you used a custom domain, ensure you configured your DNS as described above. 
         - Verify the domain status is `Active`:
             - `kubectl get managedcertificates jupyter-managed-cert -n ${NAMESPACE} --output jsonpath='{.status.domainStatus[0].status}'`
             - Note: This can take up to 20 minutes to propagate.
@@ -126,7 +126,7 @@ gcloud container clusters get-credentials ${CLUSTER_NAME} --location=${CLUSTER_L
             - Go to `localhost:8265` in a browser
         - If IAP is enabled (`ray_dashboard_add_auth = true`):
             - Fetch the domain: `terraform output ray-dashboard-managed-cert`
-            - If you used a custom domain, ensure you configured your DNS as described above. This can be skipped if using `nip.io`.
+            - If you used a custom domain, ensure you configured your DNS as described above.
             - Verify the domain status is `Active`:
                 - `kubectl get managedcertificates ray-dashboard-managed-cert -n rag --output jsonpath='{.status.domainStatus[0].status}'`
                 - Note: This can take up to 20 minutes to propagate.
@@ -141,7 +141,7 @@ gcloud container clusters get-credentials ${CLUSTER_NAME} --location=${CLUSTER_L
         - Go to `localhost:8080` in a browser
     * If IAP is enabled (`frontend_add_auth = true`):
         - Fetch the domain: `terraform output frontend_uri`
-        - If you used a custom domain, ensure you configured your DNS as described above. This can be skipped if using `nip.io`.
+        - If you used a custom domain, ensure you configured your DNS as described above.
         - Verify the domain status is `Active`:
             - `kubectl get managedcertificates frontend-managed-cert -n rag --output jsonpath='{.status.domainStatus[0].status}'`
             - Note: This can take up to 20 minutes to propagate.
@@ -160,9 +160,9 @@ We recommend you configure authenticated access via IAP for your services.
     * `frontend_add_auth = true`
     * `ray_dashboard_add_auth = true`
 3) Allowlist principals for your services via `jupyter_members_allowlist`, `frontend_members_allowlist` and `ray_dashboard_members_allowlist`.
-4) Configure custom domains names via `jupyter_domain`, `frontend_domain` and `ray_dashboard_domain` for your services. If left blank, we'll provision test `nip.io` domains for you.
+4) Configure custom domains names via `jupyter_domain`, `frontend_domain` and `ray_dashboard_domain` for your services. 
 5) Configure DNS records for your custom domains:
-    - [Register a Domain on Google Cloud Domains](https://cloud.google.com/domains/docs/register-domain#registering-a-domain) or use a domain registrar of your choice. You can skip this if using `nip.io`.
+    - [Register a Domain on Google Cloud Domains](https://cloud.google.com/domains/docs/register-domain#registering-a-domain) or use a domain registrar of your choice.
     - Set up your DNS service to point to the public IP
         * Run `terraform output frontend_ip_address` to get the public ip address of frontend, and add an A record in your DNS configuration to point to the public IP address.
         * Run `terraform output jupyterhub_ip_address` to get the public ip address of jupyterhub, and add an A record in your DNS configuration to point to the public IP address.
@@ -178,7 +178,7 @@ We recommend you configure authenticated access via IAP for your services.
 
 # Troubleshooting
 
-Set your the namespace, cluster name and location from `workloads.tfvars`):
+Set your the namespace, cluster name and location from `workloads.tfvars`:
 
 ```
 export NAMESPACE=rag

--- a/applications/rag/frontend/variables.tf
+++ b/applications/rag/frontend/variables.tf
@@ -129,8 +129,8 @@ variable "support_email" {
 
 variable "domain" {
   type        = string
-  description = "Provide domain for ingress resource and ssl certificate. If it's empty, it will use nip.io wildcard dns"
-  default     = ""
+  description = "Provide domain for ingress resource and ssl certificate."
+  default     = "frontend.example.com"
 }
 
 variable "client_id" {

--- a/applications/rag/metadata.yaml
+++ b/applications/rag/metadata.yaml
@@ -97,7 +97,7 @@ spec:
       - name: frontend_domain
         description: Domain used for application and SSL certificate. 
         varType: string
-        defaultValue: "rag.example.com"
+        defaultValue: "frontend.example.com"
       - name: frontend_k8s_backend_config_name
         description: Name of the Kubernetes Backend Config
         varType: string

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -152,8 +152,8 @@ variable "frontend_k8s_backend_service_port" {
 
 variable "frontend_domain" {
   type        = string
-  description = "Domain used for SSL certificate. If it's empty, *.nip.io DNS is used."
-  default     = ""
+  description = "Domain used for SSL certificate."
+  default     = "frontend.example.com"
 }
 
 variable "frontend_client_id" {
@@ -211,8 +211,8 @@ variable "ray_dashboard_k8s_backend_service_port" {
 
 variable "ray_dashboard_domain" {
   type        = string
-  description = "Domain used for SSL certificate. If it's empty, *.nip.io DNS is used."
-  default     = ""
+  description = "Domain used for SSL certificate."
+  default     = "ray.example.com"
 }
 
 variable "ray_dashboard_client_id" {
@@ -278,8 +278,8 @@ variable "jupyter_k8s_backend_service_port" {
 
 variable "jupyter_domain" {
   type        = string
-  description = "Domain used for SSL certificate. If it's empty, *.nip.io DNS is used."
-  default     = ""
+  description = "Domain used for SSL certificate."
+  default     = "jupyter.example.com"
 }
 
 variable "support_email" {

--- a/applications/rag/workloads.tfvars
+++ b/applications/rag/workloads.tfvars
@@ -58,15 +58,15 @@ dataset_embeddings_table_name = "netflix_reviews_db"
 
 ## Jupyter IAP Settings
 jupyter_add_auth          = false                                                                 # Set to true to enable authenticated access via IAP.
-jupyter_domain            = ""                                                                    # Custom domain for ingress resource and ssl certificate. If empty, it will use nip.io wildcard DNS.
+jupyter_domain            = "jupyter.example.com"                                                 # Custom domain for ingress resource and ssl certificate. 
 jupyter_members_allowlist = "user:<email>,group:<email>,serviceAccount:<email>,domain:google.com" # Allowlist principals for access.
 
 ## Frontend IAP Settings
 frontend_add_auth          = false                                                                 # Set to true to enable authenticated access via IAP.
-frontend_domain            = ""                                                                    # Custom domain for ingress resource and ssl certificate. If empty, it will use nip.io wildcard DNS.
+frontend_domain            = "frontend.example.com"                                                # Custom domain for ingress resource and ssl certificate.
 frontend_members_allowlist = "user:<email>,group:<email>,serviceAccount:<email>,domain:google.com" # Allowlist principals for access.
 
 ## Ray Dashboard IAP Settings
 ray_dashboard_add_auth          = false                                                                 # Set to true to enable authenticated access via IAP.
-ray_dashboard_domain            = ""                                                                    # Custom domain for ingress resource and ssl certificate. If empty, it will use nip.io wildcard DNS.
+ray_dashboard_domain            = "ray.example.com"                                                     # Custom domain for ingress resource and ssl certificate. 
 ray_dashboard_members_allowlist = "user:<email>,group:<email>,serviceAccount:<email>,domain:google.com" # Allowlist principals for access.

--- a/applications/ray/tfvars_examples/raycluster-with-iap-auth.tfvars
+++ b/applications/ray/tfvars_examples/raycluster-with-iap-auth.tfvars
@@ -53,7 +53,7 @@ ray_dashboard_k8s_iap_secret_name      = "ray-dashboard-iap-secret"
 ray_dashboard_k8s_backend_config_name  = "ray-dashboard-iap-config"
 ray_dashboard_k8s_backend_service_port = 8265
 
-ray_dashboard_domain            = ""
+ray_dashboard_domain            = "ray.example.com"
 ray_dashboard_client_id         = ""
 ray_dashboard_client_secret     = ""
 ray_dashboard_members_allowlist = "user:<email>"

--- a/applications/ray/variables.tf
+++ b/applications/ray/variables.tf
@@ -229,8 +229,8 @@ variable "ray_dashboard_k8s_backend_service_port" {
 
 variable "ray_dashboard_domain" {
   type        = string
-  description = "Domain used for SSL certificate. If it's empty, *.nip.io DNS is used."
-  default     = ""
+  description = "Domain used for SSL certificate."
+  default     = "ray.example.com"
 }
 
 variable "support_email" {

--- a/applications/ray/workloads.tfvars
+++ b/applications/ray/workloads.tfvars
@@ -53,7 +53,7 @@ ray_dashboard_k8s_iap_secret_name      = "ray-dashboard-iap-secret"
 ray_dashboard_k8s_backend_config_name  = "ray-dashboard-iap-config"
 ray_dashboard_k8s_backend_service_port = 8265
 
-ray_dashboard_domain            = ""
+ray_dashboard_domain            = "ray.example.com"
 ray_dashboard_client_id         = ""
 ray_dashboard_client_secret     = ""
 ray_dashboard_members_allowlist = "user:<email>,group:<email>,serviceAccount:<email>,domain:google.com"

--- a/modules/iap/charts/iap/templates/managed-cert.yaml
+++ b/modules/iap/charts/iap/templates/managed-cert.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+## ignore template if domain is empty
+{{- if  .Values.iap.managedCertificate.domain }}
 
 apiVersion: networking.gke.io/v1
 kind: ManagedCertificate
@@ -19,3 +21,5 @@ metadata:
 spec:
   domains: 
   - {{ .Values.iap.managedCertificate.domain }}
+
+{{- end -}}

--- a/modules/iap/iap.tf
+++ b/modules/iap/iap.tf
@@ -83,8 +83,9 @@ resource "helm_release" "iap" {
   }
 
   set {
-    name  = "iap.managedCertificate.domain"
-    value = var.domain != "" ? var.domain : "${google_compute_global_address.ip_address.address}.nip.io"
+    name = "iap.managedCertificate.domain"
+    // add support for wildcard DNS ex; *.example.com
+    value = startswith(var.domain, "*.") ? "${google_compute_global_address.ip_address.address}.${trimprefix(var.domain, "*.")}" : var.domain
   }
 
   set {

--- a/modules/iap/outputs.tf
+++ b/modules/iap/outputs.tf
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 output "domain" {
-  value = var.domain == "" ? "${google_compute_global_address.ip_address.address}.nip.io" : var.domain
+  value = startswith(var.domain, "*.") ? "${google_compute_global_address.ip_address.address}.${trimprefix(var.domain, "*.")}" : var.domain
 }
 
 output "ip_address" {

--- a/modules/iap/variables.tf
+++ b/modules/iap/variables.tf
@@ -65,7 +65,7 @@ variable "k8s_backend_service_port" {
 
 variable "domain" {
   type        = string
-  description = "Provide domain for ingress resource and ssl certificate. If it's empty, it will use nip.io wildcard dns"
+  description = "Provide domain for ingress resource and ssl certificate. "
   default     = ""
 }
 

--- a/modules/jupyter/variables.tf
+++ b/modules/jupyter/variables.tf
@@ -104,8 +104,8 @@ variable "create_brand" {
 
 variable "domain" {
   type        = string
-  description = "Provide domain for ingress resource and ssl certificate. If it's empty, it will use nip.io wildcard dns"
-  default     = ""
+  description = "Provide domain for ingress resource and ssl certificate."
+  default     = "jupyter.example.com"
 }
 
 variable "support_email" {

--- a/modules/kuberay-cluster/variables.tf
+++ b/modules/kuberay-cluster/variables.tf
@@ -212,8 +212,8 @@ variable "k8s_backend_service_port" {
 
 variable "domain" {
   type        = string
-  description = "Provide domain for ingress resource and ssl certificate. If it's empty, it will use nip.io wildcard dns"
-  default     = ""
+  description = "Provide domain for ingress resource and ssl certificate."
+  default     = "ray.example.com"
 }
 
 variable "support_email" {


### PR DESCRIPTION
- Remove all references of nip.io
- add support as wildcardDNS, that means for better development experience, dev can provide domain inputs as ***.nip.io** that will spin up application specific static-ip and setup nip.io based sub-domains.
