### PR TITLE
Use different SA names for Ray, Jupyter and RAG

### DIFF
--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -52,7 +52,7 @@ variable "additional_labels" {
 variable "jupyter_service_account" {
   type        = string
   description = "Google Cloud IAM service account for authenticating with GCP services"
-  default     = "jupyter-sa"
+  default     = "jupyter-rag-sa"
 }
 
 variable "enable_grafana_on_ray_dashboard" {
@@ -70,7 +70,7 @@ variable "create_ray_service_account" {
 variable "ray_service_account" {
   type        = string
   description = "Google Cloud IAM service account for authenticating with GCP services"
-  default     = "ray-sa"
+  default     = "ray-rag-sa"
 }
 
 variable "create_rag_service_account" {

--- a/applications/rag/workloads.tfvars
+++ b/applications/rag/workloads.tfvars
@@ -37,14 +37,14 @@ cloudsql_instance = "pgvector-instance"
 ## Service accounts
 
 # Creates a google service account & k8s service account & configures workload identity with appropriate permissions.
-ray_service_account             = "ray-sa"
+ray_service_account             = "ray-rag-sa"
 enable_grafana_on_ray_dashboard = false
 
 # Creates a google service account & k8s service account & configures workload identity with appropriate permissions.
 rag_service_account = "rag-sa"
 
 # Creates a google service account & k8s service account & configures workload identity with appropriate permissions.
-jupyter_service_account = "jupyter-sa"
+jupyter_service_account = "jupyter-rag-sa"
 
 ## Embeddings table name - change this to the TABLE_NAME used in the notebook.
 dataset_embeddings_table_name = "netflix_reviews_db"


### PR DESCRIPTION
This allows creating Ray and Jupyter applications in the same project, and also doesn't accidentally delete SAs for the wrong deployment during tf destroy.