### PR TITLE
Alter locust to not require a hf token

### DIFF
--- a/benchmarks/benchmark/tools/locust-load-inference/README.md
+++ b/benchmarks/benchmark/tools/locust-load-inference/README.md
@@ -148,13 +148,16 @@ credentials_config = {
 
 A model may require a security token to access it. For example, Llama2 from HuggingFace is a gated model that requires a [user access token](https://huggingface.co/docs/hub/en/security-tokens). If the model you want to run does not require this, skip this step.
 
-If you followed steps from `.../../infra/`, Secret Manager and the user access token should already be set up. Alternatively you can create a Kubernetes Secret to store your Hugging Face CLI token. You can do this from the command line with kubectl:
-```bash
-kubectl create secret generic huggingface-secret --from-literal=token='************'
-```
+If you followed steps from `.../../infra/`, Secret Manager and the user access token should already be set up. If not, it is strongly recommended that you use Workload Identity and Secret Manager to access the user access tokens to avoid adding a plain text token into the terraform state. To do so, follow the instructions for [setting up a secret in Secret Manager here](https://cloud.google.com/kubernetes-engine/docs/tutorials/workload-identity-secrets).
 
-This command creates a new Secret named huggingface-secret, which has a key token containing your Hugging Face CLI token.
-It is important to note that for any production or shared environments, directly storing user access tokens as literals is not advisable.
+Once complete, you should add these related secret values to your `terraform.tfvars`:
+
+```bash
+# ex. "projects/sample-project/secrets/hugging_face_secret"
+hugging_face_secret = $SECRET_ID
+ # ex. 1
+hugging_face_secret_version =  $SECRET_VERSION
+```
 
 ### Step 7: login to gcloud
 

--- a/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/requirements.txt
+++ b/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/requirements.txt
@@ -24,7 +24,7 @@ pyzmq==25.0.0
 requests==2.31.0
 roundrobin==0.0.2
 six==1.16.0
-transformers==4.36.0
+transformers==4.39.3
 typing_extensions==4.1.1
 urllib3==1.26.18
 Werkzeug==2.3.8

--- a/benchmarks/benchmark/tools/locust-load-inference/main.tf
+++ b/benchmarks/benchmark/tools/locust-load-inference/main.tf
@@ -24,24 +24,29 @@ locals {
     ? "${path.module}/manifest-templates"
     : pathexpand(var.templates_path)
   )
+  hugging_face_token_secret = (
+    var.hugging_face_secret == null || var.hugging_face_secret_version == null
+    ? null
+    : "${var.hugging_face_secret}/versions/${var.hugging_face_secret_version}"
+  )
 
   all_locust_manifests = flatten([for manifest_file in local.locust_templates :
     [for data in split("---", templatefile(manifest_file, {
-      artifact_registry          = var.artifact_registry
-      namespace                  = var.namespace
-      inference_server_service   = var.inference_server_service
-      inference_server_framework = var.inference_server_framework
-      best_of                    = var.best_of
-      gcs_path                   = var.gcs_path
-      ksa                        = var.ksa
-      max_num_prompts            = var.max_num_prompts
-      max_output_len             = var.max_output_len
-      max_prompt_len             = var.max_prompt_len
-      num_locust_workers         = var.num_locust_workers
-      sax_model                  = var.sax_model
-      tokenizer                  = var.tokenizer
-      use_beam_search            = var.use_beam_search
-      huggingface_secret         = var.huggingface_secret
+      artifact_registry              = var.artifact_registry
+      namespace                      = var.namespace
+      inference_server_service       = var.inference_server_service
+      inference_server_framework     = var.inference_server_framework
+      best_of                        = var.best_of
+      gcs_path                       = var.gcs_path
+      ksa                            = var.ksa
+      max_num_prompts                = var.max_num_prompts
+      max_output_len                 = var.max_output_len
+      max_prompt_len                 = var.max_prompt_len
+      num_locust_workers             = var.num_locust_workers
+      sax_model                      = var.sax_model
+      tokenizer                      = var.tokenizer
+      use_beam_search                = var.use_beam_search
+      hugging_face_token_secret_list = local.hugging_face_token_secret == null ? [] : [local.hugging_face_token_secret]
     })) : data]
   ])
 }

--- a/benchmarks/benchmark/tools/locust-load-inference/manifest-templates/locust-worker-controller.yaml.tpl
+++ b/benchmarks/benchmark/tools/locust-load-inference/manifest-templates/locust-worker-controller.yaml.tpl
@@ -44,8 +44,10 @@ spec:
               value: ${tokenizer}
             - name: USE_BEAM_SEARCH
               value: ${use_beam_search}
+%{ for hugging_face_token_secret in hugging_face_token_secret_list ~}
             - name: HUGGINGFACE_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: ${huggingface_secret}  # Replace ${huggingface_secret} with your secret's name
-                  key: token
+                  name: hf-token
+                  key: HF_TOKEN
+%{ endfor ~}

--- a/benchmarks/benchmark/tools/locust-load-inference/variables.tf
+++ b/benchmarks/benchmark/tools/locust-load-inference/variables.tf
@@ -191,9 +191,16 @@ variable "run_test_automatically" {
   default     = false
 }
 
-variable "huggingface_secret" {
+variable "hugging_face_secret" {
   description = "name of the kubectl huggingface secret token"
   type        = string
   nullable    = true
-  default     = "huggingface-secret"
+  default     = null
+}
+
+variable "hugging_face_secret_version" {
+  description = "Secret version in Secret Manager"
+  type        = string
+  nullable    = true
+  default     = null
 }


### PR DESCRIPTION
Additionally, changed how it does use one to be identical to tgi, including using secret manager (rather than a k8s secret, which would end up being stored in tf state.)

Also bump version of transformers to support google/gemma-2b