### PR TITLE
Bump GMP delay to 60 seconds

### DIFF
--- a/modules/kuberay-monitoring/main.tf
+++ b/modules/kuberay-monitoring/main.tf
@@ -14,7 +14,7 @@
 
 # Temporary workaround to ensure the GMP webhook is installed before applying PodMonitorings.
 resource "time_sleep" "wait_for_gmp_operator" {
-  create_duration = "30s"
+  create_duration = "60s"
 }
 
 # google managed prometheus engine


### PR DESCRIPTION
The bump to 30 seconds reduced flakiness to nearly zero cases over the last 5 days. Doubling to 60 seconds to ensure we don't hit this during demo season. We already have a long-term fix underway to replace this.