### PR TITLE
fix versions in stage-2. Fix toleration on csi-driver-gcp-plugin.

### DIFF
--- a/benchmarks/infra/stage-2/modules/gke-setup/modules/gcs-fuse/main.tf
+++ b/benchmarks/infra/stage-2/modules/gke-setup/modules/gcs-fuse/main.tf
@@ -33,7 +33,7 @@ data "google_storage_bucket" "bucket" {
 }
 
 module "gcs-fuse-bucket" {
-  source     = "git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/gcs"
+  source     = "git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/gcs?ref=v30.0.0&depth=1"
   count      = var.bucket_create ? 1 : 0
   project_id = var.project_id
   name       = var.bucket_name

--- a/benchmarks/infra/stage-2/modules/gke-setup/modules/output-benchmark/main.tf
+++ b/benchmarks/infra/stage-2/modules/gke-setup/modules/output-benchmark/main.tf
@@ -15,7 +15,7 @@
  */
 
 module "gcs-result-bucket" {
-  source     = "git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/gcs"
+  source     = "git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/gcs?ref=v30.0.0&depth=1"
   project_id = var.project_id
   name       = var.output_bucket_name
   location   = var.output_bucket_location

--- a/benchmarks/infra/stage-2/modules/gke-setup/modules/secret-manager/csi-driver-gcp-plugin/provider-gcp-plugin.yaml
+++ b/benchmarks/infra/stage-2/modules/gke-setup/modules/secret-manager/csi-driver-gcp-plugin/provider-gcp-plugin.yaml
@@ -99,9 +99,6 @@ spec:
           hostPath:
             path: /etc/kubernetes/secrets-store-csi-providers
       tolerations:
-        - key: kubernetes.io/arch
-          operator: Equal
-          value: arm64
-          effect: NoSchedule
+      - operator: Exists
       nodeSelector:
         kubernetes.io/os: linux

--- a/benchmarks/infra/stage-2/modules/gke-setup/modules/secret-manager/main.tf
+++ b/benchmarks/infra/stage-2/modules/gke-setup/modules/secret-manager/main.tf
@@ -38,7 +38,7 @@ locals {
 }
 
 module "secret-manager" {
-  source     = "git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/secret-manager"
+  source     = "git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/secret-manager?ref=v30.0.0&depth=1"
   project_id = var.project_id
   secrets = {
     "${var.secret_name}" = {

--- a/benchmarks/infra/stage-2/modules/gke-setup/modules/workload-identity/gcp.tf
+++ b/benchmarks/infra/stage-2/modules/gke-setup/modules/workload-identity/gcp.tf
@@ -21,7 +21,7 @@ data "google_service_account" "gsa" {
 }
 
 module "workload-service-account" {
-  source      = "git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/iam-service-account"
+  source      = "git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/iam-service-account?ref=v30.0.0&depth=1"
   count       = var.google_service_account_create ? 1 : 0
   project_id  = var.project_id
   name        = var.google_service_account


### PR DESCRIPTION
Set stage-2 gcp modules to be fixed at stable version. Avoid any breaking changes to main.

Fix tolerations in csi-driver-gcp-plugin. Enables pod to be scheduled on every node (required for secret manager to work properly).

Toleration matches the tolerations in the other similar infra daemonsets, eg. https://github.com/GoogleCloudPlatform/ai-on-gke/blob/494b866d04d234654913f6e2e6a7b53f6d8e0688/benchmarks/infra/stage-2/modules/gke-setup/modules/secret-manager/csi-driver/secrets-store-csi-driver.yaml#L140