### PR TITLE
Mark RAG vector embedding and prompt tests as optional

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -365,10 +365,11 @@ steps:
           exit 1
         fi
 
-        if [[ $(cat /workspace/rag_prompt_result.txt) != "pass" ]]; then
-          echo "rag frontend test failed"
-          exit 1
-        fi
+        # TODO: re-add this check once generating embeddings in CI is stable
+        # if [[ $(cat /workspace/rag_prompt_result.txt) != "pass" ]]; then
+        #   echo "rag frontend test failed"
+        #   exit 1
+        # fi
 
     waitFor: ['cleanup gke cluster']
         


### PR DESCRIPTION
We recently introduced vector embedding generation and prompts in the RAG tests. This has been a little flakey so marking optional for now while we deflake it.