### PR TITLE
[WIP] fix metadata labels for RAG, Ray and Jupyter quick starts

### DIFF
--- a/applications/jupyter/main.tf
+++ b/applications/jupyter/main.tf
@@ -145,7 +145,7 @@ module "jupyterhub" {
   providers                         = { helm = helm.jupyter, kubernetes = kubernetes.jupyter }
   project_id                        = var.project_id
   namespace                         = local.kubernetes_namespace
-  additional_labels                 = var.additional_labels
+  created_by                        = var.created_by
   workload_identity_service_account = local.workload_identity_service_account
   gcs_bucket                        = var.gcs_bucket
   autopilot_cluster                 = local.enable_autopilot

--- a/applications/jupyter/metadata.display.yaml
+++ b/applications/jupyter/metadata.display.yaml
@@ -42,11 +42,6 @@ spec:
           name: add_auth
           title: Enable IAP Authentication
           section: iap_auth
-        additional_labels:
-          name: additional_labels
-          title: Additional Labels
-          invisible: true
-          section: cluster_details
         autopilot_cluster:
           name: autopilot_cluster
           title: GKE Cluster Type
@@ -76,6 +71,11 @@ spec:
         cluster_name:
           name: cluster_name
           title: Cluster Name
+          section: cluster_details
+        created_by:
+          name: created_by
+          title: Created By metadatal label
+          invisible: true
           section: cluster_details
         create_brand:
           name: create_brand

--- a/applications/jupyter/metadata.yaml
+++ b/applications/jupyter/metadata.yaml
@@ -40,12 +40,6 @@ spec:
         description: Enable IAP authentication on jupyterhub
         varType: bool
         defaultValue: false
-      - name: additional_labels
-        description: Additional labels to add to Kubernetes resources.
-        varType: list(string)
-        defaultValue:
-          - created-by=gke-ai-quick-start-solutions
-          - ai.gke.io=jupyter
       - name: autopilot_cluster
         varType: bool
         defaultValue: false
@@ -67,6 +61,10 @@ spec:
       - name: cluster_name
         varType: string
         required: true
+      - name: created_by
+        description: Created By metadata label
+        varType: string
+        defaultValue: "gke-ai-quick-start-solutions"
       - name: create_brand
         description: Create Brand OAuth Screen
         varType: bool

--- a/applications/jupyter/variables.tf
+++ b/applications/jupyter/variables.tf
@@ -31,11 +31,10 @@ variable "kubernetes_namespace" {
   description = "Kubernetes namespace where resources are deployed"
 }
 
-variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
-  description = "Additional labels to add to Kubernetes resources."
-  default     = ["created-by=ai-on-gke", "ai.gke.io=jupyter"]
+variable "created_by" {
+  type        = string
+  description = "Metadata to add created-by labels"
+  default     = "ai-on-gke"
 }
 
 variable "gcs_bucket" {

--- a/applications/rag/frontend/main.tf
+++ b/applications/rag/frontend/main.tf
@@ -17,10 +17,6 @@ data "google_project" "project" {
 
 locals {
   instance_connection_name = format("%s:%s:%s", var.project_id, var.cloudsql_instance_region, var.cloudsql_instance)
-  additional_labels = tomap({
-    for item in var.additional_labels :
-    split("=", item)[0] => split("=", item)[1]
-  })
 }
 
 # IAP Section: Creates the GKE components
@@ -86,24 +82,30 @@ resource "kubernetes_deployment" "rag_frontend_deployment" {
   metadata {
     name      = "rag-frontend"
     namespace = var.namespace
-    labels = merge({
-      app = "rag-frontend"
-    }, local.additional_labels)
+    labels = {
+      app          = "rag-frontend"
+      "ai.gke.io"  = "rag"
+      "created-by" = var.created_by
+    }
   }
 
   spec {
     replicas = 3
     selector {
-      match_labels = merge({
-        app = "rag-frontend"
-      }, local.additional_labels)
+      match_labels = {
+        app          = "rag-frontend"
+        "ai.gke.io"  = "rag"
+        "created-by" = var.created_by
+      }
     }
 
     template {
       metadata {
-        labels = merge({
-          app = "rag-frontend"
-        }, local.additional_labels)
+        labels = {
+          app          = "rag-frontend"
+          "ai.gke.io"  = "rag"
+          "created-by" = var.created_by
+        }
       }
 
       spec {

--- a/applications/rag/frontend/variables.tf
+++ b/applications/rag/frontend/variables.tf
@@ -23,11 +23,10 @@ variable "namespace" {
   default     = "rag"
 }
 
-variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
-  description = "Additional labels to add to Kubernetes resources."
-  default     = []
+variable "created_by" {
+  type        = string
+  description = "Metadata to add created-by labels"
+  default     = "ai-on-gke"
 }
 
 variable "region" {

--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -183,6 +183,7 @@ module "cloudsql" {
 
 module "jupyterhub" {
   source     = "../../modules/jupyter"
+  created_by = var.created_by
   providers  = { helm = helm.rag, kubernetes = kubernetes.rag }
   namespace  = local.kubernetes_namespace
   project_id = var.project_id
@@ -225,6 +226,7 @@ module "kuberay-logging" {
 
 module "kuberay-cluster" {
   source                 = "../../modules/kuberay-cluster"
+  created_by             = var.created_by
   providers              = { helm = helm.rag, kubernetes = kubernetes.rag }
   project_id             = var.project_id
   namespace              = local.kubernetes_namespace
@@ -272,7 +274,7 @@ module "inference-server" {
   source            = "../../tutorials-and-examples/hf-tgi"
   providers         = { kubernetes = kubernetes.rag }
   namespace         = local.kubernetes_namespace
-  additional_labels = var.additional_labels
+  created_by        = var.created_by
   autopilot_cluster = local.enable_autopilot
   depends_on        = [module.namespace]
 }
@@ -284,7 +286,7 @@ module "frontend" {
   create_service_account        = var.create_rag_service_account
   google_service_account        = local.rag_service_account
   namespace                     = local.kubernetes_namespace
-  additional_labels             = var.additional_labels
+  created_by                    = var.created_by
   inference_service_endpoint    = module.inference-server.inference_service_endpoint
   cloudsql_instance             = module.cloudsql.instance
   cloudsql_instance_region      = local.cloudsql_instance_region

--- a/applications/rag/metadata.display.yaml
+++ b/applications/rag/metadata.display.yaml
@@ -22,11 +22,6 @@ spec:
           enumValueLabels:
             - label: Confirm that all prerequisites have been met.
               value: "true"
-        additional_labels:
-          name: additional_labels
-          title: Additional Labels
-          invisible: true
-          section: cluster_details
         autopilot_cluster:
           name: autopilot_cluster
           title: GKE Cluster Type
@@ -63,6 +58,11 @@ spec:
           name: cpu_pools
           title: Cpu Pools
           invisible: true
+        created_by:
+          name: created_by
+          title: Created By metadatal label
+          invisible: true
+          section: cluster_details
         create_brand:
           name: create_brand
           title: Create Brand

--- a/applications/rag/metadata.yaml
+++ b/applications/rag/metadata.yaml
@@ -20,12 +20,6 @@ spec:
       - name: acknowledge
         varType: bool
         required: true
-      - name: additional_labels
-        description: Additional labels to add to Kubernetes resources.
-        varType: list(string)
-        defaultValue:
-          - created-by=gke-ai-quick-start-solutions
-          - ai.gke.io=rag
       - name: autopilot_cluster
         varType: string
         defaultValue: false
@@ -47,6 +41,10 @@ spec:
       - name: cluster_name
         varType: string
         required: true
+      - name: created_by
+        description: Created By metadata label
+        varType: string
+        defaultValue: "gke-ai-quick-start-solutions"
       - name: create_brand
         description: Create Brand OAuth Screen
         varType: bool

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -42,11 +42,10 @@ variable "kubernetes_namespace" {
   default     = "rag"
 }
 
-variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
-  description = "Additional labels to add to Kubernetes resources."
-  default     = ["created-by=ai-on-gke", "ai.gke.io=rag"]
+variable "created_by" {
+  type        = string
+  description = "Metadata to add created-by labels"
+  default     = "ai-on-gke"
 }
 
 variable "jupyter_service_account" {

--- a/applications/ray/metadata.display.yaml
+++ b/applications/ray/metadata.display.yaml
@@ -22,11 +22,6 @@ spec:
           enumValueLabels:
             - label: Confirm that all prerequisites have been met.
               value: "true"
-        additional_labels:
-          name: additional_labels
-          title: Additional Labels
-          invisible: true
-          section: cluster_details
         autopilot_cluster:
           name: autopilot_cluster
           title: GKE Cluster Type
@@ -44,6 +39,11 @@ spec:
         cluster_name:
           name: cluster_name
           title: Cluster Name
+          section: cluster_details
+        created_by:
+          name: created_by
+          title: Created By metadatal label
+          invisible: true
           section: cluster_details
         create_brand:
           name: create_brand

--- a/applications/ray/metadata.yaml
+++ b/applications/ray/metadata.yaml
@@ -17,12 +17,6 @@ spec:
   content: {}
   interfaces:
     variables:
-      - name: additional_labels
-        description: Additional labels to add to Kubernetes resources.
-        varType: list(string)
-        defaultValue:
-          - created-by=gke-ai-quick-start-solutions
-          - ai.gke.io=ray
       - name: acknowledge
         varType: bool
         required: true
@@ -40,6 +34,10 @@ spec:
       - name: cluster_name
         varType: string
         required: true
+      - name: created_by
+        description: Created By metadata label
+        varType: string
+        defaultValue: "gke-ai-quick-start-solutions"
       - name: create_brand
         description: Create Brand OAuth Screen
         varType: bool

--- a/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
@@ -27,7 +27,8 @@ hub:
     # This is the timestamp of the image, we should avoid using 'latest'
     tag: '1710974014'
   labels:
-    ${indent(4, chomp(jsonencode(additional_labels)))}
+    ai.gke.io: jupyter
+    created-by: ${created_by}
   config:
     JupyterHub:
       authenticator_class: ${authenticator_class}
@@ -53,7 +54,8 @@ prePuller:
 
 proxy:
   labels:
-    ${indent(4, chomp(jsonencode(additional_labels)))}
+    ai.gke.io: jupyter
+    created-by: ${created_by}
   chp:
     networkPolicy:
       enabled: false
@@ -90,7 +92,8 @@ singleuser:
     JUPYTER_ALLOW_INSECURE_WRITES: "true"
     CLOUDSQL_INSTANCE_CONNECTION_NAME: ${cloudsql_instance_connection_name}
   extraLabels:
-    ${indent(4, chomp(jsonencode(additional_labels)))}
+    ai.gke.io: jupyter
+    created-by: ${created_by}
   image:
     name: ${notebook_image}
     tag: ${notebook_image_tag}

--- a/modules/jupyter/jupyter_config/config-selfauth.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth.yaml
@@ -27,7 +27,8 @@ hub:
     # This is the timestamp of the image, we should avoid using 'latest'
     tag: '1710974014'
   labels:
-    ${indent(4, chomp(jsonencode(additional_labels)))}
+    ai.gke.io: jupyter
+    created-by: ${created_by}
   config:
     JupyterHub:
       authenticator_class: ${authenticator_class}
@@ -53,7 +54,8 @@ prePuller:
 
 proxy:
   labels:
-    ${indent(4, chomp(jsonencode(additional_labels)))}
+    ai.gke.io: jupyter
+    created-by: ${created_by}
   chp:
     networkPolicy:
       enabled: false
@@ -88,7 +90,8 @@ singleuser:
     JUPYTER_ALLOW_INSECURE_WRITES: "true"
     CLOUDSQL_INSTANCE_CONNECTION_NAME: ${cloudsql_instance_connection_name}
   extraLabels:
-    ${indent(4, chomp(jsonencode(additional_labels)))}
+    ai.gke.io: jupyter
+    created-by: ${created_by}
   image:
     name: ${notebook_image}
     tag: ${notebook_image_tag}

--- a/modules/jupyter/main.tf
+++ b/modules/jupyter/main.tf
@@ -18,10 +18,6 @@ data "google_project" "project" {
 
 locals {
   cloudsql_instance_connection_name = var.cloudsql_instance_name != "" ? format("%s:%s:%s", var.project_id, var.db_region, var.cloudsql_instance_name) : ""
-  additional_labels = tomap({
-    for item in var.additional_labels :
-    split("=", item)[0] => split("=", item)[1]
-  })
 }
 
 # IAP Section: Creates the GKE components
@@ -114,7 +110,7 @@ resource "helm_release" "jupyterhub" {
     project_id                        = var.project_id
     project_number                    = data.google_project.project.number
     namespace                         = var.namespace
-    additional_labels                 = local.additional_labels
+    created_by                        = var.created_by
     backend_config                    = var.k8s_backend_config_name
     service_name                      = var.k8s_backend_service_name
     authenticator_class               = var.add_auth ? "'gcpiapjwtauthenticator.GCPIAPAuthenticator'" : "dummy"
@@ -133,7 +129,7 @@ resource "helm_release" "jupyterhub" {
       project_id                        = var.project_id
       project_number                    = data.google_project.project.number
       namespace                         = var.namespace
-      additional_labels                 = local.additional_labels
+      created_by                        = var.created_by
       backend_config                    = var.k8s_backend_config_name
       service_name                      = var.k8s_backend_service_name
       authenticator_class               = var.add_auth ? "'gcpiapjwtauthenticator.GCPIAPAuthenticator'" : "dummy"

--- a/modules/jupyter/variables.tf
+++ b/modules/jupyter/variables.tf
@@ -45,11 +45,10 @@ variable "gcs_bucket" {
   description = "GCS bucket to mount on the notebook via GCSFuse and CSI"
 }
 
-variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
-  description = "Additional labels to add to Kubernetes resources."
-  default     = ["created-by=ai-on-gke", "ai.gke.io=jupyter"]
+variable "created_by" {
+  type        = string
+  description = "Metadata to add created-by labels"
+  default     = "ai-on-gke"
 }
 
 variable "workload_identity_service_account" {

--- a/modules/kuberay-cluster/main.tf
+++ b/modules/kuberay-cluster/main.tf
@@ -21,10 +21,6 @@ resource "google_storage_bucket_iam_member" "gcs-bucket-iam" {
 locals {
   security_context                  = { for k, v in var.security_context : k => v if v != null }
   cloudsql_instance_connection_name = format("%s:%s:%s", var.project_id, var.db_region, var.cloudsql_instance_name)
-  additional_labels = tomap({
-    for item in var.additional_labels :
-    split("=", item)[0] => split("=", item)[1]
-  })
 }
 
 resource "helm_release" "ray-cluster" {
@@ -42,7 +38,7 @@ resource "helm_release" "ray-cluster" {
     templatefile("${path.module}/values.yaml", {
       gcs_bucket                        = var.gcs_bucket
       k8s_service_account               = var.google_service_account
-      additional_labels                 = local.additional_labels
+      created_by                        = var.created_by
       grafana_host                      = var.grafana_host
       security_context                  = local.security_context
       secret_name                       = var.db_secret_name

--- a/modules/kuberay-cluster/values.yaml
+++ b/modules/kuberay-cluster/values.yaml
@@ -56,7 +56,8 @@ head:
     #     memory: "512Mi"
   labels:
     cloud.google.com/gke-ray-node-type: head
-    ${indent(4, chomp(yamlencode(additional_labels)))}
+    ai.gke.io: ray
+    created-by: ${created_by}
   serviceAccountName: ${k8s_service_account}
   rayStartParams:
     dashboard-host: '0.0.0.0'
@@ -169,7 +170,8 @@ worker:
   type: worker
   labels:
     cloud.google.com/gke-ray-node-type: worker
-    ${indent(4, chomp(yamlencode(additional_labels)))}
+    ai.gke.io: ray
+    created-by: ${created_by}
   serviceAccountName: ${k8s_service_account}
   rayStartParams:
     block: 'true'

--- a/modules/kuberay-cluster/variables.tf
+++ b/modules/kuberay-cluster/variables.tf
@@ -42,11 +42,10 @@ variable "namespace" {
   default     = "ray-system"
 }
 
-variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
-  description = "Additional labels to add to Kubernetes resources."
-  default     = ["created-by=ai-on-gke", "ai.gke.io=ray"]
+variable "created_by" {
+  type        = string
+  description = "Metadata to add created-by labels"
+  default     = "ai-on-gke"
 }
 
 variable "enable_tpu" {

--- a/tutorials-and-examples/hf-tgi/main.tf
+++ b/tutorials-and-examples/hf-tgi/main.tf
@@ -12,13 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-locals {
-  additional_labels = tomap({
-    for item in var.additional_labels :
-    split("=", item)[0] => split("=", item)[1]
-  })
-}
-
 resource "kubernetes_service" "inference_service" {
   metadata {
     name = "mistral-7b-instruct-service"
@@ -50,25 +43,31 @@ resource "kubernetes_deployment" "inference_deployment" {
   metadata {
     name      = "mistral-7b-instruct"
     namespace = var.namespace
-    labels = merge({
-      app = "mistral-7b-instruct"
-    }, local.additional_labels)
+    labels = {
+      app          = "mistral-7b-instruct"
+      "ai.gke.io"  = "hf-tgi"
+      "created-by" = var.created_by
+    }
   }
 
   spec {
     replicas = 1
 
     selector {
-      match_labels = merge({
-        app = "mistral-7b-instruct"
-      }, local.additional_labels)
+      match_labels = {
+        app          = "mistral-7b-instruct"
+        "ai.gke.io"  = "hf-tgi"
+        "created-by" = var.created_by
+      }
     }
 
     template {
       metadata {
-        labels = merge({
-          app = "mistral-7b-instruct"
-        }, local.additional_labels)
+        labels = {
+          app          = "mistral-7b-instruct"
+          "ai.gke.io"  = "hf-tgi"
+          "created-by" = var.created_by
+        }
       }
 
       spec {

--- a/tutorials-and-examples/hf-tgi/variables.tf
+++ b/tutorials-and-examples/hf-tgi/variables.tf
@@ -18,11 +18,10 @@ variable "namespace" {
   default     = "default"
 }
 
-variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
-  description = "Additional labels to add to Kubernetes resources."
-  default     = []
+variable "created_by" {
+  type        = string
+  description = "Metadata to add created-by labels"
+  default     = "ai-on-gke"
 }
 
 variable "autopilot_cluster" {


### PR DESCRIPTION
Terraform seems to have some issues with rendering the list(string) type, which is causing issues with metadata labels we add to quick start deployments. This simplifies the labels and removes the dependency to list(string) 