### PR TITLE
Move additional_labels to string for MP

### DIFF
--- a/applications/jupyter/metadata.yaml
+++ b/applications/jupyter/metadata.yaml
@@ -42,10 +42,8 @@ spec:
         defaultValue: false
       - name: additional_labels
         description: Additional labels to add to Kubernetes resources.
-        varType: list(string)
-        defaultValue:
-          - created-by=gke-ai-quick-start-solutions
-          - ai.gke.io=jupyter
+        varType: string
+        defaultValue: "created-by=gke-ai-quick-start-solutions,ai.gke.io=jupyter"
       - name: autopilot_cluster
         varType: bool
         defaultValue: false

--- a/applications/jupyter/variables.tf
+++ b/applications/jupyter/variables.tf
@@ -32,10 +32,10 @@ variable "kubernetes_namespace" {
 }
 
 variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
+  // string is used instead of map(string) since blueprint metadata does not support maps.
+  type        = string
   description = "Additional labels to add to Kubernetes resources."
-  default     = ["created-by=ai-on-gke", "ai.gke.io=jupyter"]
+  default     = "created-by=ai-on-gke,ai.gke.io=jupyter"
 }
 
 variable "gcs_bucket" {

--- a/applications/rag/frontend/main.tf
+++ b/applications/rag/frontend/main.tf
@@ -18,7 +18,7 @@ data "google_project" "project" {
 locals {
   instance_connection_name = format("%s:%s:%s", var.project_id, var.cloudsql_instance_region, var.cloudsql_instance)
   additional_labels = tomap({
-    for item in var.additional_labels :
+    for item in split(",",var.additional_labels) :
     split("=", item)[0] => split("=", item)[1]
   })
 }
@@ -26,7 +26,7 @@ locals {
 # IAP Section: Creates the GKE components
 module "iap_auth" {
   count  = var.add_auth ? 1 : 0
-  source = "../../../modules/iap"
+  source = "github.com/GoogleCloudPlatform/ai-on-gke//modules/iap?ref=labels"
 
   project_id               = var.project_id
   namespace                = var.namespace

--- a/applications/rag/frontend/main.tf
+++ b/applications/rag/frontend/main.tf
@@ -26,7 +26,7 @@ locals {
 # IAP Section: Creates the GKE components
 module "iap_auth" {
   count  = var.add_auth ? 1 : 0
-  source = "github.com/GoogleCloudPlatform/ai-on-gke//modules/iap?ref=labels"
+  source = "../../../modules/iap"
 
   project_id               = var.project_id
   namespace                = var.namespace

--- a/applications/rag/frontend/main.tf
+++ b/applications/rag/frontend/main.tf
@@ -18,7 +18,7 @@ data "google_project" "project" {
 locals {
   instance_connection_name = format("%s:%s:%s", var.project_id, var.cloudsql_instance_region, var.cloudsql_instance)
   additional_labels = tomap({
-    for item in split(",",var.additional_labels) :
+    for item in split(",", var.additional_labels) :
     split("=", item)[0] => split("=", item)[1]
   })
 }

--- a/applications/rag/frontend/variables.tf
+++ b/applications/rag/frontend/variables.tf
@@ -24,10 +24,10 @@ variable "namespace" {
 }
 
 variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
+  // string is used instead of map(string) since blueprint metadata does not support maps.
+  type        = string
   description = "Additional labels to add to Kubernetes resources."
-  default     = []
+  default     = ""
 }
 
 variable "region" {

--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -182,12 +182,12 @@ module "cloudsql" {
 }
 
 module "jupyterhub" {
-  source     = "../../modules/jupyter"
-  providers  = { helm = helm.rag, kubernetes = kubernetes.rag }
-  namespace  = local.kubernetes_namespace
-  project_id = var.project_id
-  gcs_bucket = var.gcs_bucket
-  add_auth   = var.jupyter_add_auth
+  source            = "../../modules/jupyter"
+  providers         = { helm = helm.rag, kubernetes = kubernetes.rag }
+  namespace         = local.kubernetes_namespace
+  project_id        = var.project_id
+  gcs_bucket        = var.gcs_bucket
+  add_auth          = var.jupyter_add_auth
   additional_labels = var.additional_labels
 
   autopilot_cluster                 = local.enable_autopilot
@@ -240,7 +240,7 @@ module "kuberay-cluster" {
   disable_network_policy = var.disable_ray_cluster_network_policy
   depends_on             = [module.kuberay-operator]
   use_custom_image       = true
-  additional_labels = var.additional_labels
+  additional_labels      = var.additional_labels
 
   # IAP Auth parameters
   add_auth                 = var.ray_dashboard_add_auth

--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -61,7 +61,7 @@ module "project-services" {
 }
 
 module "infra" {
-  source = "github.com/GoogleCloudPlatform/ai-on-gke//infrastructure?ref=labels"
+  source = "../../infrastructure"
   count  = var.create_cluster ? 1 : 0
 
   project_id         = var.project_id
@@ -145,14 +145,14 @@ provider "helm" {
 }
 
 module "namespace" {
-  source           = "github.com/GoogleCloudPlatform/ai-on-gke//modules/kubernetes-namespace?ref=labels"
+  source           = "../../modules/kubernetes-namespace"
   providers        = { helm = helm.rag }
   create_namespace = true
   namespace        = local.kubernetes_namespace
 }
 
 module "kuberay-operator" {
-  source                 = "github.com/GoogleCloudPlatform/ai-on-gke//modules/kuberay-operator?ref=labels"
+  source                 = "../../modules/kuberay-operator"
   providers              = { helm = helm.rag, kubernetes = kubernetes.rag }
   name                   = "kuberay-operator"
   project_id             = var.project_id
@@ -164,14 +164,14 @@ module "kuberay-operator" {
 }
 
 module "gcs" {
-  source      = "github.com/GoogleCloudPlatform/ai-on-gke//modules/gcs?ref=labels"
+  source      = "../../modules/gcs"
   count       = var.create_gcs_bucket ? 1 : 0
   project_id  = var.project_id
   bucket_name = var.gcs_bucket
 }
 
 module "cloudsql" {
-  source        = "github.com/GoogleCloudPlatform/ai-on-gke//modules/cloudsql?ref=labels"
+  source        = "../../modules/cloudsql"
   providers     = { kubernetes = kubernetes.rag }
   project_id    = var.project_id
   instance_name = local.cloudsql_instance
@@ -182,17 +182,18 @@ module "cloudsql" {
 }
 
 module "jupyterhub" {
-  source     = "github.com/GoogleCloudPlatform/ai-on-gke//modules/jupyter?ref=labels"
+  source     = "../../modules/jupyter"
   providers  = { helm = helm.rag, kubernetes = kubernetes.rag }
   namespace  = local.kubernetes_namespace
   project_id = var.project_id
   gcs_bucket = var.gcs_bucket
   add_auth   = var.jupyter_add_auth
+  additional_labels = var.additional_labels
 
   autopilot_cluster                 = local.enable_autopilot
   workload_identity_service_account = local.jupyter_service_account
 
-  notebook_image     = "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image?ref=labels"
+  notebook_image     = "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image"
   notebook_image_tag = "v1.1-rag"
 
   db_secret_name         = module.cloudsql.db_secret_name
@@ -217,14 +218,14 @@ module "jupyterhub" {
 }
 
 module "kuberay-logging" {
-  source     = "github.com/GoogleCloudPlatform/ai-on-gke//modules/kuberay-logging?ref=labels"
+  source     = "../../modules/kuberay-logging"
   providers  = { kubernetes = kubernetes.rag }
   namespace  = local.kubernetes_namespace
   depends_on = [module.namespace]
 }
 
 module "kuberay-cluster" {
-  source                 = "github.com/GoogleCloudPlatform/ai-on-gke//modules/kuberay-cluster?ref=labels"
+  source                 = "../../modules/kuberay-cluster"
   providers              = { helm = helm.rag, kubernetes = kubernetes.rag }
   project_id             = var.project_id
   namespace              = local.kubernetes_namespace
@@ -239,6 +240,7 @@ module "kuberay-cluster" {
   disable_network_policy = var.disable_ray_cluster_network_policy
   depends_on             = [module.kuberay-operator]
   use_custom_image       = true
+  additional_labels = var.additional_labels
 
   # IAP Auth parameters
   add_auth                 = var.ray_dashboard_add_auth
@@ -256,7 +258,7 @@ module "kuberay-cluster" {
 }
 
 module "kuberay-monitoring" {
-  source                          = "github.com/GoogleCloudPlatform/ai-on-gke//modules/kuberay-monitoring?ref=labels"
+  source                          = "../../modules/kuberay-monitoring"
   providers                       = { helm = helm.rag, kubernetes = kubernetes.rag }
   project_id                      = var.project_id
   autopilot_cluster               = local.enable_autopilot
@@ -269,7 +271,7 @@ module "kuberay-monitoring" {
 }
 
 module "inference-server" {
-  source            = "github.com/GoogleCloudPlatform/ai-on-gke//tutorials-and-examples/hf-tgi?ref=labels"
+  source            = "../../tutorials-and-examples/hf-tgi"
   providers         = { kubernetes = kubernetes.rag }
   namespace         = local.kubernetes_namespace
   additional_labels = var.additional_labels

--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -61,7 +61,7 @@ module "project-services" {
 }
 
 module "infra" {
-  source = "../../infrastructure"
+  source = "github.com/GoogleCloudPlatform/ai-on-gke//infrastructure?ref=labels"
   count  = var.create_cluster ? 1 : 0
 
   project_id         = var.project_id
@@ -145,14 +145,14 @@ provider "helm" {
 }
 
 module "namespace" {
-  source           = "../../modules/kubernetes-namespace"
+  source           = "github.com/GoogleCloudPlatform/ai-on-gke//modules/kubernetes-namespace?ref=labels"
   providers        = { helm = helm.rag }
   create_namespace = true
   namespace        = local.kubernetes_namespace
 }
 
 module "kuberay-operator" {
-  source                 = "../../modules/kuberay-operator"
+  source                 = "github.com/GoogleCloudPlatform/ai-on-gke//modules/kuberay-operator?ref=labels"
   providers              = { helm = helm.rag, kubernetes = kubernetes.rag }
   name                   = "kuberay-operator"
   project_id             = var.project_id
@@ -164,14 +164,14 @@ module "kuberay-operator" {
 }
 
 module "gcs" {
-  source      = "../../modules/gcs"
+  source      = "github.com/GoogleCloudPlatform/ai-on-gke//modules/gcs?ref=labels"
   count       = var.create_gcs_bucket ? 1 : 0
   project_id  = var.project_id
   bucket_name = var.gcs_bucket
 }
 
 module "cloudsql" {
-  source        = "../../modules/cloudsql"
+  source        = "github.com/GoogleCloudPlatform/ai-on-gke//modules/cloudsql?ref=labels"
   providers     = { kubernetes = kubernetes.rag }
   project_id    = var.project_id
   instance_name = local.cloudsql_instance
@@ -182,7 +182,7 @@ module "cloudsql" {
 }
 
 module "jupyterhub" {
-  source     = "../../modules/jupyter"
+  source     = "github.com/GoogleCloudPlatform/ai-on-gke//modules/jupyter?ref=labels"
   providers  = { helm = helm.rag, kubernetes = kubernetes.rag }
   namespace  = local.kubernetes_namespace
   project_id = var.project_id
@@ -192,7 +192,7 @@ module "jupyterhub" {
   autopilot_cluster                 = local.enable_autopilot
   workload_identity_service_account = local.jupyter_service_account
 
-  notebook_image     = "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image"
+  notebook_image     = "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image?ref=labels"
   notebook_image_tag = "v1.1-rag"
 
   db_secret_name         = module.cloudsql.db_secret_name
@@ -217,14 +217,14 @@ module "jupyterhub" {
 }
 
 module "kuberay-logging" {
-  source     = "../../modules/kuberay-logging"
+  source     = "github.com/GoogleCloudPlatform/ai-on-gke//modules/kuberay-logging?ref=labels"
   providers  = { kubernetes = kubernetes.rag }
   namespace  = local.kubernetes_namespace
   depends_on = [module.namespace]
 }
 
 module "kuberay-cluster" {
-  source                 = "../../modules/kuberay-cluster"
+  source                 = "github.com/GoogleCloudPlatform/ai-on-gke//modules/kuberay-cluster?ref=labels"
   providers              = { helm = helm.rag, kubernetes = kubernetes.rag }
   project_id             = var.project_id
   namespace              = local.kubernetes_namespace
@@ -256,7 +256,7 @@ module "kuberay-cluster" {
 }
 
 module "kuberay-monitoring" {
-  source                          = "../../modules/kuberay-monitoring"
+  source                          = "github.com/GoogleCloudPlatform/ai-on-gke//modules/kuberay-monitoring?ref=labels"
   providers                       = { helm = helm.rag, kubernetes = kubernetes.rag }
   project_id                      = var.project_id
   autopilot_cluster               = local.enable_autopilot
@@ -269,7 +269,7 @@ module "kuberay-monitoring" {
 }
 
 module "inference-server" {
-  source            = "../../tutorials-and-examples/hf-tgi"
+  source            = "github.com/GoogleCloudPlatform/ai-on-gke//tutorials-and-examples/hf-tgi?ref=labels"
   providers         = { kubernetes = kubernetes.rag }
   namespace         = local.kubernetes_namespace
   additional_labels = var.additional_labels

--- a/applications/rag/metadata.yaml
+++ b/applications/rag/metadata.yaml
@@ -22,10 +22,8 @@ spec:
         required: true
       - name: additional_labels
         description: Additional labels to add to Kubernetes resources.
-        varType: list(string)
-        defaultValue:
-          - created-by=gke-ai-quick-start-solutions
-          - ai.gke.io=rag
+        varType: string
+        defaultValue: "created-by=gke-ai-quick-start-solutions,ai.gke.io=rag"
       - name: autopilot_cluster
         varType: string
         defaultValue: false

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -43,10 +43,10 @@ variable "kubernetes_namespace" {
 }
 
 variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
+  // string is used instead of map(string) since blueprint metadata does not support maps.
+  type        = string
   description = "Additional labels to add to Kubernetes resources."
-  default     = ["created-by=ai-on-gke", "ai.gke.io=rag"]
+  default     = "created-by=ai-on-gke,ai.gke.io=rag"
 }
 
 variable "jupyter_service_account" {

--- a/applications/ray/metadata.yaml
+++ b/applications/ray/metadata.yaml
@@ -19,10 +19,8 @@ spec:
     variables:
       - name: additional_labels
         description: Additional labels to add to Kubernetes resources.
-        varType: list(string)
-        defaultValue:
-          - created-by=gke-ai-quick-start-solutions
-          - ai.gke.io=ray
+        varType: string
+        defaultValue: "created-by=gke-ai-quick-start-solutions,ai.gke.io=ray"
       - name: acknowledge
         varType: bool
         required: true

--- a/modules/jupyter/main.tf
+++ b/modules/jupyter/main.tf
@@ -19,7 +19,7 @@ data "google_project" "project" {
 locals {
   cloudsql_instance_connection_name = var.cloudsql_instance_name != "" ? format("%s:%s:%s", var.project_id, var.db_region, var.cloudsql_instance_name) : ""
   additional_labels = tomap({
-    for item in var.additional_labels :
+    for item in split(",", var.additional_labels) :
     split("=", item)[0] => split("=", item)[1]
   })
 }

--- a/modules/jupyter/variables.tf
+++ b/modules/jupyter/variables.tf
@@ -46,10 +46,10 @@ variable "gcs_bucket" {
 }
 
 variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
+  // string is used instead of map(string) since blueprint metadata does not support maps.
+  type        = string
   description = "Additional labels to add to Kubernetes resources."
-  default     = ["created-by=ai-on-gke", "ai.gke.io=jupyter"]
+  default     = "created-by=ai-on-gke,ai.gke.io=jupyter"
 }
 
 variable "workload_identity_service_account" {

--- a/modules/kuberay-cluster/main.tf
+++ b/modules/kuberay-cluster/main.tf
@@ -22,7 +22,7 @@ locals {
   security_context                  = { for k, v in var.security_context : k => v if v != null }
   cloudsql_instance_connection_name = format("%s:%s:%s", var.project_id, var.db_region, var.cloudsql_instance_name)
   additional_labels = tomap({
-    for item in var.additional_labels :
+    for item in split(",", var.additional_labels) :
     split("=", item)[0] => split("=", item)[1]
   })
 }

--- a/modules/kuberay-cluster/variables.tf
+++ b/modules/kuberay-cluster/variables.tf
@@ -43,10 +43,10 @@ variable "namespace" {
 }
 
 variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
+  // string is used instead of map(string) since blueprint metadata does not support maps.
+  type        = string
   description = "Additional labels to add to Kubernetes resources."
-  default     = ["created-by=ai-on-gke", "ai.gke.io=ray"]
+  default     = "created-by=ai-on-gke,ai.gke.io=ray"
 }
 
 variable "enable_tpu" {

--- a/tutorials-and-examples/hf-tgi/main.tf
+++ b/tutorials-and-examples/hf-tgi/main.tf
@@ -14,7 +14,7 @@
 
 locals {
   additional_labels = tomap({
-    for item in split(",",var.additional_labels) :
+    for item in split(",", var.additional_labels) :
     split("=", item)[0] => split("=", item)[1]
   })
 }

--- a/tutorials-and-examples/hf-tgi/main.tf
+++ b/tutorials-and-examples/hf-tgi/main.tf
@@ -14,7 +14,7 @@
 
 locals {
   additional_labels = tomap({
-    for item in var.additional_labels :
+    for item in split(",",var.additional_labels) :
     split("=", item)[0] => split("=", item)[1]
   })
 }

--- a/tutorials-and-examples/hf-tgi/variables.tf
+++ b/tutorials-and-examples/hf-tgi/variables.tf
@@ -19,10 +19,10 @@ variable "namespace" {
 }
 
 variable "additional_labels" {
-  // list(string) is used instead of map(string) since blueprint metadata does not support maps.
-  type        = list(string)
+  // string is used instead of map(string) since blueprint metadata does not support maps.
+  type        = string
   description = "Additional labels to add to Kubernetes resources."
-  default     = []
+  default     = ""
 }
 
 variable "autopilot_cluster" {


### PR DESCRIPTION
Update list(string) for additional_labels variable type to string because of a bug with marketplace support with list(string) type.

Using string to addtional_labels in string format, refer example - "created-by=gke-ai-quick-start-solutions,ai.gke.io=rag"