### PR TITLE
Enable image streaming by default for CPU pools

### DIFF
--- a/applications/jupyter/variables.tf
+++ b/applications/jupyter/variables.tf
@@ -182,6 +182,7 @@ variable "cpu_pools" {
     autoscaling  = true
     min_count    = 1
     max_count    = 3
+    enable_gcfs  = true
     disk_size_gb = 100
     disk_type    = "pd-standard"
   }]
@@ -200,7 +201,7 @@ variable "gpu_pools" {
     disk_size_gb           = optional(number, 100)
     disk_type              = optional(string, "pd-standard")
     image_type             = optional(string, "COS_CONTAINERD")
-    enable_gcfs            = optional(bool, false)
+    enable_gcfs            = optional(bool, true)
     enable_gvnic           = optional(bool, false)
     logging_variant        = optional(string, "DEFAULT")
     auto_repair            = optional(bool, true)

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -347,7 +347,7 @@ variable "cpu_pools" {
     disk_size_gb           = optional(number, 100)
     disk_type              = optional(string, "pd-standard")
     image_type             = optional(string, "COS_CONTAINERD")
-    enable_gcfs            = optional(bool, false)
+    enable_gcfs            = optional(bool, true)
     enable_gvnic           = optional(bool, false)
     logging_variant        = optional(string, "DEFAULT")
     auto_repair            = optional(bool, true)
@@ -363,6 +363,7 @@ variable "cpu_pools" {
     autoscaling  = true
     min_count    = 1
     max_count    = 3
+    enable_gcfs  = true
     disk_size_gb = 100
     disk_type    = "pd-standard"
   }]

--- a/applications/ray/variables.tf
+++ b/applications/ray/variables.tf
@@ -137,6 +137,7 @@ variable "cpu_pools" {
     autoscaling  = true
     min_count    = 1
     max_count    = 3
+    enable_gcfs  = true
     disk_size_gb = 100
     disk_type    = "pd-standard"
   }]

--- a/infrastructure/platform.tfvars
+++ b/infrastructure/platform.tfvars
@@ -35,6 +35,7 @@ cpu_pools = [{
   autoscaling  = true
   min_count    = 1
   max_count    = 3
+  enable_gcfs  = true
   disk_size_gb = 100
   disk_type    = "pd-standard"
 }]


### PR DESCRIPTION
We currently enable image streamign for GPU node pools but not CPU node pools. Not sure why we only enabled it for GPU node pools but it probably makes sense to enable for all node pools by default. 

Fixes https://github.com/GoogleCloudPlatform/ai-on-gke/issues/509