### PR TITLE
Update webhook cert-manager install to work with GKE autopilot clusters

### DIFF
--- a/applications/ray/kuberay-tpu-webhook/Makefile
+++ b/applications/ray/kuberay-tpu-webhook/Makefile
@@ -31,16 +31,7 @@ docker-build:
   
 # Push the docker image  
 docker-push:  
-	docker push ${IMG}  
-
-# Install once per cluster
-install-cert-manager:  
-	helm repo add jetstack https://charts.jetstack.io
-	helm repo update
-	helm install --create-namespace --namespace cert-manager --set installCRDs=true --set global.leaderElection.namespace=cert-manager cert-manager jetstack/cert-manager
-
-uninstall-cert-manager:
-	helm uninstall cert-manager -n cert-manager
+	docker push ${IMG}
 
 deploy-cert:
 	kubectl apply -f certs/

--- a/applications/ray/kuberay-tpu-webhook/Makefile
+++ b/applications/ray/kuberay-tpu-webhook/Makefile
@@ -32,12 +32,15 @@ docker-build:
 # Push the docker image  
 docker-push:  
 	docker push ${IMG}  
-  
+
+# Install once per cluster
 install-cert-manager:  
-	kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml
+	helm repo add jetstack https://charts.jetstack.io
+	helm repo update
+	helm install --create-namespace --namespace cert-manager --set installCRDs=true --set global.leaderElection.namespace=cert-manager cert-manager jetstack/cert-manager
 
 uninstall-cert-manager:
-	kubectl delete -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml
+	helm uninstall cert-manager -n cert-manager
 
 deploy-cert:
 	kubectl apply -f certs/

--- a/ray-on-gke/guides/tpu/README.md
+++ b/ray-on-gke/guides/tpu/README.md
@@ -46,16 +46,21 @@ accelerator_type       = "nvidia-tesla-t4"
 
 ### Manually Installing the TPU Initialization Webhook
 
-The TPU Initialization Webhook automatically bootstraps the TPU environment for TPU clusters. The webhook needs to be installed once per GKE cluster and requires a Kuberay Operator running v1.1+ and GKE cluster version of 1.28+. 
+The TPU Initialization Webhook automatically bootstraps the TPU environment for TPU clusters. The webhook needs to be installed once per GKE cluster and requires a Kuberay Operator running v1.1+ and GKE cluster version of 1.28+. The webhook requires [cert-manager](https://github.com/cert-manager/cert-manager) to be installed in-cluster to handle TLS certificate injection. cert-manager can be installed in both GKE standard and autopilot clusters using the following helm commands:
+```
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm install --create-namespace --namespace cert-manager --set installCRDs=true --set global.leaderElection.namespace=cert-manager cert-manager jetstack/cert-manager
+```
+After installing cert-manager, it may take up to two minutes for the certificate to become ready.
 
+Installing the webhook:
 1. `git clone https://github.com/GoogleCloudPlatform/ai-on-gke`
 2. `cd applications/ray/kuberay-tpu-webhook` 
-3. `make install-cert-manager` - it may take up to two minutes for the certificate to become ready
-4. `make deploy`
+3. `make deploy`
     - this will create the webhook deployment, configs, and service in the "ray-system" namespace
     - to change the namespace, edit the "namespace" value in each .yaml in deployments/ and certs/
-
-5. `make deploy-cert`
+4. `make deploy-cert`
 
    
 


### PR DESCRIPTION
This PR changes the `make install-cert-manager` command to one that works for both GKE standard and autopilot clusters. The previous `kubectl apply` command to install cert-manager is incompatible with GKE autopilot since the default `global.leaderElection.namespace` is a managed namespace on autopilot.

 This PR was tested by installing cert-manager using the helm commands on both standard and autopilot clusters and verifying that the webhook was successfully issued a certificate.