### PR TITLE
Ray TPU Webhook: Remove Error for nil workerGroupSpecs

### DIFF
--- a/applications/ray/kuberay-tpu-webhook/main.go
+++ b/applications/ray/kuberay-tpu-webhook/main.go
@@ -261,9 +261,6 @@ func validateRayCluster(admissionReview *admissionv1.AdmissionReview) (*admissio
 	klog.V(0).InfoS("validateRayCluster", "RayCluster", namespace+"/"+clusterName)
 	headlessServiceName = fmt.Sprintf("%s-%s", clusterName, headlessServiceSuffix)
 	workerGroupSpecs := raycluster.Spec.WorkerGroupSpecs
-	if workerGroupSpecs == nil {
-		return nil, errors.New("WorkerGroupSpecs not specified")
-	}
 	for i := 0; i < len(workerGroupSpecs); i++ {
 		workerGroupSpec := workerGroupSpecs[i]
 		if containerRequestingTPUs(workerGroupSpec.Template.Spec.Containers...) {


### PR DESCRIPTION
This PR removes an error returned by the validating admission webhook when a RayCluster is created with no workerGroupSpecs, making it pass-through for the RayCluster.

This PR has been tested with:

- [x]  Unit tests
- [x]  Manual tests