### PR TITLE
Change nodepool name to a placeholder

### DIFF
--- a/tutorials-and-examples/workflow-orchestration/dws-examples/job.yaml
+++ b/tutorials-and-examples/workflow-orchestration/dws-examples/job.yaml
@@ -14,7 +14,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        cloud.google.com/gke-nodepool: dws-nodepool
+        cloud.google.com/gke-nodepool: NODEPOOL_NAME
       tolerations:
       - key: "nvidia.com/gpu"
         operator: "Exists"


### PR DESCRIPTION
We are including this example in tutorials (https://cloud.devsite.corp.google.com/kubernetes-engine/docs/how-to/provisioningrequest#run_your_job). To enable the node pool name to be displayed as an editable variable in the tutorial I need to reformat it here.

Node pool is not defined in this example (it is only referenced) so the user might want to use any name. Having a placeholder makes it clearer.