### PR TITLE
Set the default GKE cluster type for jupyterhub to GKE Autopilot.

### DIFF
--- a/applications/jupyter/README.md
+++ b/applications/jupyter/README.md
@@ -20,7 +20,8 @@ This module deploys the following resources, once per user:
     - iap.googleapis.com (required when using authentication with Identity Aware Proxy)
 
 2. A functional GKE cluster.
-    - To create a new standard or autopilot cluster, follow the instructions under `infrastructure/README.md`
+    - To create a new standard or autopilot cluster, follow the instructions in [`infrastructure/README.md`](https://github.com/GoogleCloudPlatform/ai-on-gke/blob/main/infrastructure/README.md)
+    - Alternatively, you can set the `create_cluster` variable to true in `workloads.tfvars` to provision a new GKE cluster. This will default to creating a GKE Autopilot cluster; if you want to provision a standard cluster you must also set `autopilot_cluster` to false.
 
 3. This module is configured to use Identity Aware Proxy (IAP) as default authentication method for JupyterHub. It expects the brand & the OAuth consent configured in your org. You can check the details here: [OAuth consent screen](https://console.cloud.google.com/apis/credentials/consent)
 
@@ -116,7 +117,7 @@ gcloud auth application-default login
 1. Extract the randomly generated password for JupyterHub login
 
 ```
-terraform output password
+terraform output jupyterhub_password
 ```
 
 2. Setup port forwarding for the frontend: `kubectl port-forward service/proxy-public -n <namespace> 8081:80 &`, and open `localhost:8081` in a browser.

--- a/applications/jupyter/variables.tf
+++ b/applications/jupyter/variables.tf
@@ -150,7 +150,7 @@ variable "private_cluster" {
 
 variable "autopilot_cluster" {
   type    = bool
-  default = false
+  default = true
 }
 
 variable "cpu_pools" {

--- a/applications/jupyter/workloads.tfvars
+++ b/applications/jupyter/workloads.tfvars
@@ -13,13 +13,18 @@
 # limitations under the License.
 
 ##common variables
-## Need to pull this variables from tf output from previous platform stage
+## Need to pull this variables from tf output from previous infrastructure stage
 project_id = "<your project ID>"
 
-## this is required for terraform to connect to GKE master and deploy workloads
-create_cluster        = false # this flag will create a new standard public gke cluster in default network
-cluster_name          = "ml-cluster"
-cluster_location      = "us-central1"
+## This is required for terraform to connect to GKE cluster and deploy workloads.
+cluster_name     = "ml-cluster"
+cluster_location = "us-central1"
+
+## If terraform should create a new GKE cluster, fill in this section as well.
+##    By default, a public autopilot GKE cluster will be created in the default network.
+##    Set the autopilot_cluster variable to false to create a standard cluster instead.
+create_cluster        = false
+autopilot_cluster     = true
 cluster_membership_id = "" # required for private cluster, defaults to `cluster_name`
 
 #######################################################

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,6 +1,6 @@
 # Setup Infra
 
-Platform module (to be renamed to Infra), creates the GKE cluster & other related resources for the AI applications / workloads to be deployed on them. 
+The infrastructure module creates the GKE cluster and other related resources for the AI applications / workloads to be deployed on them. 
 
 1) Update the ```platform.tfvars``` file with the required configuration. Kindly refer to ```tfvars_examples``` for sample configuration.
 
@@ -21,12 +21,13 @@ Following service APIs are enabled,
 
 if not already enabled, use the following command:
 ```
-gcloud services enable container.googleapis.com gkehub.googleapis.com
+gcloud services enable container.googleapis.com gkehub.googleapis.com \
+  servicenetworking.googleapis.com cloudresourcemanager.googleapis.com
 ```
 ## Network Connectivity
 
 ### Private GKE Cluster with internal endpoint
-Default config in ```platform.tfvars``` creates a private GKE cluster with internal endpoints & cluster is added to project-scoped Anthos fleet.
+The default configuration in ```platform.tfvars``` creates a private GKE cluster with internal endpoints and adds the cluster to a project-scoped Anthos fleet.
 For admin access to cluster, Anthos Connect Gateway is used. 
 
 ### Private GKE Cluster with external endpoint


### PR DESCRIPTION
Also add instructions to use a standard cluster if preferred.