### PR TITLE
Add event filters for TPU Provisioner creation controller

### DIFF
--- a/tpu-provisioner/internal/controller/constants.go
+++ b/tpu-provisioner/internal/controller/constants.go
@@ -1,5 +1,0 @@
-package controller
-
-const (
-	DisableAutoProvisioningLabel = "tpu-provisioner.cloud.google.com/disable-autoprovisioning"
-)

--- a/tpu-provisioner/internal/controller/constants.go
+++ b/tpu-provisioner/internal/controller/constants.go
@@ -1,0 +1,5 @@
+package controller
+
+const (
+	DisableAutoProvisioningLabel = "tpu-provisioner.cloud.google.com/disable-autoprovisioning"
+)

--- a/tpu-provisioner/internal/controller/creation_controller.go
+++ b/tpu-provisioner/internal/controller/creation_controller.go
@@ -52,6 +52,7 @@ type PodCriteria struct {
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=pods/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=pods/finalizers,verbs=update
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *CreationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	lg := ctrllog.FromContext(ctx)
@@ -98,6 +99,7 @@ func (r *CreationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				isUnschedulable(pod) &&
 				doesRequestResource(pod, r.PodCriteria.ResourceType) &&
 				hasNodeSelectors(pod, cloud.GKETPUNodeSelector) &&
+				!autoProvisioningDisabled(pod) &&
 				!podDeleted(pod)
 		})).
 		Complete(r)

--- a/tpu-provisioner/internal/controller/creation_controller.go
+++ b/tpu-provisioner/internal/controller/creation_controller.go
@@ -34,6 +34,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
+// When this pod label is set to "true", the TPU provisioner will not reconcile the pod.
+const DisableAutoProvisioningLabel = "tpu-provisioner.cloud.google.com/disable-autoprovisioning"
+
 // CreationReconciler watches Pods and creates Node Pools.
 type CreationReconciler struct {
 	client.Client
@@ -93,7 +96,7 @@ func (r *CreationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			// Only reconcile pods which meet the conditions defined below.
 			pod, ok := object.(*corev1.Pod)
 			return ok &&
-				podPartOfJobSet(pod) &&
+				partOfJobSet(pod) &&
 				isLeaderPod(pod) &&
 				isPending(pod) &&
 				isUnschedulable(pod) &&

--- a/tpu-provisioner/internal/controller/creation_controller.go
+++ b/tpu-provisioner/internal/controller/creation_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/ai-on-gke/tpu-provisioner/internal/cloud"
 
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,6 +32,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
 // CreationReconciler watches Pods and creates Node Pools.
@@ -96,5 +98,34 @@ func (r *CreationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 func (r *CreationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Pod{}).
+		WithEventFilter(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			// Only reconcile JobSet leader pods which have not been scheduled and
+			// have not been marked for deletion.
+			pod, ok := object.(*corev1.Pod)
+			return ok && podPartOfJobSet(pod) && isLeaderPod(pod) && !podScheduled(pod) && !podDeleted(pod)
+		})).
 		Complete(r)
+}
+
+// podScheduled returns true if the pod has been scheduled, otherwise it returns false.
+func podScheduled(pod *corev1.Pod) bool {
+	return pod.Spec.NodeName != ""
+}
+
+// podDeleted returns true if hte pod has been marked for deletion, otherwise it returns false.
+func podDeleted(pod *corev1.Pod) bool {
+	return pod.DeletionTimestamp != nil
+}
+
+// podPartOfJobSet returns true if the pod is part of a JobSet, otherwise it returns false.
+func podPartOfJobSet(pod *corev1.Pod) bool {
+	// Annotation is from here:
+	// https://github.com/kubernetes-sigs/jobset/blob/6343f09b8a1851090586d0efca16c6ab68982318/api/jobset/v1alpha2/jobset_types.go#L23
+	return pod.Annotations["jobset.sigs.k8s.io/jobset-name"] != ""
+}
+
+// isLeaderPod returns true if the given pod is a leader pod (job completion index of 0),
+// otherwise it returns false.
+func isLeaderPod(pod *corev1.Pod) bool {
+	return pod.Annotations[batchv1.JobCompletionIndexAnnotation] == "0"
 }

--- a/tpu-provisioner/internal/controller/creation_controller_test.go
+++ b/tpu-provisioner/internal/controller/creation_controller_test.go
@@ -91,6 +91,10 @@ var _ = Describe("Creation controller", func() {
 			pod:    makeFollowerPod(),
 			status: makeRunningStatus(),
 		}),
+		Entry("pending leader pod with auto provisioned disabled annotation should not trigger node pool creation", &testCase{
+			pod:    makeLeaderPodAutoProvisioningDisabled(),
+			status: makePendingStatus(),
+		}),
 	)
 })
 
@@ -100,6 +104,12 @@ func makeLeaderPod() *corev1.Pod {
 
 func makeFollowerPod() *corev1.Pod {
 	return makePod(&makePodArgs{name: "follower-pod", completionIndex: "1"})
+}
+
+func makeLeaderPodAutoProvisioningDisabled() *corev1.Pod {
+	leaderPod := makeLeaderPod()
+	leaderPod.Annotations[DisableAutoProvisioningLabel] = "true"
+	return leaderPod
 }
 
 // makePendingStatus returns a pod status indicating it became unschedulable at the given time.

--- a/tpu-provisioner/internal/controller/creation_controller_test.go
+++ b/tpu-provisioner/internal/controller/creation_controller_test.go
@@ -7,116 +7,217 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apires "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Define utility constants for object names and testing timeouts/durations and intervals.
+const (
+	timeout  = time.Second * 10
+	duration = time.Second * 10
+	interval = time.Millisecond * 250
 )
 
 // +kubebuilder:docs-gen:collapse=Imports
 
 var _ = Describe("Creation controller", func() {
 
-	// Define utility constants for object names and testing timeouts/durations and intervals.
-	const (
-		timeout  = time.Second * 10
-		duration = time.Second * 10
-		interval = time.Millisecond * 250
-	)
+	// A test case contains a pod to create, the status we will update it to have, and whether or not
+	// we expect this pod to trigger a node pool creation.
+	type testCase struct {
+		pod                  *corev1.Pod
+		status               *corev1.PodStatus
+		wantNodePoolCreation bool
+	}
 
-	Context("When watching Pods", func() {
-		It("Should create a Node Pool when expected", func() {
+	DescribeTable("pods are created and go through a status update",
+		// Logic for each test case.
+		func(tc *testCase) {
 			ctx := context.Background()
-
-			By("Creating a non-pending Pod")
-
-			ignoreMePod := corev1.Pod{
+			// Create test namespace for each entry to isolate each test case.
+			ns := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "should-not-trigger-node-pool-creation",
-					Namespace: "default",
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "test",
-							Image: "test",
-						},
-					},
+					GenerateName: "test-ns-",
 				},
 			}
-			Expect(k8sClient.Create(ctx, &ignoreMePod)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
-			By("Creating a to-be pending Pod")
+			// Clean up temporary namespace after each test case.
+			defer func() {
+				Expect(deleteNamespace(ctx, k8sClient, ns)).To(Succeed())
+			}()
 
-			targetPod := corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "should-trigger-node-pool-creation",
-					Namespace: "default",
-				},
-				Spec: corev1.PodSpec{
-					NodeSelector: map[string]string{
-						"test-key":                          "test-val",
-						"cloud.google.com/gke-tpu-topology": "2x2x4",
-					},
-					Containers: []corev1.Container{
-						{
-							Name:  "test",
-							Image: "test",
-							Resources: corev1.ResourceRequirements{
-								Limits: map[corev1.ResourceName]apires.Quantity{
-									corev1.ResourceName(resourceName): {
-										Format: "1",
-									},
-								},
-								Requests: map[corev1.ResourceName]apires.Quantity{
-									corev1.ResourceName(resourceName): {
-										Format: "2",
-									},
-								},
+			// Create pod in test namespace.
+			pod := tc.pod
+			pod.Namespace = ns.Name
+
+			By(fmt.Sprintf("Creating pod %s", pod.Name))
+			Expect(k8sClient.Create(ctx, pod)).To(Succeed())
+
+			// Perform pod status update if required.
+			if tc.status != nil {
+				updatePodStatus(ctx, k8sClient, pod, *tc.status)
+			}
+
+			// Check node pool creation attempts.
+			if tc.wantNodePoolCreation {
+				By("Checking that the pod triggered a node pool creation attempt")
+				assertNodePoolCreationTriggered(pod)
+			} else {
+				By("Checking that pod did not trigger a node pool creation attempt")
+				assertNodePoolCreationNotTriggered(pod)
+			}
+		},
+		// Test cases.
+		Entry("pending leader pod should trigger node pool creation", &testCase{
+			pod:                  makeLeaderPod(),
+			status:               makePendingStatus(),
+			wantNodePoolCreation: true,
+		}),
+		Entry("non-pending leader pod should not trigger node pool creation", &testCase{
+			pod:    makeLeaderPod(),
+			status: makeRunningStatus(),
+		}),
+		Entry("pending follower pod should not trigger node pool creation", &testCase{
+			pod:    makeFollowerPod(),
+			status: makePendingStatus(),
+		}),
+		Entry("non-pending follower pod should not trigger node pool creation", &testCase{
+			pod:    makeFollowerPod(),
+			status: makeRunningStatus(),
+		}),
+	)
+})
+
+func makeLeaderPod() *corev1.Pod {
+	return makePod(&makePodArgs{name: "leader-pod", completionIndex: "0"})
+}
+
+func makeFollowerPod() *corev1.Pod {
+	return makePod(&makePodArgs{name: "follower-pod", completionIndex: "1"})
+}
+
+// makePendingStatus returns a pod status indicating it became unschedulable at the given time.
+func makePendingStatus() *corev1.PodStatus {
+	lastTransitionTime := metav1.Now()
+	return &corev1.PodStatus{
+		Phase: corev1.PodPending,
+		Conditions: []corev1.PodCondition{
+			{
+				Type:               corev1.PodScheduled,
+				Status:             corev1.ConditionFalse,
+				Reason:             corev1.PodReasonUnschedulable,
+				LastProbeTime:      lastTransitionTime,
+				LastTransitionTime: lastTransitionTime,
+				Message:            fmt.Sprintf("0/3 nodes are available: 3 Insufficient %s.", resourceName),
+			},
+		},
+	}
+}
+
+// makeRunningStatus returns a pod status indicating it started running at the given time.
+func makeRunningStatus() *corev1.PodStatus {
+	lastTransitionTime := metav1.Now()
+	return &corev1.PodStatus{
+		Phase: corev1.PodPending,
+		Conditions: []corev1.PodCondition{
+			{
+				Type:               corev1.PodScheduled,
+				Status:             corev1.ConditionTrue,
+				Reason:             corev1.PodReasonUnschedulable,
+				LastProbeTime:      lastTransitionTime,
+				LastTransitionTime: lastTransitionTime,
+			},
+		},
+	}
+}
+
+// updatePodStatus updates the pod status and verifies the status update request eventually succeeds.
+func updatePodStatus(ctx context.Context, k8sClient client.Client, pod *corev1.Pod, status corev1.PodStatus) {
+	// Fetch the created pod with latest resource version to update its status.
+	var createdPod corev1.Pod
+	Eventually(func() error {
+		nn := types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace}
+		return k8sClient.Get(ctx, nn, &createdPod)
+	}, timeout, interval).Should(Succeed())
+
+	By(fmt.Sprintf("Updating the pod status to %s", status.Phase))
+	createdPod.Status = status
+	Expect(k8sClient.Status().Update(ctx, &createdPod)).Should(Succeed())
+}
+
+// assertNodePoolCreationTriggered validates that the given pod did trigger a node pool
+// creation by checking that we eventually see the provider make a node pool creation attempt.
+func assertNodePoolCreationTriggered(pod *corev1.Pod) {
+	Eventually(func() bool {
+		return provider.getCreated(types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})
+	}, timeout, interval).Should(BeTrue())
+}
+
+// assertNodePoolCreationNotTriggered validates that the given pod did not trigger a node pool
+// creation by checking that we consistently see the provider has made no node pool creation attempts
+// for thet given pod.
+func assertNodePoolCreationNotTriggered(pod *corev1.Pod) {
+	Consistently(func() bool {
+		return provider.getCreated(types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})
+	}, timeout, interval).Should(BeFalse())
+}
+
+// deleteNamespace deletes the namespace and all the objects in it.
+func deleteNamespace(ctx context.Context, c client.Client, ns *corev1.Namespace) error {
+	if ns == nil {
+		return nil
+	}
+	if err := c.Delete(ctx, ns, client.PropagationPolicy(metav1.DeletePropagationForeground)); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+type makePodArgs struct {
+	name              string
+	completionIndex   string
+	deletionTimestamp *metav1.Time
+}
+
+func makePod(args *makePodArgs) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: args.name,
+			Annotations: map[string]string{
+				"jobset.sigs.k8s.io/jobset-name":     "test-js",
+				batchv1.JobCompletionIndexAnnotation: args.completionIndex,
+			},
+			DeletionTimestamp: args.deletionTimestamp,
+		},
+		Spec: corev1.PodSpec{
+			NodeSelector: map[string]string{
+				"test-key":                          "test-val",
+				"cloud.google.com/gke-tpu-topology": "2x2x4",
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "test",
+					Image: "test",
+					Resources: corev1.ResourceRequirements{
+						Limits: map[corev1.ResourceName]apires.Quantity{
+							corev1.ResourceName(resourceName): {
+								Format: "1",
+							},
+						},
+						Requests: map[corev1.ResourceName]apires.Quantity{
+							corev1.ResourceName(resourceName): {
+								Format: "2",
 							},
 						},
 					},
 				},
-			}
-			Expect(k8sClient.Create(ctx, &targetPod)).Should(Succeed())
-
-			By("Getting the created Pod in order to update its status")
-
-			var createdTargetPod corev1.Pod
-			Eventually(func() error {
-				nn := types.NamespacedName{Name: targetPod.Name, Namespace: targetPod.Namespace}
-				return k8sClient.Get(ctx, nn, &createdTargetPod)
-			}, timeout, interval).Should(Succeed())
-
-			createdTargetPod.Status = corev1.PodStatus{
-				Phase: corev1.PodPending,
-				Conditions: []corev1.PodCondition{
-					{
-						Type:               corev1.PodScheduled,
-						Status:             corev1.ConditionFalse,
-						Reason:             corev1.PodReasonUnschedulable,
-						LastProbeTime:      metav1.Time{Time: time.Now()},
-						LastTransitionTime: metav1.Time{Time: time.Now()},
-						Message:            fmt.Sprintf("0/3 nodes are available: 3 Insufficient %s.", resourceName),
-					},
-				},
-			}
-
-			By("Updating the created Pod to simulate a pending status")
-			Expect(k8sClient.Status().Update(ctx, &createdTargetPod)).Should(Succeed())
-
-			By("Checking that a Node Pool creation attempt was made")
-			// Ensure the pending Pod resulted in a Node Pool creation attempt.
-			Eventually(func() bool {
-				return provider.getCreated(types.NamespacedName{Name: targetPod.Name, Namespace: targetPod.Namespace})
-			}, timeout, interval).Should(BeTrue())
-
-			By("Checking that excessive Node Pool creation attempts were not made")
-			// Ensure the non-pending Pod did not result in a Node Pool creation attempt.
-			Consistently(func() bool {
-				return provider.getCreated(types.NamespacedName{Name: ignoreMePod.Name, Namespace: ignoreMePod.Namespace})
-			}, timeout, interval).Should(BeFalse())
-		})
-	})
-
-})
+			},
+		},
+	}
+}

--- a/tpu-provisioner/internal/controller/events.go
+++ b/tpu-provisioner/internal/controller/events.go
@@ -1,5 +1,0 @@
-package controller
-
-// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
-
-// See pkg cloud for events.

--- a/tpu-provisioner/internal/controller/pod_utils.go
+++ b/tpu-provisioner/internal/controller/pod_utils.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -39,4 +40,22 @@ func hasNodeSelectors(p *corev1.Pod, selectors ...string) bool {
 		}
 	}
 	return true
+}
+
+// podDeleted returns true if hte pod has been marked for deletion, otherwise it returns false.
+func podDeleted(pod *corev1.Pod) bool {
+	return pod.DeletionTimestamp != nil
+}
+
+// podPartOfJobSet returns true if the pod is part of a JobSet, otherwise it returns false.
+func podPartOfJobSet(pod *corev1.Pod) bool {
+	// Annotation is from here:
+	// https://github.com/kubernetes-sigs/jobset/blob/6343f09b8a1851090586d0efca16c6ab68982318/api/jobset/v1alpha2/jobset_types.go#L23
+	return pod.Annotations["jobset.sigs.k8s.io/jobset-name"] != ""
+}
+
+// isLeaderPod returns true if the given pod is a leader pod (job completion index of 0),
+// otherwise it returns false.
+func isLeaderPod(pod *corev1.Pod) bool {
+	return pod.Annotations[batchv1.JobCompletionIndexAnnotation] == "0"
 }

--- a/tpu-provisioner/internal/controller/pod_utils.go
+++ b/tpu-provisioner/internal/controller/pod_utils.go
@@ -47,8 +47,8 @@ func podDeleted(pod *corev1.Pod) bool {
 	return pod.DeletionTimestamp != nil
 }
 
-// podPartOfJobSet returns true if the pod is part of a JobSet, otherwise it returns false.
-func podPartOfJobSet(pod *corev1.Pod) bool {
+// partOfJobSet returns true if the pod is part of a JobSet, otherwise it returns false.
+func partOfJobSet(pod *corev1.Pod) bool {
 	// Annotation is from here:
 	// https://github.com/kubernetes-sigs/jobset/blob/6343f09b8a1851090586d0efca16c6ab68982318/api/jobset/v1alpha2/jobset_types.go#L23
 	return pod.Annotations["jobset.sigs.k8s.io/jobset-name"] != ""

--- a/tpu-provisioner/internal/controller/pod_utils.go
+++ b/tpu-provisioner/internal/controller/pod_utils.go
@@ -59,3 +59,10 @@ func podPartOfJobSet(pod *corev1.Pod) bool {
 func isLeaderPod(pod *corev1.Pod) bool {
 	return pod.Annotations[batchv1.JobCompletionIndexAnnotation] == "0"
 }
+
+// autoProvisioningDisabled returns true if the pod has
+// "tpu-provisioner.cloud.google.com/disable-autoprovisioning=true"
+// set as a label or annotation. Otherwise, it returns false.
+func autoProvisioningDisabled(pod *corev1.Pod) bool {
+	return pod.Labels[DisableAutoProvisioningLabel] == "true" || pod.Annotations[DisableAutoProvisioningLabel] == "true"
+}


### PR DESCRIPTION
This change ensures the TPU Provisioner creation controller only reconciles pods matching the following conditions:

- Part of a JobSet
- Leader pod (job completion index 0)
- Not yet scheduled
- Not marked for deletion
- Pod does not have label `tpu-provisioner.cloud.google.com/disable-autoprovisioning=true`