### PR TITLE
Add private_cluster_configuration instead of enable_private_endpoint.…

### DIFF
--- a/benchmarks/infra/stage-1/README.md
+++ b/benchmarks/infra/stage-1/README.md
@@ -68,27 +68,60 @@ gcloud container fleet memberships get-credentials <cluster-name>
 kubectl get nodes
 ```
 
-<!-- BEGIN TFDOC -->
-## Variables
+<!-- BEGIN_TF_DOCS -->
+Copyright 2024 Google LLC
 
-| name | description | type | required | default |
-|---|---|:---:|:---:|:---:|
-| [cluster_name](variables.tf#L22) | Name of new or existing cluster. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L17) | Project id of existing or created project. | <code>string</code> | ✓ |  |
-| [cluster_options](variables.tf#L59) | Specific cluster configuration options | <code title="object&#40;&#123;&#10;  release_channel                       &#61; optional&#40;string, &#34;REGULAR&#34;&#41;&#10;  enable_backup_agent                   &#61; optional&#40;bool, false&#41;&#10;  enable_gcs_fuse_csi_driver            &#61; optional&#40;bool, false&#41;&#10;  enable_gcp_filestore_csi_driver       &#61; optional&#40;bool, false&#41;&#10;  enable_gce_persistent_disk_csi_driver &#61; optional&#40;bool, false&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [enable_private_endpoint](variables.tf#L39) | When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. | <code>bool</code> |  | <code>true</code> |
-| [filestore_storage](variables.tf#L96) | Filestore storage instances. If GKE deployment is regional, tier should be set to ENTERPRISE | <code title="map&#40;object&#40;&#123;&#10;  name        &#61; string&#10;  tier        &#61; string&#10;  capacity_gb &#61; number&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [gke_location](variables.tf#L33) | Region or zone used for cluster. | <code>string</code> |  | <code>&#34;us-central1-a&#34;</code> |
-| [nodepools](variables.tf#L71) | Nodepools for the cluster | <code title="map&#40;object&#40;&#123;&#10;  machine_type   &#61; optional&#40;string, &#34;n2-standard-2&#34;&#41;,&#10;  gke_version    &#61; optional&#40;string&#41;,&#10;  max_node_count &#61; optional&#40;number, 10&#41;,&#10;  min_node_count &#61; optional&#40;number, 1&#41;,&#10;&#10;&#10;  guest_accelerator &#61; optional&#40;object&#40;&#123;&#10;    type  &#61; optional&#40;string&#41;,&#10;    count &#61; optional&#40;number&#41;,&#10;    gpu_driver &#61; optional&#40;object&#40;&#123;&#10;      version                    &#61; optional&#40;string, &#34;LATEST&#34;&#41;,&#10;      partition_size             &#61; optional&#40;string&#41;,&#10;      max_shared_clients_per_gpu &#61; optional&#40;number&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;&#10;&#10;&#10;  local_nvme_ssd_block_config &#61; optional&#40;object&#40;&#123;&#10;    local_ssd_count &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [region](variables.tf#L27) | Region used for network resources. | <code>string</code> |  | <code>&#34;us-central1&#34;</code> |
-| [vpc_create](variables.tf#L45) | Project configuration for newly created VPC. Leave null to use existing VPC, or defaults when project creation is required. | <code title="object&#40;&#123;&#10;  name                     &#61; optional&#40;string&#41;&#10;  subnet_name              &#61; optional&#40;string&#41;&#10;  primary_range_nodes      &#61; optional&#40;string, &#34;10.0.0.0&#47;24&#34;&#41;&#10;  secondary_range_pods     &#61; optional&#40;string, &#34;10.16.0.0&#47;20&#34;&#41;&#10;  secondary_range_services &#61; optional&#40;string, &#34;10.32.0.0&#47;24&#34;&#41;&#10;  enable_cloud_nat         &#61; optional&#40;bool, false&#41;&#10;  proxy_only_subnet        &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+No providers.
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_gke-infra"></a> [gke-infra](#module\_gke-infra) | ./modules/gke-infra/ | n/a |
+
+## Resources
+
+No resources.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of new or existing cluster. | `string` | n/a | yes |
+| <a name="input_cluster_options"></a> [cluster\_options](#input\_cluster\_options) | Specific cluster configuration options | <pre>object({<br>    release_channel                       = optional(string, "REGULAR")<br>    enable_backup_agent                   = optional(bool, false)<br>    enable_gcs_fuse_csi_driver            = optional(bool, false)<br>    enable_gcp_filestore_csi_driver       = optional(bool, false)<br>    enable_gce_persistent_disk_csi_driver = optional(bool, false)<br>  })</pre> | `{}` | no |
+| <a name="input_filestore_storage"></a> [filestore\_storage](#input\_filestore\_storage) | Filestore storage instances. If GKE deployment is regional, tier should be set to ENTERPRISE | <pre>map(object({<br>    name        = string<br>    tier        = string<br>    capacity_gb = number<br>  }))</pre> | `{}` | no |
+| <a name="input_gke_location"></a> [gke\_location](#input\_gke\_location) | Region or zone used for cluster. | `string` | `"us-central1-a"` | no |
+| <a name="input_nodepools"></a> [nodepools](#input\_nodepools) | Nodepools for the cluster | <pre>map(object({<br>    machine_type   = optional(string, "n2-standard-2"),<br>    gke_version    = optional(string),<br>    max_node_count = optional(number, 10),<br>    min_node_count = optional(number, 1),<br><br>    guest_accelerator = optional(object({<br>      type  = optional(string),<br>      count = optional(number),<br>      gpu_driver = optional(object({<br>        version                    = optional(string, "LATEST"),<br>        partition_size             = optional(string),<br>        max_shared_clients_per_gpu = optional(number)<br>      }))<br>    }))<br><br>    ephemeral_ssd_block_config = optional(object({<br>      ephemeral_ssd_count = optional(number)<br>    }))<br><br>    local_nvme_ssd_block_config = optional(object({<br>      local_ssd_count = optional(number)<br>    }))<br>  }))</pre> | `{}` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix used for resource names. | `string` | `"ai-gke-0"` | no |
+| <a name="input_private_cluster_config"></a> [private\_cluster\_config](#input\_private\_cluster\_config) | Private cluster configuration. Default of {} configures a private\_cluster with the values in below object. Set to null to make cluster public, which can be used for simple kubectl access when debugging or learning but should not be used in production. | <pre>object({<br>    # Is overriden by above variable enable_private_endpoint<br>    enable_private_endpoint = optional(bool, true)<br>    master_global_access    = optional(bool, true)<br>  })</pre> | `{}` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id of existing or created project. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Region used for network resources. | `string` | `"us-central1"` | no |
+| <a name="input_vpc_create"></a> [vpc\_create](#input\_vpc\_create) | Project configuration for newly created VPC. Leave null to use existing VPC, or defaults when project creation is required. | <pre>object({<br>    name                     = optional(string)<br>    subnet_name              = optional(string)<br>    primary_range_nodes      = optional(string, "10.0.0.0/24")<br>    secondary_range_pods     = optional(string, "10.16.0.0/20")<br>    secondary_range_services = optional(string, "10.32.0.0/24")<br>    enable_cloud_nat         = optional(bool, false)<br>    proxy_only_subnet        = optional(string)<br>  })</pre> | `null` | no |
 
 ## Outputs
 
-| name | description | sensitive |
-|---|---|:---:|
-| [created_resources](outputs.tf#L17) | IDs of the resources created, if any. |  |
-| [fleet_host](outputs.tf#L27) | Fleet Connect Gateway host that can be used to configure the GKE provider. |  |
-| [get_credentials](outputs.tf#L32) | Run one of these commands to get cluster credentials. Credentials via fleet allow reaching private clusters without no direct connectivity. |  |
-| [project_id](outputs.tf#L22) | Project ID of where the GKE cluster is hosted |  |
-<!-- END TFDOC -->
+| Name | Description |
+|------|-------------|
+| <a name="output_created_resources"></a> [created\_resources](#output\_created\_resources) | IDs of the resources created, if any. |
+| <a name="output_fleet_host"></a> [fleet\_host](#output\_fleet\_host) | Fleet Connect Gateway host that can be used to configure the GKE provider. |
+| <a name="output_get_credentials"></a> [get\_credentials](#output\_get\_credentials) | Run one of these commands to get cluster credentials. Credentials via fleet allow reaching private clusters without no direct connectivity. |
+| <a name="output_project_id"></a> [project\_id](#output\_project\_id) | Project ID of where the GKE cluster is hosted |
+<!-- END_TF_DOCS -->

--- a/benchmarks/infra/stage-1/main.tf
+++ b/benchmarks/infra/stage-1/main.tf
@@ -31,6 +31,7 @@ module "gke-infra" {
 
   registry_create = true
 
+  private_cluster_config  = var.private_cluster_config
   enable_private_endpoint = var.enable_private_endpoint
 
   vpc_create = var.vpc_create

--- a/benchmarks/infra/stage-1/modules/gke-infra/README.md
+++ b/benchmarks/infra/stage-1/modules/gke-infra/README.md
@@ -73,31 +73,81 @@ module "benchmark-0-infra" {
   }
 }
 ```
-<!-- BEGIN TFDOC -->
-## Variables
 
-| name | description | type | required | default |
-|---|---|:---:|:---:|:---:|
-| [cluster_name](variables.tf#L81) | Name of new or existing cluster. | <code>string</code> | ✓ |  |
-| [project_id](variables.tf#L101) | Project id of existing or created project. | <code>string</code> | ✓ |  |
-| [cluster_create](variables.tf#L17) | Cluster configuration for newly created cluster. Set to null to use existing cluster, or create using defaults in new project. | <code title="object&#40;&#123;&#10;  labels &#61; optional&#40;map&#40;string&#41;&#41;&#10;  master_authorized_ranges &#61; optional&#40;map&#40;string&#41;, &#123;&#10;    rfc-1918-10-8 &#61; &#34;10.0.0.0&#47;8&#34;&#10;  &#125;&#41;&#10;  master_ipv4_cidr_block &#61; optional&#40;string, &#34;172.16.255.0&#47;28&#34;&#41;&#10;  vpc &#61; optional&#40;object&#40;&#123;&#10;    id        &#61; string&#10;    subnet_id &#61; string&#10;    secondary_range_names &#61; optional&#40;object&#40;&#123;&#10;      pods     &#61; optional&#40;string, &#34;pods&#34;&#41;&#10;      services &#61; optional&#40;string, &#34;services&#34;&#41;&#10;    &#125;&#41;, &#123;&#125;&#41;&#10;  &#125;&#41;&#41;&#10;  version &#61; optional&#40;string&#41;&#10;  options &#61; optional&#40;object&#40;&#123;&#10;    release_channel                       &#61; optional&#40;string, &#34;REGULAR&#34;&#41;&#10;    enable_backup_agent                   &#61; optional&#40;bool, false&#41;&#10;    enable_gcs_fuse_csi_driver            &#61; optional&#40;bool, false&#41;&#10;    enable_gcp_filestore_csi_driver       &#61; optional&#40;bool, false&#41;&#10;    enable_gce_persistent_disk_csi_driver &#61; optional&#40;bool, false&#41;&#10;  &#125;&#41;, &#123;&#125;&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [enable_private_endpoint](variables.tf#L75) | When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. | <code>bool</code> |  | <code>true</code> |
-| [filestore_storage](variables.tf#L143) | Filestore storage instances. If GKE deployment is regional, tier should be set to ENTERPRISE | <code title="map&#40;object&#40;&#123;&#10;  name        &#61; string&#10;  tier        &#61; string&#10;  capacity_gb &#61; number&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [fleet_project_id](variables.tf#L88) | GKE Fleet project id. If null cluster project will also be used for fleet. | <code>string</code> |  | <code>null</code> |
-| [gke_location](variables.tf#L112) | Region or zone used for cluster. | <code>string</code> |  | <code>&#34;us-central1-a&#34;</code> |
-| [nodepools](variables.tf#L118) | Nodepools for the cluster | <code title="map&#40;object&#40;&#123;&#10;  machine_type   &#61; optional&#40;string, &#34;n2-standard-2&#34;&#41;,&#10;  gke_version    &#61; optional&#40;string&#41;,&#10;  max_node_count &#61; optional&#40;number, 10&#41;,&#10;  min_node_count &#61; optional&#40;number, 1&#41;,&#10;&#10;&#10;  guest_accelerator &#61; optional&#40;object&#40;&#123;&#10;    type  &#61; optional&#40;string&#41;,&#10;    count &#61; optional&#40;number&#41;,&#10;    gpu_driver &#61; optional&#40;object&#40;&#123;&#10;      version                    &#61; string&#10;      partition_size             &#61; optional&#40;string&#41;&#10;      max_shared_clients_per_gpu &#61; optional&#40;number&#41;&#10;    &#125;&#41;&#41;&#10;  &#125;&#41;&#41;&#10;&#10;&#10;  local_nvme_ssd_block_config &#61; optional&#40;object&#40;&#123;&#10;    local_ssd_count &#61; optional&#40;number&#41;&#10;  &#125;&#41;&#41;&#10;&#125;&#41;&#41;">map&#40;object&#40;&#123;&#8230;&#125;&#41;&#41;</code> |  | <code>&#123;&#125;</code> |
-| [prefix](variables.tf#L94) | Prefix used for resource names. | <code>string</code> |  | <code>&#34;ai-gke-0&#34;</code> |
-| [project_create](variables.tf#L45) | Project configuration for newly created project. Leave null to use existing project. Project creation forces VPC and cluster creation. | <code title="object&#40;&#123;&#10;  billing_account &#61; string&#10;  parent          &#61; optional&#40;string&#41;&#10;  shared_vpc_host &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
-| [region](variables.tf#L106) | Region used for network resources. | <code>string</code> |  | <code>&#34;us-central1&#34;</code> |
-| [registry_create](variables.tf#L55) | Create remote Docker Artifact Registry. | <code>bool</code> |  | <code>true</code> |
-| [vpc_create](variables.tf#L61) | Project configuration for newly created VPC. Leave null to use existing VPC, or defaults when project creation is required. | <code title="object&#40;&#123;&#10;  name                     &#61; optional&#40;string&#41;&#10;  subnet_name              &#61; optional&#40;string&#41;&#10;  primary_range_nodes      &#61; optional&#40;string, &#34;10.0.0.0&#47;24&#34;&#41;&#10;  secondary_range_pods     &#61; optional&#40;string, &#34;10.16.0.0&#47;20&#34;&#41;&#10;  secondary_range_services &#61; optional&#40;string, &#34;10.32.0.0&#47;24&#34;&#41;&#10;  enable_cloud_nat         &#61; optional&#40;bool, false&#41;&#10;  proxy_only_subnet        &#61; optional&#40;string&#41;&#10;&#125;&#41;">object&#40;&#123;&#8230;&#125;&#41;</code> |  | <code>null</code> |
+<!-- BEGIN_TF_DOCS -->
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_cluster-autopilot"></a> [cluster-autopilot](#module\_cluster-autopilot) | git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/gke-cluster-autopilot | v30.0.0&depth=1 |
+| <a name="module_cluster-nodepool"></a> [cluster-nodepool](#module\_cluster-nodepool) | git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/gke-nodepool | v30.0.0&depth=1 |
+| <a name="module_cluster-service-account"></a> [cluster-service-account](#module\_cluster-service-account) | git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/iam-service-account | v30.0.0&depth=1 |
+| <a name="module_cluster-standard"></a> [cluster-standard](#module\_cluster-standard) | git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/gke-cluster-standard | v30.0.0&depth=1 |
+| <a name="module_fleet"></a> [fleet](#module\_fleet) | git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/gke-hub | v30.0.0&depth=1 |
+| <a name="module_fleet-project"></a> [fleet-project](#module\_fleet-project) | git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/project | v30.0.0&depth=1 |
+| <a name="module_nat"></a> [nat](#module\_nat) | git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/net-cloudnat | v30.0.0&depth=1 |
+| <a name="module_project"></a> [project](#module\_project) | git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/project | v30.0.0&depth=1 |
+| <a name="module_registry"></a> [registry](#module\_registry) | git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/artifact-registry | v30.0.0&depth=1 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | git::https://github.com/GoogleCloudPlatform/cloud-foundation-fabric.git//modules/net-vpc | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_filestore_instance.instance](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/filestore_instance) | resource |
+| [google_container_cluster.cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_create"></a> [cluster\_create](#input\_cluster\_create) | Cluster configuration for newly created cluster. Set to null to use existing cluster, or create using defaults in new project. | <pre>object({<br>    labels = optional(map(string))<br>    master_authorized_ranges = optional(map(string), {<br>      rfc-1918-10-8 = "10.0.0.0/8"<br>    })<br>    master_ipv4_cidr_block = optional(string, "172.16.255.0/28")<br>    vpc = optional(object({<br>      id        = string<br>      subnet_id = string<br>      secondary_range_names = optional(object({<br>        pods     = optional(string, "pods")<br>        services = optional(string, "services")<br>      }), {})<br>    }))<br>    version = optional(string)<br>    options = optional(object({<br>      release_channel                       = optional(string, "REGULAR")<br>      enable_backup_agent                   = optional(bool, false)<br>      dns_cache                             = optional(bool, true)<br>      enable_gcs_fuse_csi_driver            = optional(bool, false)<br>      enable_gcp_filestore_csi_driver       = optional(bool, false)<br>      enable_gce_persistent_disk_csi_driver = optional(bool, false)<br>    }), {})<br>  })</pre> | `null` | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | Name of new or existing cluster. | `string` | n/a | yes |
+| <a name="input_enable_private_endpoint"></a> [enable\_private\_endpoint](#input\_enable\_private\_endpoint) | When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled. | `bool` | `true` | no |
+| <a name="input_filestore_storage"></a> [filestore\_storage](#input\_filestore\_storage) | Filestore storage instances. If GKE deployment is regional, tier should be set to ENTERPRISE | <pre>map(object({<br>    name        = string<br>    tier        = string<br>    capacity_gb = number<br>  }))</pre> | `{}` | no |
+| <a name="input_fleet_project_id"></a> [fleet\_project\_id](#input\_fleet\_project\_id) | GKE Fleet project id. If null cluster project will also be used for fleet. | `string` | `null` | no |
+| <a name="input_gke_autopilot"></a> [gke\_autopilot](#input\_gke\_autopilot) | Create GKE Autopiot cluster | `bool` | `false` | no |
+| <a name="input_gke_location"></a> [gke\_location](#input\_gke\_location) | Region or zone used for cluster. | `string` | `"us-central1-a"` | no |
+| <a name="input_node_locations"></a> [node\_locations](#input\_node\_locations) | Zones in which the GKE Autopilot cluster's nodes are located. | `list(string)` | `[]` | no |
+| <a name="input_nodepools"></a> [nodepools](#input\_nodepools) | Nodepools for the GKE Standard cluster | <pre>map(object({<br>    machine_type   = optional(string, "n2-standard-2"),<br>    gke_version    = optional(string),<br>    max_node_count = optional(number, 10),<br>    min_node_count = optional(number, 1),<br><br>    guest_accelerator = optional(object({<br>      type  = optional(string),<br>      count = optional(number),<br>      gpu_driver = optional(object({<br>        version                    = string<br>        partition_size             = optional(string)<br>        max_shared_clients_per_gpu = optional(number)<br>      }))<br>    }))<br><br>    ephemeral_ssd_block_config = optional(object({<br>      ephemeral_ssd_count = optional(number)<br>    }))<br><br>    local_nvme_ssd_block_config = optional(object({<br>      local_ssd_count = optional(number)<br>    }))<br>  }))</pre> | `{}` | no |
+| <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix used for resource names. | `string` | `"ai-gke-0"` | no |
+| <a name="input_private_cluster_config"></a> [private\_cluster\_config](#input\_private\_cluster\_config) | Private cluster configuration. Default of {} configures a private\_cluster with the values in below object. Set to null to make cluster public, which can be used for simple kubectl access when debugging or learning but should not be used in production. | <pre>object({<br>    # Is overriden by above variable enable_private_endpoint<br>    enable_private_endpoint = optional(bool, true)<br>    master_global_access    = optional(bool, true)<br>  })</pre> | `{}` | no |
+| <a name="input_project_create"></a> [project\_create](#input\_project\_create) | Project configuration for newly created project. Leave null to use existing project. Project creation forces VPC and cluster creation. | <pre>object({<br>    billing_account = string<br>    parent          = optional(string)<br>    shared_vpc_host = optional(string)<br>  })</pre> | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id of existing or created project. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | Region used for network resources. | `string` | `"us-central1"` | no |
+| <a name="input_registry_create"></a> [registry\_create](#input\_registry\_create) | Create remote Docker Artifact Registry. | `bool` | `true` | no |
+| <a name="input_vpc_create"></a> [vpc\_create](#input\_vpc\_create) | Project configuration for newly created VPC. Leave null to use existing VPC, or defaults when project creation is required. | <pre>object({<br>    name                     = optional(string)<br>    subnet_name              = optional(string)<br>    primary_range_nodes      = optional(string, "10.0.0.0/24")<br>    secondary_range_pods     = optional(string, "10.16.0.0/20")<br>    secondary_range_services = optional(string, "10.32.0.0/24")<br>    enable_cloud_nat         = optional(bool, false)<br>    proxy_only_subnet        = optional(string)<br>  })</pre> | `null` | no |
 
 ## Outputs
 
-| name | description | sensitive |
-|---|---|:---:|
-| [created_resources](outputs.tf#L17) | IDs of the resources created, if any. |  |
-| [fleet_host](outputs.tf#L49) | Fleet Connect Gateway host that can be used to configure the GKE provider. |  |
-| [get_credentials](outputs.tf#L58) | Run one of these commands to get cluster credentials. Credentials via fleet allow reaching private clusters without no direct connectivity. |  |
-| [project_id](outputs.tf#L44) | Project ID of where the GKE cluster is hosted |  |
-<!-- END TFDOC -->
+| Name | Description |
+|------|-------------|
+| <a name="output_created_resources"></a> [created\_resources](#output\_created\_resources) | IDs of the resources created, if any. |
+| <a name="output_fleet_host"></a> [fleet\_host](#output\_fleet\_host) | Fleet Connect Gateway host that can be used to configure the GKE provider. |
+| <a name="output_get_credentials"></a> [get\_credentials](#output\_get\_credentials) | Run one of these commands to get cluster credentials. Credentials via fleet allow reaching private clusters without no direct connectivity. |
+| <a name="output_project_id"></a> [project\_id](#output\_project\_id) | Project ID of where the GKE cluster is hosted |
+<!-- END_TF_DOCS -->

--- a/benchmarks/infra/stage-1/modules/gke-infra/cluster.tf
+++ b/benchmarks/infra/stage-1/modules/gke-infra/cluster.tf
@@ -84,10 +84,9 @@ module "cluster-standard" {
     master_authorized_ranges = var.cluster_create.master_authorized_ranges
     master_ipv4_cidr_block   = var.cluster_create.master_ipv4_cidr_block
   }
-  private_cluster_config = {
+  private_cluster_config = var.private_cluster_config == null ? null : merge(var.private_cluster_config, {
     enable_private_endpoint = var.enable_private_endpoint
-    master_global_access    = true
-  }
+  })
   labels          = var.cluster_create.labels
   release_channel = var.cluster_create.options.release_channel
   backup_configs = {
@@ -139,12 +138,9 @@ module "cluster-autopilot" {
     master_authorized_ranges = var.cluster_create.master_authorized_ranges
     master_ipv4_cidr_block   = var.cluster_create.master_ipv4_cidr_block
   }
-  private_cluster_config = {
-    enable_private_endpoint = var.enable_private_endpoint
-    master_global_access    = true
-  }
-  labels          = var.cluster_create.labels
-  release_channel = var.cluster_create.options.release_channel
+  private_cluster_config = var.private_cluster_config
+  labels                 = var.cluster_create.labels
+  release_channel        = var.cluster_create.options.release_channel
   backup_configs = {
     enable_backup_agent = var.cluster_create.options.enable_backup_agent
   }

--- a/benchmarks/infra/stage-1/modules/gke-infra/variables.tf
+++ b/benchmarks/infra/stage-1/modules/gke-infra/variables.tf
@@ -79,10 +79,24 @@ variable "vpc_create" {
   default = null
 }
 
-variable "enable_private_endpoint" {
-  description = "When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled."
-  type        = bool
-  default     = true
+variable "private_cluster_config" {
+  description = "Private cluster configuration. Default of {} configures a private_cluster with the values in below object. Set to null to make cluster public, which can be used for simple kubectl access when debugging or learning but should not be used in production."
+  type = object({
+    # When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled.
+    enable_private_endpoint = optional(bool, true)
+    master_global_access    = optional(bool, true)
+  })
+  default = {}
+}
+
+variable "private_cluster_config" {
+  description = "Private cluster configuration. Default of {} configures a private_cluster with the values in below object. Set to null to make cluster public, which can be used for simple kubectl access when debugging or learning but should not be used in production."
+  type = object({
+    # Is overriden by above variable enable_private_endpoint
+    enable_private_endpoint = optional(bool, true)
+    master_global_access    = optional(bool, true)
+  })
+  default = {}
 }
 
 variable "cluster_name" {

--- a/benchmarks/infra/stage-1/variables.tf
+++ b/benchmarks/infra/stage-1/variables.tf
@@ -36,10 +36,24 @@ variable "gke_location" {
   default     = "us-central1-a"
 }
 
-variable "enable_private_endpoint" {
-  description = "When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled."
-  type        = bool
-  default     = true
+variable "private_cluster_config" {
+  description = "Private cluster configuration. Default of {} configures a private_cluster with the values in below object. Set to null to make cluster public, which can be used for simple kubectl access when debugging or learning but should not be used in production."
+  type = object({
+    # When true, the cluster's private endpoint is used as the cluster endpoint and access through the public endpoint is disabled.
+    enable_private_endpoint = optional(bool, true)
+    master_global_access    = optional(bool, true)
+  })
+  default = {}
+}
+
+variable "private_cluster_config" {
+  description = "Private cluster configuration. Default of {} configures a private_cluster with the values in below object. Set to null to make cluster public, which can be used for simple kubectl access when debugging or learning but should not be used in production."
+  type = object({
+    # Is overriden by above variable enable_private_endpoint
+    enable_private_endpoint = optional(bool, true)
+    master_global_access    = optional(bool, true)
+  })
+  default = {}
 }
 
 variable "vpc_create" {


### PR DESCRIPTION
Purpose is to allow creating a public cluster just setting variables.

Tested with first a terraform apply setting `private_cluster_configuration = null` that created a public cluster, then swapping the value to {} which resulted in this terraform plan: https://imgur.com/a/PDy1roA