### PR TITLE
[TPU Provisioner] Fix dockerfile and bump go to 1.22

### DIFF
--- a/tpu-provisioner/Dockerfile
+++ b/tpu-provisioner/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.22 as builder
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -20,7 +20,7 @@ COPY internal/ internal/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -mod=vendor -a -o manager cmd/main.go
+RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/tpu-provisioner/go.mod
+++ b/tpu-provisioner/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleCloudPlatform/ai-on-gke/tpu-provisioner
 
-go 1.22.0
+go 1.22
 
 require (
 	cloud.google.com/go/compute/metadata v0.3.0


### PR DESCRIPTION
This PR fixes container image build errors:
- Remove `-mod=vendor` from build command in Dockerfile since we removed vendor files in #614 
- Fix Go version format