### PR TITLE
Guide for Maxtext Prometheus Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ deploy/
 
 # IDEs
 .idea/
+.vscode/
 
 # Python
 __pycache__/

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/README.md
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/README.md
@@ -229,3 +229,8 @@ kubectl port-forward svc/jetstream-svc 9000:9000
 ```
 
 To run benchmarking, pass in the flag `--server 127.0.0.1` when running the benchmarking script.
+
+
+### View Prometheus Metrics
+
+This example also includes a Prometheus server accessible on port 9090, this Prometheus server is configured to scrape metrics from pods with the label `maxengine-server`, within these pods the metrics are emitted by a prometheus client on port 9091. The Prometheus server can be accessed on port 9090 either by its [HTTP API](https://prometheus.io/docs/prometheus/latest/querying/api/) or its web UI. If needed, the metrics emitted by the client (being scraped by the server), can also be accessed via port 9091 on the `maxengine-server` pods.

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/README.md
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/README.md
@@ -233,4 +233,13 @@ To run benchmarking, pass in the flag `--server 127.0.0.1` when running the benc
 
 ### View Prometheus Metrics
 
-This example also includes a Prometheus server accessible on port 9090, this Prometheus server is configured to scrape metrics from pods with the label `maxengine-server`, within these pods the metrics are emitted by a prometheus client on port 9091. The Prometheus server can be accessed on port 9090 either by its [HTTP API](https://prometheus.io/docs/prometheus/latest/querying/api/) or its web UI. If needed, the metrics emitted by the client (being scraped by the server), can also be accessed via port 9091 on the `maxengine-server` pods.
+This example deployment also sets the `--prometheus_port` flag to 9090 for the maxengine server container. Setting this starts a prometheus client endpoint and emits metrics in this example on port 9090. Make HTTP requests to that endpoint and it will respond with the current value of whatever metrics are registered: 
+
+```
+# HELP jetstream_prefill_backlog_size Size of prefill queue
+# TYPE jetstream_prefill_backlog_size gauge
+jetstream_prefill_backlog_size{id="maxengine-server-58f8786f4c-4587n"} 57.0
+# HELP jetstream_slots_available_percentage The percentage of available slots in decode batch
+# TYPE jetstream_slots_available_percentage gauge
+jetstream_slots_available_percentage{id="maxengine-server-58f8786f4c-4587n",idx="0"} 0.78125
+```

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/deployment.yaml
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/deployment.yaml
@@ -98,9 +98,6 @@ data:
       - job_name: 'prometheus'
         kubernetes_sd_configs:
         - role: pod
-          namespaces:
-            names:
-              - "slabe"
           selectors:
             - role: pod
               label: "app=maxengine-server"

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/deployment.yaml
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/deployment.yaml
@@ -18,6 +18,9 @@ spec:
       containers:
       - name: maxengine-server
         image: us-docker.pkg.dev/cloud-tpu-images/inference/maxengine-server:v0.2.0
+        env:
+          - name: PROMETHEUS_ENABLED_ON_PORT
+            value: "9091"
         securityContext:
           privileged: true
         args:
@@ -35,6 +38,9 @@ spec:
         - load_parameters_path=gs://BUCKET_NAME/final/unscanned/gemma_7b-it/0/checkpoints/0/items
         ports:
         - containerPort: 9000
+          name: jetstream-grpc
+        - containerPort: 9091
+          name: prometheus-http
         resources:
           requests:
             google.com/tpu: 8
@@ -61,4 +67,92 @@ spec:
     name: jetstream-grpc
     port: 9000
     targetPort: 9000
-
+  - protocol: TCP
+    name: prometheus-http
+    port: 9091
+    targetPort: 9091
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-svc
+spec:
+  selector:
+    app: prometheus-server
+  ports:
+  - protocol: TCP
+    name: prometheus-client-http
+    port: 9090
+    targetPort: 9090
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-server-conf
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 500ms
+      evaluation_interval: 500ms
+    scrape_configs:
+      - job_name: 'prometheus'
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+              - "slabe"
+          selectors:
+            - role: pod
+              label: "app=maxengine-server"
+        relabel_configs:
+          - source_labels: [__address__]
+            action: replace
+            regex: ([^:]+):.*
+            replacement: $1:9091
+            target_label: __address__
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus-server
+  template:
+    metadata:
+      labels:
+        app: prometheus-server
+    spec:
+      containers:
+        - name: prometheus
+          image: prom/prometheus
+          ports:
+            - containerPort: 9090
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/prometheus
+      volumes:
+        - name: config-volume
+          configMap:
+            name: prometheus-server-conf
+            defaultMode: 420
+      serviceAccountName: prometheus
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: prometheus

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/deployment.yaml
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/deployment.yaml
@@ -18,9 +18,6 @@ spec:
       containers:
       - name: maxengine-server
         image: us-docker.pkg.dev/cloud-tpu-images/inference/maxengine-server:v0.2.0
-        env:
-          - name: PROMETHEUS_ENABLED_ON_PORT
-            value: "9091"
         securityContext:
           privileged: true
         args:
@@ -36,6 +33,7 @@ spec:
         - scan_layers=false
         - weight_dtype=bfloat16
         - load_parameters_path=gs://BUCKET_NAME/final/unscanned/gemma_7b-it/0/checkpoints/0/items
+        - prometheus_port=9090
         ports:
         - containerPort: 9000
           name: jetstream-grpc


### PR DESCRIPTION
Note: this guide requires new releases on MaxText and Jetstream repos to work, otherwise: modify the dockerfiles for maxtext-server and jetstream-http-server so that they use the latest masters of Jetsteam and MaxText repos since the demoed changes havent been picked up in a release in either repo. Also note MaxText depends on jetstream so a change will need to be made there too