### PR TITLE
Update docker file for pytorch

### DIFF
--- a/tutorials-and-examples/inference-servers/jetstream/pytorch/jetstream-pytorch-server/Dockerfile
+++ b/tutorials-and-examples/inference-servers/jetstream/pytorch/jetstream-pytorch-server/Dockerfile
@@ -4,8 +4,7 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PYTORCH_JETSTREAM_VERSION=jetstream-v0.2.0
-ENV JETSTREAM_VERSION=v0.2.0
+ENV PYTORCH_JETSTREAM_VERSION=v0.2.2
 
 RUN apt -y update && apt install -y --no-install-recommends \
     ca-certificates \
@@ -20,13 +19,6 @@ RUN git clone https://github.com/google/jetstream-pytorch.git && \
 cd /jetstream-pytorch && \
 git checkout ${PYTORCH_JETSTREAM_VERSION} && \
 bash install_everything.sh
-
-RUN git clone https://github.com/google/JetStream.git && \
-cd /JetStream && \
-git checkout ${JETSTREAM_VERSION} && \
-pip install -e .
-
-ENV PYTHONPATH=$PYTHONPATH:$(pwd)/deps/xla/experimental/torch_xla2:$(pwd)/JetStream:$(pwd)
 
 COPY jetstream_pytorch_server_entrypoint.sh /usr/bin/
 


### PR DESCRIPTION
when using jetstream-pytorch, one should not install Jetstream again. 
`install-everything.sh` script will install a particular version of Jetstream, please don't overwrite it.