### PR TITLE
few small fixes for http tgi route

### DIFF
--- a/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/run.sh
+++ b/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/run.sh
@@ -23,7 +23,7 @@ LOCUST_MODE=${LOCUST_MODE:-standalone}
 if [[ "$REQUEST_TYPE" = "grpc" ]]; then 
     LOCUST_OPTS="$LOCUST_OPTS GrpcBenchmarkUser --host=$TARGET_HOST"
 else
-    LOCUST_OPTS="$LOCUST_OPTS BenchmarkUser --host='http://$TARGET_HOST"
+    LOCUST_OPTS="$LOCUST_OPTS BenchmarkUser --host=http://$TARGET_HOST"
 fi
 
 if [[ "$LOCUST_MODE" = "master" ]]; then

--- a/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/tasks.py
+++ b/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/tasks.py
@@ -169,12 +169,12 @@ class BenchmarkUser(FastHttpUser):
         test_start_time = time.time()
         with self.client.post("/generate", headers=headers, json=request, catch_response=True) as resp:
             if resp.status_code == 200:
-                self.handle_successful_response(prompt, resp, test_start_time)
+                handle_successful_response(prompt, resp, test_start_time)
             else:
                 if resp.status_code == 0:
                     logging.error(
                         f"Failed request with invalid response code: {resp.status_code}. Due to requests.RequestException thrown by Session, caused by connection errors, timeouts or similar. Try increasing connection_timeout")
-                self.handle_failed_response(request, resp)
+                handle_failed_response(request, resp)
 
 def handle_successful_response(prompt, reponse, start_time):
     global model_params

--- a/benchmarks/benchmark/tools/locust-load-inference/sample-terraform.tfvars
+++ b/benchmarks/benchmark/tools/locust-load-inference/sample-terraform.tfvars
@@ -9,7 +9,7 @@ ksa       = "benchmark-ksa"
 
 # Locust service configuration 
 artifact_registry                        = "us-central1-docker.pkg.dev/$PROJECT_ID/ai-benchmark"
-inference_server_service                 = "http://tgi" # inference server service name
+inference_server_service                 = "tgi" # inference server service name
 locust_runner_kubernetes_service_account = "sample-runner-ksa"
 output_bucket                            = "benchmark-output"
 gcs_path                                 = "gs://${PROJECT_ID}-ai-gke-benchmark-fuse/ShareGPT_V3_unfiltered_cleaned_split_filtered_prompts.txt"
@@ -23,3 +23,5 @@ test_duration = 60
 # Increase test_users to allow more parallelism (especially when testing HPA)
 test_users = 1
 test_rate  = 5
+
+stop_timeout = 10800


### PR DESCRIPTION
A few additional fixes required for http route

Tested end to end, validated locust comes up, and successful response.

Updates:
- remove single ' in run.sh
- remove self. references to methods that no longer belong to http user class
- update recommended defaults in sample tfvars file to work for tgi http