### PR TITLE
[FIX] add GKE standard cluster GMP namespace to networkpolicy

### DIFF
--- a/modules/kuberay-cluster/main.tf
+++ b/modules/kuberay-cluster/main.tf
@@ -202,7 +202,7 @@ resource "kubernetes_network_policy" "kuberay-cluster-allow-network-policy" {
           match_expressions {
             key      = "kubernetes.io/metadata.name"
             operator = "In"
-            values   = [var.namespace, "gke-gmp-system"]
+            values   = [var.namespace, "gke-gmp-system", "gmp-system"]
           }
         }
       }


### PR DESCRIPTION
`gmp-system` is the namespace for GKE Standard clusters and `gke-gmp-system` for Autopilot clusters. Both are needed to make GMP working in different clusters.