### PR TITLE
Support vllm openai api server

### DIFF
--- a/benchmarks/inference-server/vllm/main.tf
+++ b/benchmarks/inference-server/vllm/main.tf
@@ -51,6 +51,7 @@ resource "kubernetes_manifest" "default" {
     namespace                      = var.namespace
     model_id                       = var.model_id
     gpu_count                      = var.gpu_count
+    swap_space                     = var.swap_space
     ksa                            = var.ksa
     hugging_face_token_secret_list = local.hugging_face_token_secret == null ? [] : [local.hugging_face_token_secret]
   }))

--- a/benchmarks/inference-server/vllm/manifest-templates/vllm.tftpl
+++ b/benchmarks/inference-server/vllm/manifest-templates/vllm.tftpl
@@ -52,8 +52,8 @@ spec:
           ports:
             - containerPort: 80
           image: "vllm/vllm-openai:v0.3.3"
-          command: ["python3", "-m", "vllm.entrypoints.api_server"]
-          args: ["--model", "${model_id}", "--tensor-parallel-size", "${gpu_count}", "--port", "80"]
+          command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
+          args: ["--model", "${model_id}", "--tensor-parallel-size", "${gpu_count}", "--port", "80", "--swap-space", "${swap_space}", "--disable-log-requests"]
           env:
             - name: PORT
               value: 80

--- a/benchmarks/inference-server/vllm/variables.tf
+++ b/benchmarks/inference-server/vllm/variables.tf
@@ -64,7 +64,7 @@ variable "swap_space" {
   nullable    = false
   default     = 4
   validation {
-    condition     = var.swap_space >= 0 
+    condition     = var.swap_space >= 0
     error_message = "swap space must be greater than or equal to 0."
   }
 }

--- a/benchmarks/inference-server/vllm/variables.tf
+++ b/benchmarks/inference-server/vllm/variables.tf
@@ -58,6 +58,17 @@ variable "gpu_count" {
   }
 }
 
+variable "swap_space" {
+  description = "The size (GiB) of CPU memory per GPU to use as swap space. See https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/llm.py#L65 for more details."
+  type        = number
+  nullable    = false
+  default     = 4
+  validation {
+    condition     = var.swap_space >= 0 
+    error_message = "swap space must be greater than or equal to 0."
+  }
+}
+
 variable "ksa" {
   description = "Kubernetes Service Account used for workload."
   type        = string


### PR DESCRIPTION
Per https://docs.vllm.ai/en/latest/serving/metrics.html, openai api server supports vLLM serving metrics by default. This PR therefore:
- updates api server from vanilla to openai mode
- adds `swap_space` argument suggested in vLLM [benchmarks](https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py#L6)

e2e tests with model `meta-llama/Llama-2-7b-chat-hf`. After [terraform apply](https://github.com/GoogleCloudPlatform/ai-on-gke/tree/main/benchmarks/inference-server/vllm#step-4-terraform-initialize-plan-and-apply):
```
# Get vLLM LB's external IP
$ VLLM_EXTERNAL_IP=`kubectl -n benchmark get service vllm -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`

# send a prompt to the endpoint
$ curl $VLLM_EXTERNAL_IP/v1/completions \
    -H "Content-Type: application/json" \
    -d '{
        "model": "meta-llama/Llama-2-7b-chat-hf",
        "prompt": "Seattle City is a",
        "max_tokens": 7,
        "temperature": 0
    }'

# Check prometheus metrics
$ curl $VLLM_EXTERNAL_IP/metrics/

...
# TYPE vllm:prompt_tokens_total counter
vllm:prompt_tokens_total{model_name="meta-llama/Llama-2-7b-chat-hf"} 9.0
...

 
```