### PR TITLE
Bump Jetstream, maxtext, jetstream-pytorch versions in Jetstream inference server guide

### DIFF
--- a/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/tasks.py
+++ b/benchmarks/benchmark/tools/locust-load-inference/locust-docker/locust-tasks/tasks.py
@@ -333,7 +333,7 @@ class GrpcBenchmarkUser(GrpcUser):
     def grpc_infer(self):
         prompt = get_random_prompt(self)
         request = jetstream_pb2.DecodeRequest(
-            additional_text=prompt,
+            text_content=jetstream_pb2.DecodeRequest.TextContent(text=request.prompt),
             priority=0,
             max_tokens=model_params["max_output_len"],
         )

--- a/tutorials-and-examples/inference-servers/checkpoints/README.md
+++ b/tutorials-and-examples/inference-servers/checkpoints/README.md
@@ -5,8 +5,8 @@ The `checkpoint_entrypoint.sh` script overviews how to convert your inference ch
 Build the checkpoint conversion Dockerfile
 ```
 docker build -t inference-checkpoint .
-docker tag inference-checkpoint us-central1-docker.pkg.dev/tpu-vm-gke-testing/slabe-maxtext/inference-checkpoint:v0.2.2
-docker push us-central1-docker.pkg.dev/tpu-vm-gke-testing/slabe-maxtext/inference-checkpoint:v0.2.2
+docker tag inference-checkpoint us-docker.pkg.dev/cloud-tpu-images/inference/inference-checkpoint:v0.2.2
+docker push us-docker.pkg.dev/cloud-tpu-images/inference/inference-checkpoint:v0.2.2
 ```
 
 Now you can use it in a [Kubernetes job](../jetstream/maxtext/single-host-inference/checkpoint-job.yaml) and pass the following arguments

--- a/tutorials-and-examples/inference-servers/checkpoints/README.md
+++ b/tutorials-and-examples/inference-servers/checkpoints/README.md
@@ -5,8 +5,8 @@ The `checkpoint_entrypoint.sh` script overviews how to convert your inference ch
 Build the checkpoint conversion Dockerfile
 ```
 docker build -t inference-checkpoint .
-docker tag inference-checkpoint us-docker.pkg.dev/cloud-tpu-images/inference/inference-checkpoint:v0.2.2
-docker push us-docker.pkg.dev/cloud-tpu-images/inference/inference-checkpoint:v0.2.2
+docker tag inference-checkpoint gcr.io/${PROJECT_ID}/inference-checkpoint:latest
+docker push gcr.io/${PROJECT_ID}/inference-checkpoint:latest
 ```
 
 Now you can use it in a [Kubernetes job](../jetstream/maxtext/single-host-inference/checkpoint-job.yaml) and pass the following arguments

--- a/tutorials-and-examples/inference-servers/checkpoints/README.md
+++ b/tutorials-and-examples/inference-servers/checkpoints/README.md
@@ -5,8 +5,8 @@ The `checkpoint_entrypoint.sh` script overviews how to convert your inference ch
 Build the checkpoint conversion Dockerfile
 ```
 docker build -t inference-checkpoint .
-docker tag inference-checkpoint gcr.io/${PROJECT_ID}/inference-checkpoint:latest
-docker push gcr.io/${PROJECT_ID}/inference-checkpoint:latest
+docker tag inference-checkpoint us-central1-docker.pkg.dev/tpu-vm-gke-testing/slabe-maxtext/inference-checkpoint:v0.2.2
+docker push us-central1-docker.pkg.dev/tpu-vm-gke-testing/slabe-maxtext/inference-checkpoint:v0.2.2
 ```
 
 Now you can use it in a [Kubernetes job](../jetstream/maxtext/single-host-inference/checkpoint-job.yaml) and pass the following arguments

--- a/tutorials-and-examples/inference-servers/checkpoints/checkpoint_converter.sh
+++ b/tutorials-and-examples/inference-servers/checkpoints/checkpoint_converter.sh
@@ -51,7 +51,7 @@ convert_maxtext_checkpoint() {
     MAXTEXT_VERSION=$5
 
     if [ -z $MAXTEXT_VERSION ]; then
-        MAXTEXT_VERSION=jetstream-v0.2.0
+        MAXTEXT_VERSION=prometheus-flag-import-fix
     fi
 
     git clone https://github.com/google/maxtext.git
@@ -77,10 +77,10 @@ convert_pytorch_checkpoint() {
     OUTPUT_CKPT_DIR=$3
     QUANTIZE=$4
     PYTORCH_VERSION=$5
-    JETSTREAM_VERSION=v0.2.0
+    JETSTREAM_VERSION=v0.2.2
 
     if [ -z $PYTORCH_VERSION ]; then
-        PYTORCH_VERSION=jetstream-v0.2.0
+        PYTORCH_VERSION=jetstream-v0.2.2
     fi
 
     CKPT_PATH="$(echo ${INPUT_CKPT_DIR} | awk -F'gs://' '{print $2}')"

--- a/tutorials-and-examples/inference-servers/checkpoints/checkpoint_converter.sh
+++ b/tutorials-and-examples/inference-servers/checkpoints/checkpoint_converter.sh
@@ -51,7 +51,7 @@ convert_maxtext_checkpoint() {
     MAXTEXT_VERSION=$5
 
     if [ -z $MAXTEXT_VERSION ]; then
-        MAXTEXT_VERSION=prometheus-flag-import-fix
+        MAXTEXT_VERSION=jetstream-v0.2.2
     fi
 
     git clone https://github.com/google/maxtext.git

--- a/tutorials-and-examples/inference-servers/jetstream/http-server/Dockerfile
+++ b/tutorials-and-examples/inference-servers/jetstream/http-server/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV JETSTREAM_VERSION=v0.2.0
+ENV JETSTREAM_VERSION=v0.2.2
 
 RUN apt -y update && apt install -y --no-install-recommends \
     ca-certificates \

--- a/tutorials-and-examples/inference-servers/jetstream/http-server/http_server.py
+++ b/tutorials-and-examples/inference-servers/jetstream/http-server/http_server.py
@@ -24,7 +24,6 @@ import fastapi
 import grpc
 from jetstream.core.proto import jetstream_pb2
 from jetstream.core.proto import jetstream_pb2_grpc
-from jetstream.tools.load_tester import collect_tokens
 import pydantic
 
 
@@ -82,5 +81,7 @@ async def generate_prompt(
   async with grpc.aio.insecure_channel("127.0.0.1:9000", options=options) as channel:
     stub = jetstream_pb2_grpc.OrchestratorStub(channel)
     response = stub.Decode(request)
-    tokens = collect_tokens(response, print_interim=False)
-    return "".join(tokens)
+    output = ""
+    async for token_list in response:
+      output += str(token_list.response[0])
+    return output

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/maxengine-server/Dockerfile
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/maxengine-server/Dockerfile
@@ -4,7 +4,7 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV MAXTEXT_VERSION=prometheus-flag-import-fix
+ENV MAXTEXT_VERSION=jetstream-v0.2.2
 ENV JETSTREAM_VERSION=v0.2.2
 
 RUN apt -y update && apt install -y --no-install-recommends \

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/maxengine-server/Dockerfile
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/maxengine-server/Dockerfile
@@ -5,7 +5,6 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV MAXTEXT_VERSION=jetstream-v0.2.2
-ENV JETSTREAM_VERSION=v0.2.2
 
 RUN apt -y update && apt install -y --no-install-recommends \
     ca-certificates \
@@ -16,16 +15,11 @@ RUN apt -y update && apt install -y --no-install-recommends \
 RUN update-alternatives --install \
     /usr/bin/python3 python3 /usr/bin/python3.10 1
 
-RUN git clone https://github.com/google/maxtext.git && \
-git clone https://github.com/google/JetStream.git
+RUN git clone https://github.com/google/maxtext.git
 
 RUN cd maxtext/ && \
 git checkout ${MAXTEXT_VERSION} && \
 bash setup.sh
-
-RUN cd /JetStream && \
-git checkout ${JETSTREAM_VERSION} && \
-pip install -e .
 
 COPY maxengine_server_entrypoint.sh /usr/bin/
 

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/maxengine-server/Dockerfile
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/maxengine-server/Dockerfile
@@ -4,8 +4,8 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV MAXTEXT_VERSION=jetstream-v0.2.0
-ENV JETSTREAM_VERSION=v0.2.0
+ENV MAXTEXT_VERSION=prometheus-flag-import-fix
+ENV JETSTREAM_VERSION=v0.2.2
 
 RUN apt -y update && apt install -y --no-install-recommends \
     ca-certificates \

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/checkpoint-job.yaml
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/checkpoint-job.yaml
@@ -9,9 +9,9 @@ spec:
       restartPolicy: Never
       containers:
       - name: inference-checkpoint
-        image: us-docker.pkg.dev/cloud-tpu-images/inference/inference-checkpoint:v0.2.0
+        image: us-central1-docker.pkg.dev/tpu-vm-gke-testing/slabe-maxtext/inference-checkpoint:v0.2.2
         args:
-        - -b=BUCKET_NAME
+        - -b=slabe-jetstream
         - -m=google/gemma/maxtext/7b-it/2
         volumeMounts:
         - mountPath: "/kaggle/"

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/checkpoint-job.yaml
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/checkpoint-job.yaml
@@ -9,9 +9,9 @@ spec:
       restartPolicy: Never
       containers:
       - name: inference-checkpoint
-        image: us-central1-docker.pkg.dev/tpu-vm-gke-testing/slabe-maxtext/inference-checkpoint:v0.2.2
+        image: us-docker.pkg.dev/cloud-tpu-images/inference/inference-checkpoint:v0.2.2
         args:
-        - -b=slabe-jetstream
+        - -b=BUCKET_NAME
         - -m=google/gemma/maxtext/7b-it/2
         volumeMounts:
         - mountPath: "/kaggle/"

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/deployment.yaml
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/deployment.yaml
@@ -17,7 +17,7 @@ spec:
         cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
       containers:
       - name: maxengine-server
-        image: us-central1-docker.pkg.dev/tpu-vm-gke-testing/slabe-maxtext/maxengine-server:v0.2.2
+        image: us-docker.pkg.dev/cloud-tpu-images/inference/maxengine-server:v0.2.0
         imagePullPolicy: Always
         securityContext:
           privileged: true
@@ -33,7 +33,7 @@ spec:
         - ici_tensor_parallelism=1
         - scan_layers=false
         - weight_dtype=bfloat16
-        - load_parameters_path=gs://slabe-jetstream/final/unscanned/gemma_7b-it/0/checkpoints/0/items
+        - load_parameters_path=gs://BUCKET_NAME/final/unscanned/gemma_7b-it/0/checkpoints/0/items
         - prometheus_port=9100
         ports:
         - containerPort: 9000
@@ -43,7 +43,7 @@ spec:
           limits:
             google.com/tpu: 8
       - name: jetstream-http
-        image: us-central1-docker.pkg.dev/tpu-vm-gke-testing/slabe-maxtext/jetstream-http:v0.2.2
+        image: us-docker.pkg.dev/cloud-tpu-images/inference/jetstream-http:v0.2.2
         imagePullPolicy: Always
         ports:
         - containerPort: 8000

--- a/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/deployment.yaml
+++ b/tutorials-and-examples/inference-servers/jetstream/maxtext/single-host-inference/deployment.yaml
@@ -17,7 +17,8 @@ spec:
         cloud.google.com/gke-tpu-accelerator: tpu-v5-lite-podslice
       containers:
       - name: maxengine-server
-        image: us-docker.pkg.dev/cloud-tpu-images/inference/maxengine-server:v0.2.0
+        image: us-central1-docker.pkg.dev/tpu-vm-gke-testing/slabe-maxtext/maxengine-server:v0.2.2
+        imagePullPolicy: Always
         securityContext:
           privileged: true
         args:
@@ -32,7 +33,8 @@ spec:
         - ici_tensor_parallelism=1
         - scan_layers=false
         - weight_dtype=bfloat16
-        - load_parameters_path=gs://BUCKET_NAME/final/unscanned/gemma_7b-it/0/checkpoints/0/items
+        - load_parameters_path=gs://slabe-jetstream/final/unscanned/gemma_7b-it/0/checkpoints/0/items
+        - prometheus_port=9100
         ports:
         - containerPort: 9000
         resources:
@@ -41,7 +43,8 @@ spec:
           limits:
             google.com/tpu: 8
       - name: jetstream-http
-        image: us-docker.pkg.dev/cloud-tpu-images/inference/jetstream-http:v0.2.0
+        image: us-central1-docker.pkg.dev/tpu-vm-gke-testing/slabe-maxtext/jetstream-http:v0.2.2
+        imagePullPolicy: Always
         ports:
         - containerPort: 8000
 ---

--- a/tutorials-and-examples/inference-servers/jetstream/pytorch/jetstream-pytorch-server/Dockerfile
+++ b/tutorials-and-examples/inference-servers/jetstream/pytorch/jetstream-pytorch-server/Dockerfile
@@ -4,8 +4,8 @@
 FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV PYTORCH_JETSTREAM_VERSION=jetstream-v0.2.0
-ENV JETSTREAM_VERSION=v0.2.0
+ENV PYTORCH_JETSTREAM_VERSION=jetstream-v0.2.2
+ENV JETSTREAM_VERSION=v0.2.2
 
 RUN apt -y update && apt install -y --no-install-recommends \
     ca-certificates \

--- a/tutorials-and-examples/inference-servers/jetstream/pytorch/jetstream-pytorch-server/Dockerfile
+++ b/tutorials-and-examples/inference-servers/jetstream/pytorch/jetstream-pytorch-server/Dockerfile
@@ -5,7 +5,6 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTORCH_JETSTREAM_VERSION=jetstream-v0.2.2
-ENV JETSTREAM_VERSION=v0.2.2
 
 RUN apt -y update && apt install -y --no-install-recommends \
     ca-certificates \
@@ -20,11 +19,6 @@ RUN git clone https://github.com/google/jetstream-pytorch.git && \
 cd /jetstream-pytorch && \
 git checkout ${PYTORCH_JETSTREAM_VERSION} && \
 bash install_everything.sh
-
-RUN git clone https://github.com/google/JetStream.git && \
-cd /JetStream && \
-git checkout ${JETSTREAM_VERSION} && \
-pip install -e .
 
 ENV PYTHONPATH=$PYTHONPATH:$(pwd)/deps/xla/experimental/torch_xla2:$(pwd)/JetStream:$(pwd)
 


### PR DESCRIPTION
Note: the `text_content=jetstream_pb2.DecodeRequest.TextContent(text=request.prompt)` change fixes a Jetstream change that broke making requests to the endpoint, the issue around decoding responses still exists, more to do there.