### PR TITLE
Simplify how default values are set for complex variables types.

### DIFF
--- a/applications/jupyter/variables.tf
+++ b/applications/jupyter/variables.tf
@@ -155,10 +155,10 @@ variable "autopilot_cluster" {
 
 variable "cpu_pools" {
   type = list(object({
-    name                   = string
-    machine_type           = string
+    name                   = optional(string, "cpu-pool")
+    machine_type           = optional(string, "n1-standard-16")
     node_locations         = optional(string, "")
-    autoscaling            = optional(bool, false)
+    autoscaling            = optional(bool, true)
     min_count              = optional(number, 1)
     max_count              = optional(number, 3)
     local_ssd_count        = optional(number, 0)
@@ -166,7 +166,7 @@ variable "cpu_pools" {
     disk_size_gb           = optional(number, 100)
     disk_type              = optional(string, "pd-standard")
     image_type             = optional(string, "COS_CONTAINERD")
-    enable_gcfs            = optional(bool, false)
+    enable_gcfs            = optional(bool, true)
     enable_gvnic           = optional(bool, false)
     logging_variant        = optional(string, "DEFAULT")
     auto_repair            = optional(bool, true)
@@ -176,16 +176,6 @@ variable "cpu_pools" {
     initial_node_count     = optional(number, 1)
     accelerator_count      = optional(number, 0)
   }))
-  default = [{
-    name         = "cpu-pool"
-    machine_type = "n1-standard-16"
-    autoscaling  = true
-    min_count    = 1
-    max_count    = 3
-    enable_gcfs  = true
-    disk_size_gb = 100
-    disk_type    = "pd-standard"
-  }]
 }
 
 variable "gpu_pools" {
@@ -213,7 +203,6 @@ variable "gpu_pools" {
     accelerator_type       = optional(string, "nvidia-tesla-t4")
     gpu_driver_version     = optional(string, "DEFAULT")
   }))
-  default = []
 }
 
 variable "goog_cm_deployment_name" {

--- a/applications/rag/variables.tf
+++ b/applications/rag/variables.tf
@@ -336,10 +336,10 @@ variable "cloudsql_instance_region" {
 
 variable "cpu_pools" {
   type = list(object({
-    name                   = string
-    machine_type           = string
+    name                   = optional(string, "cpu-pool")
+    machine_type           = optional(string, "n1-standard-16")
     node_locations         = optional(string, "")
-    autoscaling            = optional(bool, false)
+    autoscaling            = optional(bool, true)
     min_count              = optional(number, 1)
     max_count              = optional(number, 3)
     local_ssd_count        = optional(number, 0)
@@ -357,32 +357,22 @@ variable "cpu_pools" {
     initial_node_count     = optional(number, 1)
     accelerator_count      = optional(number, 0)
   }))
-  default = [{
-    name         = "cpu-pool"
-    machine_type = "n1-standard-16"
-    autoscaling  = true
-    min_count    = 1
-    max_count    = 3
-    enable_gcfs  = true
-    disk_size_gb = 100
-    disk_type    = "pd-standard"
-  }]
 }
 
 variable "gpu_pools" {
   type = list(object({
-    name                   = string
-    machine_type           = string
+    name                   = optional(string, "gpu-pool-l4")
+    machine_type           = optional(string, "g2-standard-24")
     node_locations         = optional(string, "")
-    autoscaling            = optional(bool, false)
+    autoscaling            = optional(bool, true)
     min_count              = optional(number, 1)
     max_count              = optional(number, 3)
     local_ssd_count        = optional(number, 0)
     spot                   = optional(bool, false)
     disk_size_gb           = optional(number, 200)
-    disk_type              = optional(string, "pd-standard")
+    disk_type              = optional(string, "pd-balanced")
     image_type             = optional(string, "COS_CONTAINERD")
-    enable_gcfs            = optional(bool, false)
+    enable_gcfs            = optional(bool, true)
     enable_gvnic           = optional(bool, false)
     logging_variant        = optional(string, "DEFAULT")
     auto_repair            = optional(bool, true)
@@ -390,23 +380,10 @@ variable "gpu_pools" {
     create_service_account = optional(bool, true)
     preemptible            = optional(bool, false)
     initial_node_count     = optional(number, 1)
-    accelerator_count      = optional(number, 0)
-    accelerator_type       = optional(string, "nvidia-tesla-t4")
+    accelerator_count      = optional(number, 2)
+    accelerator_type       = optional(string, "nvidia-l4")
     gpu_driver_version     = optional(string, "DEFAULT")
   }))
-  default = [{
-    name               = "gpu-pool-l4"
-    machine_type       = "g2-standard-24"
-    autoscaling        = true
-    min_count          = 1
-    max_count          = 3
-    disk_size_gb       = 200
-    disk_type          = "pd-balanced"
-    enable_gcfs        = true
-    accelerator_count  = 2
-    accelerator_type   = "nvidia-l4"
-    gpu_driver_version = "DEFAULT"
-  }]
 }
 
 variable "goog_cm_deployment_name" {

--- a/applications/ray/variables.tf
+++ b/applications/ray/variables.tf
@@ -110,10 +110,10 @@ variable "autopilot_cluster" {
 
 variable "cpu_pools" {
   type = list(object({
-    name                   = string
-    machine_type           = string
+    name                   = optional(string, "cpu-pool")
+    machine_type           = optional(string, "n1-standard-16")
     node_locations         = optional(string, "")
-    autoscaling            = optional(bool, false)
+    autoscaling            = optional(bool, true)
     min_count              = optional(number, 1)
     max_count              = optional(number, 3)
     local_ssd_count        = optional(number, 0)
@@ -121,7 +121,7 @@ variable "cpu_pools" {
     disk_size_gb           = optional(number, 100)
     disk_type              = optional(string, "pd-standard")
     image_type             = optional(string, "COS_CONTAINERD")
-    enable_gcfs            = optional(bool, false)
+    enable_gcfs            = optional(bool, true)
     enable_gvnic           = optional(bool, false)
     logging_variant        = optional(string, "DEFAULT")
     auto_repair            = optional(bool, true)
@@ -131,24 +131,14 @@ variable "cpu_pools" {
     initial_node_count     = optional(number, 1)
     accelerator_count      = optional(number, 0)
   }))
-  default = [{
-    name         = "cpu-pool"
-    machine_type = "n1-standard-16"
-    autoscaling  = true
-    min_count    = 1
-    max_count    = 3
-    enable_gcfs  = true
-    disk_size_gb = 100
-    disk_type    = "pd-standard"
-  }]
 }
 
 variable "gpu_pools" {
   type = list(object({
-    name                   = string
-    machine_type           = string
+    name                   = optional(string, "gpu-pool-l4")
+    machine_type           = optional(string, "g2-standard-24")
     node_locations         = optional(string, "")
-    autoscaling            = optional(bool, false)
+    autoscaling            = optional(bool, true)
     min_count              = optional(number, 1)
     max_count              = optional(number, 3)
     local_ssd_count        = optional(number, 0)
@@ -156,7 +146,7 @@ variable "gpu_pools" {
     disk_size_gb           = optional(number, 100)
     disk_type              = optional(string, "pd-standard")
     image_type             = optional(string, "COS_CONTAINERD")
-    enable_gcfs            = optional(bool, false)
+    enable_gcfs            = optional(bool, true)
     enable_gvnic           = optional(bool, false)
     logging_variant        = optional(string, "DEFAULT")
     auto_repair            = optional(bool, true)
@@ -164,23 +154,10 @@ variable "gpu_pools" {
     create_service_account = optional(bool, true)
     preemptible            = optional(bool, false)
     initial_node_count     = optional(number, 1)
-    accelerator_count      = optional(number, 0)
-    accelerator_type       = optional(string, "nvidia-tesla-t4")
+    accelerator_count      = optional(number, 2)
+    accelerator_type       = optional(string, "nvidia-l4")
     gpu_driver_version     = optional(string, "DEFAULT")
   }))
-  default = [{
-    name               = "gpu-pool-l4"
-    machine_type       = "g2-standard-24"
-    autoscaling        = true
-    min_count          = 1
-    max_count          = 3
-    disk_size_gb       = 100
-    disk_type          = "pd-balanced"
-    enable_gcfs        = true
-    accelerator_count  = 2
-    accelerator_type   = "nvidia-l4"
-    gpu_driver_version = "DEFAULT"
-  }]
 }
 
 variable "goog_cm_deployment_name" {


### PR DESCRIPTION
As documented in https://developer.hashicorp.com/terraform/language/expressions/type-constraints#optional-object-type-attributes

"Terraform applies the default value you specify in the optional modifier first and then later applies any nested default values to that attribute"

which means that the values specified in "optional" constraints was **always** overridden immediately by the defaults specified below.

This change simplifies how the defaults are set, solely using the optional defaults.