### PR TITLE
explicitly shutdown ray job after generating vector embedding

### DIFF
--- a/applications/rag/README.md
+++ b/applications/rag/README.md
@@ -117,8 +117,8 @@ gcloud container clusters get-credentials ${CLUSTER_NAME} --location=${CLUSTER_L
         * `KAGGLE_USERNAME`
         * `KAGGLE_KEY`
 
-4. Generate vector embeddings: Run all the cells in the notebook to generate vector embeddings for the Netflix shows dataset (https://www.kaggle.com/datasets/shivamb/netflix-shows) and store them in the `pgvector` CloudSQL instance via a Ray job.
-    * When the last cell says the job has succeeded (eg: `Job 'raysubmit_APungAw6TyB55qxk' succeeded`), the vector embeddings have been generated and we can launch the frontend chat interface. Note that running the job can take up to 10 minutes.
+4. Generate vector embeddings: Run all the cells in the notebook to generate vector embeddings for the Netflix shows dataset (https://www.kaggle.com/datasets/shivamb/netflix-shows) via a Ray job and store them in the `pgvector` CloudSQL instance.
+    * When the last cell succeeded, the vector embeddings have been generated and we can launch the frontend chat interface. Note that the Ray job can take up to 10 minutes to finish.
     * Ray may take several minutes to create the runtime environment. During this time, the job will appear to be missing (e.g. `Status message: PENDING`).
     * Connect to the Ray dashboard to check the job status or logs:
         - If IAP is disabled (`ray_dashboard_add_auth = false`):

--- a/applications/rag/example_notebooks/rag-kaggle-ray-sql-interactive.ipynb
+++ b/applications/rag/example_notebooks/rag-kaggle-ray-sql-interactive.ipynb
@@ -297,7 +297,8 @@
     "        \n",
     "    return results\n",
     "    \n",
-    "results = ray.get(ray_data_task.remote(ds_embed))"
+    "results = ray.get(ray_data_task.remote(ds_embed))\n",
+    "ray.shutdown()"
    ]
   },
   {


### PR DESCRIPTION
In the example Rag application, the Ray job takes hours to finish. The tasks that generates the vector embedding finished in minutes but the Ray job keeps running and only performs tasks `_StatsActor.get_datasets` and `AutoscalingRequester.purge_expired_requests` for hours, which seems useless. 
This PR explicitly shutdown the ray job immediately after the generating vector embedding task finishes. And update README accordingly.

Tested in my local setup. The output of the last cell looks right.
```
print query_results, the 1st one is the hit
('57219b18-e5df-4366-a9b3-852083418346', 'This is a Movie in Argentina, Italy called Food on the Go added at May 16, 2018 whose director is Mercedes Cordova and with cast:  released at 2017.  ... (70 characters truncated) ... reans and experts trace the migration of Italian cuisine and its evolution in the Americas, delving into the ideas of origin, diaspora and heritage..', '[-0.0036982908,-0.03353295,-0.06058844,-0.008014546,0.10171392,-0.003697397,0.04272337,0.081206605,0.062229678,-0.01643632,0.039833866,0.0026987398,0 ... (4364 characters truncated) ... 924,-0.032129854,0.02613346,-0.028509595,-0.0261783,-0.011453592,0.07154794,-0.0518277,-0.091720596,0.047575016,0.055083342,-0.0025463295,0.06186504]', 0.7999349594038734)
('e0ad5bc1-e864-4f92-aed4-16996ad52ebe', 'This is a TV Show in  called High on the Hog: How African American Cuisine Transformed America added at May 26, 2021 whose director is  and with cast ... (87 characters truncated) ...  Black food is American food. Chef and writer Stephen Satterfield traces the delicious, moving throughlines from Africa to Texas in this docuseries..', '[0.010396862,-0.0422456,-0.059644096,-0.029767286,0.07857882,-0.025493082,0.022488672,0.023633001,0.06280167,0.03388864,0.020709371,-0.007858674,0.05 ... (4371 characters truncated) ... 6,-0.0260153,0.004920043,-0.018494112,-0.019482553,-0.027946316,0.025011076,-0.06256453,-0.068404205,0.056842297,0.035770953,0.014213194,0.040339824]', 0.7918958415860997)
('40689a15-4a8a-4be3-9d10-7a86b92fe69e', "from 13 regions bringing their perspectives on what's funny around the world..", '[0.07243954,0.017648632,-0.09203372,-0.03591368,0.10213807,-0.010123513,-0.00072095933,0.050368052,0.07530339,-0.0011936418,0.043744657,0.007640193,0 ... (4369 characters truncated) ... 7,-0.034957796,0.039118342,-0.0026937209,-0.045485795,-0.02032757,0.01968761,-0.06041515,-0.060845774,0.025287135,0.09369182,0.049000513,0.043077126]', 0.789816712119193)
('1d2aa4fd-2d36-4b03-9649-2713671a0512', 'this narrative anthology series features both dark and funny takes on how people strive to stay connected while staying apart..', '[0.023701617,-0.028038831,-0.10309775,-0.059317723,0.06396295,-0.021222614,0.05192678,0.037370045,0.07259524,0.059750132,0.026217751,-0.0066554584,0. ... (4367 characters truncated) ... ,-0.045540433,-0.0048542665,-0.03355242,-0.036859497,0.0057089417,0.06524175,-0.026453663,-0.027213238,0.060332436,0.017344523,0.04314727,0.08851399]', 0.7889727102485605)
('435a5b54-af9a-44fc-ba54-f94f043187ed', 'School in this 1990s series set in Sydney..', '[0.019863933,0.0051751263,-0.045103464,-0.053507026,0.08517115,0.01985376,-0.012177017,0.03175673,0.103825815,-0.009082351,0.060796462,0.011132825,0. ... (4359 characters truncated) ... 17073,-0.077103235,0.054933283,0.015395214,-0.047672,-0.018109115,0.028561505,-0.030167062,-0.03817383,0.057372205,0.06782892,0.02370035,0.042269554]', 0.7888916479220026)
```