### PR TITLE
Add Kueue exemplary setup for reservation and DWS

### DIFF
--- a/tutorials-and-examples/workflow-orchestration/dws-examples/dws_and_reservation.yaml
+++ b/tutorials-and-examples/workflow-orchestration/dws-examples/dws_and_reservation.yaml
@@ -1,0 +1,73 @@
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: "reservation"
+spec:
+  nodeLabels:
+    cloud.google.com/gke-nodepool: "reservation-nodepool" # placeholder value
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ResourceFlavor
+metadata:
+  name: "dws"
+spec:
+  nodeLabels:
+    cloud.google.com/gke-nodepool: "dws-nodepool" # placeholder value
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ClusterQueue
+metadata:
+  name: "cluster-queue"
+spec:
+  namespaceSelector: {} # match all.
+  resourceGroups:
+  - coveredResources: ["cpu", "memory", "nvidia.com/gpu"]
+    flavors:
+    - name: "reservation" # first we try reservation
+      resources:
+      - name: "cpu"
+        nominalQuota: 9
+      - name: "memory"
+        nominalQuota: 36Gi
+      - name: "nvidia.com/gpu"
+        nominalQuota: 9
+    - name: "dws"         # if reservation is saturated we try dws
+      resources:
+      - name: "cpu"
+        nominalQuota: 10000   # Infinite quota.
+      - name: "memory"
+        nominalQuota: 10000Gi # Infinite quota.
+      - name: "nvidia.com/gpu"
+        nominalQuota: 10000   # Infinite quota.
+  admissionChecksStrategy:
+    admissionChecks:
+      - name: "dws-prov"
+        onFlavors: [dws]
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: LocalQueue
+metadata:
+  namespace: "default"
+  name: "user-queue"
+spec:
+  clusterQueue: "cluster-queue"
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: AdmissionCheck
+metadata:
+  name: dws-prov
+spec:
+  controllerName: kueue.x-k8s.io/provisioning-request
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: ProvisioningRequestConfig
+    name: dws-config
+---
+apiVersion: kueue.x-k8s.io/v1beta1
+kind: ProvisioningRequestConfig
+metadata:
+  name: dws-config
+spec:
+  provisioningClassName: queued-provisioning.gke.io
+  managedResources:
+  - nvidia.com/gpu

--- a/tutorials-and-examples/workflow-orchestration/dws-examples/job-without-node-selector.yaml
+++ b/tutorials-and-examples/workflow-orchestration/dws-examples/job-without-node-selector.yaml
@@ -1,0 +1,33 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: sample-job-
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: user-queue
+  annotations:
+    provreq.kueue.x-k8s.io/maxRunDurationSeconds: "600"
+spec:
+  parallelism: 1
+  completions: 1
+  suspend: true
+  template:
+    spec:
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: dummy-job
+        image: gcr.io/k8s-staging-perf-tests/sleep:v0.0.3
+        args: ["120s"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "100Mi"
+            nvidia.com/gpu: 1
+          limits:
+            cpu: "100m"
+            memory: "100Mi"
+            nvidia.com/gpu: 1
+      restartPolicy: Never


### PR DESCRIPTION
Added Kueue exemplary setup which uses reservation nodepool first, and if there is no capacity in reservation, then tries DWS.