### PR TITLE
Bump Ray TPU Webhook Image

### DIFF
--- a/ray-on-gke/tpu/kuberay-tpu-webhook/Makefile
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/Makefile
@@ -1,5 +1,7 @@
 # Image URL to use all building/pushing image targets  
-IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/kuberay-tpu-webhook:v1.1
+IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.0-gke.1
+
+# For europe, use europe-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.0-gke.1
   
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)  
 ifeq (,$(shell go env GOBIN))  

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/deployments/deployment.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/deployments/deployment.yaml
@@ -64,7 +64,7 @@ spec:
     spec:
       serviceAccountName: kuberay-tpu-webhook
       containers:
-        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/kuberay-tpu-webhook:v1.1
+        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.0-gke.1
           imagePullPolicy: Always
           name: kuberay-tpu-webhook
           args:

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/Chart.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.1.0"
+appVersion: "1.2.0"

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/values.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/values.yaml
@@ -6,8 +6,8 @@ tpuWebhook:
     name: ray-system
   
   image:
-    repository: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/kuberay-tpu-webhook
-    tag: v1.1
+    repository: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook
+    tag: v1.2.0-gke.1
     pullPolicy: Always
 
   deployment:


### PR DESCRIPTION
This PR bumps the Ray TPU Webhook image to the latest release, `v1.2.0`. This PR also changes the docker repository used to `us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook`, the repository built to by the automated pipeline.