### PR TITLE
Decrease scrape interval of metrics from TGI and DCGM to 15s in benchmark

### DIFF
--- a/benchmarks/inference-server/text-generation-inference/hpa-templates/dcgm-podmonitoring.yaml.tftpl
+++ b/benchmarks/inference-server/text-generation-inference/hpa-templates/dcgm-podmonitoring.yaml.tftpl
@@ -26,7 +26,7 @@ spec:
       app: nvidia-dcgm-exporter
   endpoints:
     - port: metrics
-      interval: 30s
+      interval: 15s
       metricRelabeling:
         # Change the DCGM metric name that we want to use in HPA to lowercase.
         # This is because HPA doesn't work with uppercase external metrics:

--- a/benchmarks/inference-server/text-generation-inference/monitoring-templates/tgi-podmonitoring.yaml.tftpl
+++ b/benchmarks/inference-server/text-generation-inference/monitoring-templates/tgi-podmonitoring.yaml.tftpl
@@ -9,4 +9,4 @@ spec:
       app: tgi
   endpoints:
   - port: 80
-    interval: 20s
+    interval: 15s

--- a/benchmarks/infra/stage-2/modules/gke-setup/modules/nvidia-dcgm/manifest-templates/02-ds-exporter.yaml
+++ b/benchmarks/infra/stage-2/modules/gke-setup/modules/nvidia-dcgm/manifest-templates/02-ds-exporter.yaml
@@ -54,7 +54,7 @@ spec:
           image: nvcr.io/nvidia/k8s/dcgm-exporter:3.1.8-3.1.5-ubuntu20.04
           command: ["/bin/bash", "-c"]
           args:
-            - hostname $NODE_NAME; dcgm-exporter --remote-hostengine-info $(NODE_IP) --collectors /etc/dcgm-exporter/counters.csv
+            - hostname $NODE_NAME; dcgm-exporter --remote-hostengine-info $(NODE_IP) --collect-interval 5000 --collectors /etc/dcgm-exporter/counters.csv
           ports:
             - name: metrics
               containerPort: 9400


### PR DESCRIPTION
Decrease scrape interval of metrics from TGI and DCGM from 30s to 15s in benchmark, this will allow for quicker autoscaling and also for better graphs when plotting the data.

To do this, we need to export data out of DCGM more often (here I have it set to 5s by setting the [`collect-interval`](https://github.com/NVIDIA/dcgm-exporter/blob/6d499c68a93677e8ccafe857427b09d4617ebfae/pkg/cmd/app.go#L56) flag).