### PR TITLE
[WIP] Add latency profile generator

### DIFF
--- a/benchmarks/benchmark/tools/latency-profile/README.md
+++ b/benchmarks/benchmark/tools/latency-profile/README.md
@@ -1,0 +1,209 @@
+# AI on GKE Benchmark Locust
+
+<!-- BEGIN TOC -->
+- [AI on GKE Benchmark Locust](#ai-on-gke-benchmark-locust)
+  - [Overview](#overview)
+  - [Instructions](#instructions)
+    - [Step 1: prepare benchmark prompts](#step-1-prepare-benchmark-prompts)
+    - [Step 2: create and give service account access to view dataset](#step-2-create-and-give-service-account-access-to-view-dataset)
+    - [Step 3: create output bucket](#step-3-create-output-bucket)
+    - [Step 4: create and give service account access to write to output gcs bucket](#step-4-create-and-give-service-account-access-to-write-to-output-gcs-bucket)
+    - [Step 5: create artifact repository for automated Locust docker build](#step-5-create-artifact-repository-for-automated-locust-docker-build)
+    - [Step 6: create and configure terraform.tfvars](#step-6-create-and-configure-terraformtfvars)
+      - [\[optional\] set-up credentials config with kubeconfig](#optional-set-up-credentials-config-with-kubeconfig)
+      - [\[optional\] set up secret token in Secret Manager](#optional-set-up-secret-token-in-secret-manager)
+    - [Step 7: login to gcloud](#step-7-login-to-gcloud)
+    - [Step 8: terraform initialize, plan and apply](#step-8-terraform-initialize-plan-and-apply)
+    - [Step 9: start an end to end benchmark](#step-9-start-an-end-to-end-benchmark)
+      - [option 1: initiate a single end to end Locust benchmark run via curl command](#option-1-initiate-a-single-end-to-end-locust-benchmark-run-via-curl-command)
+      - [option 2: interactive benchmark with locust web ui](#option-2-interactive-benchmark-with-locust-web-ui)
+    - [Step 10: viewing metrics](#step-10-viewing-metrics)
+    - [Additional Tips](#additional-tips)
+  - [Variables](#variables)
+<!-- END TOC -->
+
+## Overview
+
+This deploys the latency profile generator which measures the throuhghput and
+latency at various request rates for the model and model server of your choice. 
+
+It currently supports the following frameworks:
+- tensorrt_llm_triton
+- text generation inference (tgi)
+- vllm
+- sax
+
+## Instructions
+
+### Step 1: create output bucket
+
+If you followed steps from `../../infra/` for creating your cluster and extra
+resources, you will already have an output bucket created for you.
+If not, you will have to create and manage your own gcs bucket for storing
+benchmarking results.
+
+Set the `output_bucket` in your `terraform.tfvars` to this gcs bucket.
+
+### Step 2: create and give service account access to write to output gcs bucket
+
+The Latency profile generator requires storage.admin access to write output to
+the given output gcs bucket. If you followed steps in `../../infra`, then you
+already have a kubernetes and gcloud service account created that has the proper
+access to the created output bucket.
+
+To give viewer permissions on the gcs bucket to the gcloud service account,
+run the following:
+
+```
+gcloud storage buckets add-iam-policy-binding  gs://$OUTPUT_BUCKET/
+--member=serviceAccount:$GOOGLE_SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com --role=roles/storage.admin
+```
+
+Your kubernetes service account will inherit the reader permissions.
+
+You will set the `lantency_profile_kubernetes_service_account` in your
+`terraform.tfvars` to the kubernetes service account name.
+
+### Step 5: create artifact repository for automated Locust docker build
+
+The latency profile generator rebuilds the docker file on each terraform apply.
+The containers will be pushed to the given `artifact_registry`. This artifact
+repository is expected to already exist. If you created your cluster via
+`../../infra/`, then an artifact repository was created for you with the same
+name as the prefix in the same location as the cluster. You can also create your
+own via this command:
+
+```bash
+gcloud artifacts repositories create ai-benchmark --location=us-central1 --repository-format=docker
+```
+
+
+### Step 6: create and configure terraform.tfvars
+
+Create a `terraform.tfvars` file. `./sample-tfvars/tgi-sample.tfvars` is
+provided as an example file. You can copy the file as a starting point.
+Note that at a minimum you will have to change the existing
+`credentials_config`, `project_id`, and `artifact_registry`.
+
+```bash
+cp ./sample-tfvars/tgi-sample.tfvars terraform.tfvars
+```
+
+Fill out your `terraform.tfvars` with the desired model and server configuration, referring to the list of required and optional variables [here](#variables). The following variables are required:
+- `credentials_config` - credentials for cluster to deploy Locust benchmark tool on
+- `project_id` - project id for enabling dependent services for building locust artifacts
+- `artifact_registry` - artifact registry to upload locust artifacts to
+- `inference_server_service` - an accessible service name for inference workload to be benchmarked **(Note: If you are using a non-80 port for your model server service, it should be specified here. Example: `my-service-name:9000`)**
+- `tokenizer` - must match the model running on the inference workload to be benchmarked
+- `inference_server_framework` - the inference workload framework
+- `output_bucket` - gcs bucket to write benchmarking metrics to.
+- `latency_profile_kubernetes_service_account` - service account giving access to latency profile generator to write to `output_bucket`
+
+#### [optional] set-up credentials config with kubeconfig
+
+If your cluster has fleet management enabled, the existing `credentials_config`
+can use the fleet host credentials like this:
+
+```bash
+credentials_config = {
+  fleet_host = "https://connectgateway.googleapis.com/v1/projects/$PROJECT_NUMBER/locations/global/gkeMemberships/$CLUSTER_NAME"
+}
+```
+
+If your cluster does not have fleet management enabled, you can use your
+cluster's kubeconfig in the `credentials_config`. You must isolate your
+cluster's kubeconfig from other clusters in the default kube.config file.
+To do this, run the following command:
+
+```bash
+KUBECONFIG=~/.kube/${CLUSTER_NAME}-kube.config gcloud container clusters get-credentials $CLUSTER_NAME --location $CLUSTER_LOCATION
+```
+
+Then update your `terraform.tfvars` `credentials_config` to the following:
+
+```bash
+credentials_config = {
+  kubeconfig = {
+    path = "~/.kube/${CLUSTER_NAME}-kube.config"
+  }
+}
+```
+
+#### [optional] set up secret token in Secret Manager
+
+A model may require a security token to access it. For example, Llama2 from
+HuggingFace is a gated model that requires a
+[user access token](https://huggingface.co/docs/hub/en/security-tokens). If the
+model you want to run does not require this, skip this step.
+
+If you followed steps from `.../../infra/`, Secret Manager and the user access
+token should already be set up. If not, it is strongly recommended that you use
+Workload Identity and Secret Manager to access the user access tokens to avoid
+adding a plain text token into the terraform state. To do so, follow the
+instructions for
+[setting up a secret in Secret Manager here](https://cloud.google.com/kubernetes-engine/docs/tutorials/workload-identity-secrets).
+
+Once complete, you should add these related secret values to your
+`terraform.tfvars`:
+
+```bash
+# ex. "projects/sample-project/secrets/hugging_face_secret"
+hugging_face_secret = $SECRET_ID
+ # ex. 1
+hugging_face_secret_version =  $SECRET_VERSION
+```
+
+### Step 7: login to gcloud
+
+Run the following gcloud command for authorization:
+
+```bash
+gcloud auth application-default login
+```
+
+### Step 8: terraform initialize, plan and apply
+
+Run the following terraform commands:
+
+```bash
+# initialize terraform
+terraform init
+
+# verify changes
+terraform plan
+
+# apply changes
+terraform apply
+```
+
+A results file will appear in GCS bucket specified as `output_bucket` in input
+variables.
+
+<!-- BEGIN_TF_DOCS -->
+
+## Variables
+
+| Name                                                                                                                 | Description                                                                                                                 | Type                                                                                                                                                                                                        | Default              | Required |
+| -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | :------: |
+| <a name="input_artifact_registry"></a> [artifact\_registry](#input\_artifact\_registry)                              | Artifact registry for storing Locust container                                                                              | `string`                                                                                                                                                                                                    | `null`               |   yes    |
+| <a name="input_best_of"></a> [best\_of](#input\_best\_of)                                                            | Benchmark server configuration for best of.                                                                                 | `number`                                                                                                                                                                                                    | `1`                  |    no    |
+| <a name="input_credentials_config"></a> [credentials\_config](#input\_credentials\_config)                           | Configure how Terraform authenticates to the cluster.                                                                       | <pre>object({<br>    fleet_host = optional(string)<br>    kubeconfig = optional(object({<br>      context = optional(string)<br>      path    = optional(string, "~/.kube/config")<br>    }))<br>  })</pre> | n/a                  |   yes    |
+| <a name="input_gcs_path"></a> [gcs\_path](#input\_gcs\_path)                                                         | Benchmark server configuration for gcs\_path for downloading prompts.                                                       | `string`                                                                                                                                                                                                    | n/a                  |   yes    |
+| <a name="input_inference_server_framework"></a> [inference\_server\_framework](#input\_inference\_server\_framework) | Benchmark server configuration for inference server framework. Can be one of: vllm, tgi, tensorrt\_llm\_triton, sax, or jetstream  | `string`                                                                                                                                                                                                    | `"tgi"`              |   yes    |
+| <a name="input_request_type"></a> [request\_type](#input\_request\_type) | Protocol to use when making requests to the model server. Can be `grpc` or `http` | `string`                                                                                                                                                                                                    | `"http"`              |   no    |
+| <a name="input_inference_server_ip"></a> [inference\_server\_ip](#input\_inference\_server\_ip)                      | Inference server ip address                                                                                                 | `string`                                                                                                                                                                                                    | n/a                  |   yes    |
+| <a name="input_ksa"></a> [ksa](#input\_ksa)                                                                          | Kubernetes Service Account used for workload.                                                                               | `string`                                                                                                                                                                                                    | `"default"`          |    no    |
+| <a name="lantency_profile_kubernetes_service_account"></a> [locust\_runner\_kubernetes\_service\_account](#locust\_runner\_kubernetes\_service\_account)                                                                          | "Kubernetes Service Account to be used for Locust runner tool. Must have storage.admin access to output_bucket"                                                                              | `string`                                                                                                                                                                                                    | `"sample-runner-ksa"`          |    no    |
+| <a name="input_output_bucket"></a> [output\_bucket](#output\_bucket)                                                                          | "Bucket name for storing results"                                                                              | `string`                                                                                                                                                                                                    | n/a          |    yes    |
+| <a name="input_max_num_prompts"></a> [max\_num\_prompts](#input\_max\_num\_prompts)                                  | Benchmark server configuration for max number of prompts.                                                                   | `number`                                                                                                                                                                                                    | `1000`               |    no    |
+| <a name="input_max_output_len"></a> [max\_output\_len](#input\_max\_output\_len)                                     | Benchmark server configuration for max output length.                                                                       | `number`                                                                                                                                                                                                    | `1024`               |    no    |
+| <a name="input_max_prompt_len"></a> [max\_prompt\_len](#input\_max\_prompt\_len)                                     | Benchmark server configuration for max prompt length.                                                                       | `number`                                                                                                                                                                                                    | `1024`               |    no    |
+| <a name="input_num_locust_workers"></a> [num\_locust\_workers](#input\num\_locust\_workers)                          | Number of locust worker pods to deploy.                                                                                     | `number`                                                                                                                                                                                                    | `1`                  |    no    |
+| <a name="input_namespace"></a> [namespace](#input\_namespace)                                                        | Namespace used for model and benchmarking deployments.                                                                      | `string`                                                                                                                                                                                                    | `"default"`          |    no    |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id)                                                      | Project id of existing or created project.                                           | `string` | n/a                  |   yes    |
+| <a name="input_sax_model"></a> [sax\_model](#input\_sax\_model)                                                      | Benchmark server configuration for sax model. Only required if framework is sax.                                            | `string`                                                                                                                                                                                                    | `""`                 |    no    |
+| <a name="input_tokenizer"></a> [tokenizer](#input\_tokenizer)                                                        | Benchmark server configuration for tokenizer.                                                                               | `string`                                                                                                                                                                                                    | `"tiiuae/falcon-7b"` |   yes    |
+| <a name="input_use_beam_search"></a> [use\_beam\_search](#input\_use\_beam\_search)                                  | Benchmark server configuration for use beam search.                                                                         | `bool`                                                                                                                                                                                                      | `false`              |    no    |
+  <a name="huggingface_secret"></a> [huggingface_secret](#input\_huggingface_secret)                                  | Name of the secret holding the huggingface token. Stored in GCP Secrets Manager.                                                                          | `string`                                                                                                                                                                                                      | `huggingface-secret`              |    no   |
+  <a name="k8s_hf_secret"></a> [k8s_hf_secret](#input\_huggingface_secret)                                  | Name of the secret holding the huggingface token. Stored in K8s. Key is expected to be named: `HF_TOKEN`. See [here](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/#use-raw-data) for more.                                                                          | `string`                                                                                                                                                                                                      | `huggingface-secret`              |    no   |
+<!-- END_TF_DOCS -->

--- a/benchmarks/benchmark/tools/latency-profile/README.md
+++ b/benchmarks/benchmark/tools/latency-profile/README.md
@@ -1,26 +1,19 @@
-# AI on GKE Benchmark Locust
+# AI on GKE Benchmark Latency Profile Generator
 
-<!-- BEGIN TOC -->
-- [AI on GKE Benchmark Locust](#ai-on-gke-benchmark-locust)
-  - [Overview](#overview)
-  - [Instructions](#instructions)
-    - [Step 1: prepare benchmark prompts](#step-1-prepare-benchmark-prompts)
-    - [Step 2: create and give service account access to view dataset](#step-2-create-and-give-service-account-access-to-view-dataset)
-    - [Step 3: create output bucket](#step-3-create-output-bucket)
-    - [Step 4: create and give service account access to write to output gcs bucket](#step-4-create-and-give-service-account-access-to-write-to-output-gcs-bucket)
-    - [Step 5: create artifact repository for automated Locust docker build](#step-5-create-artifact-repository-for-automated-locust-docker-build)
-    - [Step 6: create and configure terraform.tfvars](#step-6-create-and-configure-terraformtfvars)
-      - [\[optional\] set-up credentials config with kubeconfig](#optional-set-up-credentials-config-with-kubeconfig)
-      - [\[optional\] set up secret token in Secret Manager](#optional-set-up-secret-token-in-secret-manager)
-    - [Step 7: login to gcloud](#step-7-login-to-gcloud)
-    - [Step 8: terraform initialize, plan and apply](#step-8-terraform-initialize-plan-and-apply)
-    - [Step 9: start an end to end benchmark](#step-9-start-an-end-to-end-benchmark)
-      - [option 1: initiate a single end to end Locust benchmark run via curl command](#option-1-initiate-a-single-end-to-end-locust-benchmark-run-via-curl-command)
-      - [option 2: interactive benchmark with locust web ui](#option-2-interactive-benchmark-with-locust-web-ui)
-    - [Step 10: viewing metrics](#step-10-viewing-metrics)
-    - [Additional Tips](#additional-tips)
-  - [Variables](#variables)
-<!-- END TOC -->
+<!-- TOC -->
+* [AI on GKE Benchmark Latency Profile Generator](#ai-on-gke-benchmark-latency-profile-generator)
+  * [Overview](#overview)
+  * [Instructions](#instructions)
+    * [Step 1: create output bucket](#step-1--create-output-bucket)
+    * [Step 2: create and give service account access to write to output gcs bucket](#step-2--create-and-give-service-account-access-to-write-to-output-gcs-bucket)
+    * [Step 5: create artifact repository for automated Latency Profile Generator docker build](#step-5--create-artifact-repository-for-automated-latency-profile-generator-docker-build)
+    * [Step 6: create and configure terraform.tfvars](#step-6--create-and-configure-terraformtfvars)
+      * [[optional] set-up credentials config with kubeconfig](#optional-set-up-credentials-config-with-kubeconfig)
+      * [[optional] set up secret token in Secret Manager](#optional-set-up-secret-token-in-secret-manager)
+    * [Step 7: login to gcloud](#step-7--login-to-gcloud)
+    * [Step 8: terraform initialize, plan and apply](#step-8--terraform-initialize-plan-and-apply)
+  * [Inputs](#inputs)
+<!-- TOC -->
 
 ## Overview
 
@@ -64,7 +57,7 @@ Your kubernetes service account will inherit the reader permissions.
 You will set the `lantency_profile_kubernetes_service_account` in your
 `terraform.tfvars` to the kubernetes service account name.
 
-### Step 5: create artifact repository for automated Locust docker build
+### Step 5: create artifact repository for automated Latency Profile Generator docker build
 
 The latency profile generator rebuilds the docker file on each terraform apply.
 The containers will be pushed to the given `artifact_registry`. This artifact
@@ -80,19 +73,19 @@ gcloud artifacts repositories create ai-benchmark --location=us-central1 --repos
 
 ### Step 6: create and configure terraform.tfvars
 
-Create a `terraform.tfvars` file. `./sample-tfvars/tgi-sample.tfvars` is
-provided as an example file. You can copy the file as a starting point.
+Create a `terraform.tfvars` file. `./sample-tfvars` is provided as an example
+file. You can copy the file as a starting point.
 Note that at a minimum you will have to change the existing
 `credentials_config`, `project_id`, and `artifact_registry`.
 
 ```bash
-cp ./sample-tfvars/tgi-sample.tfvars terraform.tfvars
+cp ./sample-tfvars terraform.tfvars
 ```
 
 Fill out your `terraform.tfvars` with the desired model and server configuration, referring to the list of required and optional variables [here](#variables). The following variables are required:
-- `credentials_config` - credentials for cluster to deploy Locust benchmark tool on
-- `project_id` - project id for enabling dependent services for building locust artifacts
-- `artifact_registry` - artifact registry to upload locust artifacts to
+- `credentials_config` - credentials for cluster to deploy Latency Profile Generator benchmark tool on
+- `project_id` - project id for enabling dependent services for building Latency Profile Generator artifacts
+- `artifact_registry` - artifact registry to upload Latency Profile Generator artifacts to
 - `inference_server_service` - an accessible service name for inference workload to be benchmarked **(Note: If you are using a non-80 port for your model server service, it should be specified here. Example: `my-service-name:9000`)**
 - `tokenizer` - must match the model running on the inference workload to be benchmarked
 - `inference_server_framework` - the inference workload framework
@@ -181,29 +174,26 @@ variables.
 
 <!-- BEGIN_TF_DOCS -->
 
-## Variables
+## Inputs
 
-| Name                                                                                                                 | Description                                                                                                                 | Type                                                                                                                                                                                                        | Default              | Required |
-| -------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | :------: |
-| <a name="input_artifact_registry"></a> [artifact\_registry](#input\_artifact\_registry)                              | Artifact registry for storing Locust container                                                                              | `string`                                                                                                                                                                                                    | `null`               |   yes    |
-| <a name="input_best_of"></a> [best\_of](#input\_best\_of)                                                            | Benchmark server configuration for best of.                                                                                 | `number`                                                                                                                                                                                                    | `1`                  |    no    |
-| <a name="input_credentials_config"></a> [credentials\_config](#input\_credentials\_config)                           | Configure how Terraform authenticates to the cluster.                                                                       | <pre>object({<br>    fleet_host = optional(string)<br>    kubeconfig = optional(object({<br>      context = optional(string)<br>      path    = optional(string, "~/.kube/config")<br>    }))<br>  })</pre> | n/a                  |   yes    |
-| <a name="input_gcs_path"></a> [gcs\_path](#input\_gcs\_path)                                                         | Benchmark server configuration for gcs\_path for downloading prompts.                                                       | `string`                                                                                                                                                                                                    | n/a                  |   yes    |
-| <a name="input_inference_server_framework"></a> [inference\_server\_framework](#input\_inference\_server\_framework) | Benchmark server configuration for inference server framework. Can be one of: vllm, tgi, tensorrt\_llm\_triton, sax, or jetstream  | `string`                                                                                                                                                                                                    | `"tgi"`              |   yes    |
-| <a name="input_request_type"></a> [request\_type](#input\_request\_type) | Protocol to use when making requests to the model server. Can be `grpc` or `http` | `string`                                                                                                                                                                                                    | `"http"`              |   no    |
-| <a name="input_inference_server_ip"></a> [inference\_server\_ip](#input\_inference\_server\_ip)                      | Inference server ip address                                                                                                 | `string`                                                                                                                                                                                                    | n/a                  |   yes    |
-| <a name="input_ksa"></a> [ksa](#input\_ksa)                                                                          | Kubernetes Service Account used for workload.                                                                               | `string`                                                                                                                                                                                                    | `"default"`          |    no    |
-| <a name="lantency_profile_kubernetes_service_account"></a> [locust\_runner\_kubernetes\_service\_account](#locust\_runner\_kubernetes\_service\_account)                                                                          | "Kubernetes Service Account to be used for Locust runner tool. Must have storage.admin access to output_bucket"                                                                              | `string`                                                                                                                                                                                                    | `"sample-runner-ksa"`          |    no    |
-| <a name="input_output_bucket"></a> [output\_bucket](#output\_bucket)                                                                          | "Bucket name for storing results"                                                                              | `string`                                                                                                                                                                                                    | n/a          |    yes    |
-| <a name="input_max_num_prompts"></a> [max\_num\_prompts](#input\_max\_num\_prompts)                                  | Benchmark server configuration for max number of prompts.                                                                   | `number`                                                                                                                                                                                                    | `1000`               |    no    |
-| <a name="input_max_output_len"></a> [max\_output\_len](#input\_max\_output\_len)                                     | Benchmark server configuration for max output length.                                                                       | `number`                                                                                                                                                                                                    | `1024`               |    no    |
-| <a name="input_max_prompt_len"></a> [max\_prompt\_len](#input\_max\_prompt\_len)                                     | Benchmark server configuration for max prompt length.                                                                       | `number`                                                                                                                                                                                                    | `1024`               |    no    |
-| <a name="input_num_locust_workers"></a> [num\_locust\_workers](#input\num\_locust\_workers)                          | Number of locust worker pods to deploy.                                                                                     | `number`                                                                                                                                                                                                    | `1`                  |    no    |
-| <a name="input_namespace"></a> [namespace](#input\_namespace)                                                        | Namespace used for model and benchmarking deployments.                                                                      | `string`                                                                                                                                                                                                    | `"default"`          |    no    |
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id)                                                      | Project id of existing or created project.                                           | `string` | n/a                  |   yes    |
-| <a name="input_sax_model"></a> [sax\_model](#input\_sax\_model)                                                      | Benchmark server configuration for sax model. Only required if framework is sax.                                            | `string`                                                                                                                                                                                                    | `""`                 |    no    |
-| <a name="input_tokenizer"></a> [tokenizer](#input\_tokenizer)                                                        | Benchmark server configuration for tokenizer.                                                                               | `string`                                                                                                                                                                                                    | `"tiiuae/falcon-7b"` |   yes    |
-| <a name="input_use_beam_search"></a> [use\_beam\_search](#input\_use\_beam\_search)                                  | Benchmark server configuration for use beam search.                                                                         | `bool`                                                                                                                                                                                                      | `false`              |    no    |
-  <a name="huggingface_secret"></a> [huggingface_secret](#input\_huggingface_secret)                                  | Name of the secret holding the huggingface token. Stored in GCP Secrets Manager.                                                                          | `string`                                                                                                                                                                                                      | `huggingface-secret`              |    no   |
-  <a name="k8s_hf_secret"></a> [k8s_hf_secret](#input\_huggingface_secret)                                  | Name of the secret holding the huggingface token. Stored in K8s. Key is expected to be named: `HF_TOKEN`. See [here](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl/#use-raw-data) for more.                                                                          | `string`                                                                                                                                                                                                      | `huggingface-secret`              |    no   |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_artifact_registry"></a> [artifact\_registry](#input\_artifact\_registry) | Artifact registry for storing Latency Profile Generator container. | `string` | `null` | no |
+| <a name="input_credentials_config"></a> [credentials\_config](#input\_credentials\_config) | Configure how Terraform authenticates to the cluster. | <pre>object({<br>    fleet_host = optional(string)<br>    kubeconfig = optional(object({<br>      context = optional(string)<br>      path    = optional(string, "~/.kube/config")<br>    }))<br>  })</pre> | n/a | yes |
+| <a name="input_hugging_face_secret"></a> [hugging\_face\_secret](#input\_hugging\_face\_secret) | name of the kubectl huggingface secret token; stored in Secret Manager. Security considerations: https://kubernetes.io/docs/concepts/security/secrets-good-practices/ | `string` | `null` | no |
+| <a name="input_hugging_face_secret_version"></a> [hugging\_face\_secret\_version](#input\_hugging\_face\_secret\_version) | Secret version in Secret Manager | `string` | `null` | no |
+| <a name="input_inference_server_framework"></a> [inference\_server\_framework](#input\_inference\_server\_framework) | Benchmark server configuration for inference server framework. Can be one of: vllm, tgi, tensorrt\_llm\_triton, sax | `string` | `"tgi"` | no |
+| <a name="input_inference_server_service"></a> [inference\_server\_service](#input\_inference\_server\_service) | Inference server service | `string` | n/a | yes |
+| <a name="input_k8s_hf_secret"></a> [k8s\_hf\_secret](#input\_k8s\_hf\_secret) | Name of secret for huggingface token; stored in k8s | `string` | `null` | no |
+| <a name="input_ksa"></a> [ksa](#input\_ksa) | Kubernetes Service Account used for workload. | `string` | `"default"` | no |
+| <a name="input_latency_profile_kubernetes_service_account"></a> [latency\_profile\_kubernetes\_service\_account](#input\_latency\_profile\_kubernetes\_service\_account) | Kubernetes Service Account to be used for the latency profile generator tool | `string` | `"sample-runner-ksa"` | no |
+| <a name="input_max_num_prompts"></a> [max\_num\_prompts](#input\_max\_num\_prompts) | Benchmark server configuration for max number of prompts. | `number` | `1000` | no |
+| <a name="input_max_output_len"></a> [max\_output\_len](#input\_max\_output\_len) | Benchmark server configuration for max output length. | `number` | `256` | no |
+| <a name="input_max_prompt_len"></a> [max\_prompt\_len](#input\_max\_prompt\_len) | Benchmark server configuration for max prompt length. | `number` | `256` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace used for model and benchmarking deployments. | `string` | `"default"` | no |
+| <a name="input_output_bucket"></a> [output\_bucket](#input\_output\_bucket) | Bucket name for storing results | `string` | n/a | yes |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | Project id of existing or created project. | `string` | n/a | yes |
+| <a name="input_templates_path"></a> [templates\_path](#input\_templates\_path) | Path where manifest templates will be read from. Set to null to use the default manifests | `string` | `null` | no |
+| <a name="input_tokenizer"></a> [tokenizer](#input\_tokenizer) | Benchmark server configuration for tokenizer. | `string` | `"tiiuae/falcon-7b"` | no |
+
 <!-- END_TF_DOCS -->

--- a/benchmarks/benchmark/tools/latency-profile/build.tf
+++ b/benchmarks/benchmark/tools/latency-profile/build.tf
@@ -1,0 +1,8 @@
+resource "null_resource" "build_and_push_image" {
+
+  depends_on = [resource.google_project_service.cloudbuild]
+  provisioner "local-exec" {
+    working_dir = path.module
+    command     = "gcloud builds submit --tag ${var.artifact_registry}/latency-profile:latest container"
+  }
+}

--- a/benchmarks/benchmark/tools/latency-profile/container/Dockerfile
+++ b/benchmarks/benchmark/tools/latency-profile/container/Dockerfile
@@ -1,0 +1,22 @@
+FROM nvidia/cuda:12.1.0-devel-ubuntu22.04 AS dev
+
+RUN apt-get update -y \
+    && apt-get install -y python3-pip git vim curl wget
+RUN pip3 install --upgrade pip
+RUN pip install packaging torch transformers
+WORKDIR /workspace
+
+# install build and runtime dependencies
+COPY requirements.txt requirements.txt
+RUN pip install -r requirements.txt
+
+RUN pip install -U "huggingface_hub[cli]"
+RUN pip install gsutil
+
+RUN wget https://huggingface.co/datasets/anon8231489123/ShareGPT_Vicuna_unfiltered/resolve/main/ShareGPT_V3_unfiltered_cleaned_split.json
+
+COPY benchmark_serving.py benchmark_serving.py
+COPY latency_throughput_curve.sh latency_throughput_curve.sh
+
+RUN chmod +x latency_throughput_curve.sh
+RUN chmod +x benchmark_serving.py

--- a/benchmarks/benchmark/tools/latency-profile/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/latency-profile/container/benchmark_serving.py
@@ -1,0 +1,460 @@
+r"""Benchmark LLM serving throughput and latency.
+
+This script is for sending requests with prompts to LLM server and benchmark
+the latency and throughput at various request rates. It is a modified version of
+https://github.com/vllm-project/vllm/blob/main/benchmarks/benchmark_serving.py.
+It currently supports TGI, vLLM, Triton TensorRT-LLM and Saxml.
+"""
+
+import argparse
+import asyncio
+import json
+import random
+import time
+from typing import AsyncGenerator, List, Tuple
+
+import aiohttp
+import numpy as np
+from transformers import AutoTokenizer
+from transformers import PreTrainedTokenizerBase
+
+
+# (prompt len, output len, latency)
+REQUEST_LATENCY: List[Tuple[int, int, float]] = []
+
+MIN_SEQ_LEN = 4
+CLIENT_TIMEOUT_SEC = 3 * 60 * 60
+NEW_TEXT_KEY = "\nOutput:\n"
+
+
+def sample_requests(
+    dataset_path: str,
+    num_requests: int,
+    max_input_len: int,
+    max_output_len: int,
+    tokenizer: PreTrainedTokenizerBase,
+    use_dummy_text: bool,
+) -> List[Tuple[str, int, int]]:
+  """Samples requests from the dataset or creates dummy requests."""
+  if use_dummy_text:
+    dummy_prompt_token_ids = [0] * max_input_len
+    dummy_prompt = tokenizer.decode(dummy_prompt_token_ids)
+    dummy_requests = [(
+        dummy_prompt,
+        max_input_len,
+        max_output_len,
+    )] * num_requests
+    return dummy_requests
+
+  # Load the dataset.
+  with open(dataset_path) as f:
+    dataset = json.load(f)
+  # Filter out the conversations with less than 2 turns.
+  dataset = [data for data in dataset if len(data["conversations"]) >= 2]
+  # Only keep the first two turns of each conversation.
+  dataset = [
+      (data["conversations"][0]["value"], data["conversations"][1]["value"])
+      for data in dataset
+  ]
+
+  # Tokenize the prompts and completions.
+  prompts = [prompt for prompt, _ in dataset]
+  prompt_token_ids = tokenizer(prompts).input_ids
+  completions = [completion for _, completion in dataset]
+  completion_token_ids = tokenizer(completions).input_ids
+  tokenized_dataset = []
+  for i in range(len(dataset)):
+    output_len = len(completion_token_ids[i])
+    tokenized_dataset.append((prompts[i], prompt_token_ids[i], output_len))
+
+  # Filter out too long sequences.
+  filtered_dataset: List[Tuple[str, int, int]] = []
+  for prompt, prompt_token_ids, output_len in tokenized_dataset:
+    prompt_len = len(prompt_token_ids)
+    if prompt_len < MIN_SEQ_LEN or output_len < MIN_SEQ_LEN:
+      # Prune too short sequences.
+      # This is because TGI causes errors when the input or output length
+      # is too short.
+      continue
+    if prompt_len > max_input_len or output_len > max_output_len:
+      # Prune too long sequences.
+      continue
+    filtered_dataset.append((prompt, prompt_len, output_len))
+
+  # Sample the requests.
+  sampled_requests = random.sample(filtered_dataset, num_requests)
+  return sampled_requests
+
+
+async def get_request(
+    input_requests: List[Tuple[str, int, int]],
+    request_rate: float,
+) -> AsyncGenerator[Tuple[str, int, int], None]:
+  """Gets request async."""
+  input_requests = iter(input_requests)
+  for request in input_requests:
+    yield request
+
+    if request_rate == float("inf"):
+      # If the request rate is infinity, then we don't need to wait.
+      continue
+    # Sample the request interval from the exponential distribution.
+    interval = np.random.exponential(1.0 / request_rate)
+    # The next request will be sent after the interval.
+    await asyncio.sleep(interval)
+
+
+async def send_request(
+    backend: str,
+    api_url: str,
+    prompt: str,
+    prompt_len: int,
+    output_len: int,
+    best_of: int,
+    use_beam_search: bool,
+    top_k: int,
+    tokenizer: PreTrainedTokenizerBase,
+    sax_model: str,
+) -> None:
+  """Sends request to server."""
+  request_start_time = time.time()
+
+  headers = {"User-Agent": "Benchmark Client"}
+  if backend == "vllm":
+    pload = {
+        "prompt": prompt,
+        "n": 1,
+        "best_of": best_of,
+        "use_beam_search": use_beam_search,
+        "temperature": 0.0 if use_beam_search else 1.0,
+        "top_p": 1.0,
+        "max_tokens": output_len,
+        "ignore_eos": False,
+        "stream": False,
+    }
+  elif backend == "tgi":
+    assert not use_beam_search
+    params = {
+        "best_of": best_of,
+        "max_new_tokens": output_len,
+        "do_sample": True,
+    }
+    pload = {
+        "inputs": prompt,
+        "parameters": params,
+    }
+  elif backend == "naive_transformers":
+    # If max_length or top_k is not specified _MAX_LENGTH_DEFAULT = 200 and
+    # _TOP_K_DEFAULT = 10 in peft/handler.py will be used.
+    pload = {
+        "instances": [{
+            "prompt": prompt,
+            "max_length": output_len,
+            "top_k": top_k,
+        }]
+    }
+  elif backend == "tensorrt_llm_triton":
+    pload = {
+        "text_input": prompt,
+        "max_tokens": output_len,
+        "beam_width": 1 if not use_beam_search else best_of,
+        "temperature": 0.0 if use_beam_search else 1.0,
+        "top_p": 1.0,
+        "bad_words": "",
+        "stop_words": "",
+        "stream": False,
+    }
+  elif backend == "sax":
+    pload = {
+        "model": sax_model,
+        "prompt": prompt,
+        "n": 1,
+        "best_of": best_of,
+        "use_beam_search": use_beam_search,
+        "temperature": 0.0 if use_beam_search else 1.0,
+        "top_p": 1.0,
+        "top_k": 50,
+        "max_tokens": output_len,
+        "stream": False,
+    }
+  else:
+    raise ValueError(f"Unknown backend: {backend}")
+
+  # Set client timeout to be 3 hrs.
+  timeout = aiohttp.ClientTimeout(total=CLIENT_TIMEOUT_SEC)
+  async with aiohttp.ClientSession(timeout=timeout) as session:
+    while True:
+      async with session.post(api_url, headers=headers, json=pload) as response:
+        chunks = []
+        async for chunk, _ in response.content.iter_chunks():
+          chunks.append(chunk)
+      output = b"".join(chunks).decode("utf-8")
+      output = json.loads(output)
+
+      # Re-send the request if it failed.
+      if "error" not in output:
+        break
+
+  request_end_time = time.time()
+  # Naive HF transformers generation and TensorRT-LLM generation stops at EOS
+  # tokens and the generation may be shorter than the ground-truth output
+  # sequence length.
+  if backend == "naive_transformers":
+    complete_pred = output["predictions"][0][0]["generated_text"]
+    new_text_start_index = complete_pred.find(NEW_TEXT_KEY) + len(NEW_TEXT_KEY)
+    pred = complete_pred[new_text_start_index:]
+    output_token_ids = tokenizer(pred).input_ids
+    output_len = len(output_token_ids) - prompt_len
+  elif backend == "tensorrt_llm_triton":
+    output_token_ids = tokenizer(output["text_output"]).input_ids
+    output_len = len(output_token_ids)
+  elif backend == "sax":
+    output_token_ids = tokenizer(output["choices"][0]["text"]).input_ids
+    output_len = len(output_token_ids)
+  elif backend == "tgi":
+    output_token_ids = tokenizer(output["generated_text"]).input_ids
+    output_len = len(output_token_ids)
+  elif backend == "vllm":
+    total_token_ids = tokenizer(output["text"][0]).input_ids
+    new_total_len = len(total_token_ids)
+    output_len = new_total_len - prompt_len
+
+  request_latency = request_end_time - request_start_time
+  REQUEST_LATENCY.append((prompt_len, output_len, request_latency))
+
+
+async def benchmark(
+    backend: str,
+    api_url: str,
+    input_requests: List[Tuple[str, int, int]],
+    best_of: int,
+    use_beam_search: bool,
+    request_rate: float,
+    top_k: int,
+    tokenizer: PreTrainedTokenizerBase,
+    sax_model: str,
+) -> None:
+  """Runs benchmark with asynchronous requests."""
+  tasks: List[asyncio.Task] = []
+  async for request in get_request(input_requests, request_rate):
+    prompt, prompt_len, output_len = request
+    task = asyncio.create_task(
+        send_request(
+            backend,
+            api_url,
+            prompt,
+            prompt_len,
+            output_len,
+            best_of,
+            use_beam_search,
+            top_k,
+            tokenizer,
+            sax_model,
+        )
+    )
+    tasks.append(task)
+  await asyncio.gather(*tasks)
+
+
+def main(args: argparse.Namespace):
+  print(args)
+  random.seed(args.seed)
+  np.random.seed(args.seed)
+
+  api_url = f"http://{args.host}:{args.port}/{args.endpoint}"
+  tokenizer = AutoTokenizer.from_pretrained(
+      args.tokenizer, trust_remote_code=args.trust_remote_code
+  )
+  input_requests = sample_requests(
+      args.dataset,
+      args.num_prompts,
+      args.max_input_length,
+      args.max_output_length,
+      tokenizer,
+      args.use_dummy_text,
+  )
+
+  benchmark_start_time = time.time()
+  asyncio.run(
+      benchmark(
+          args.backend,
+          api_url,
+          input_requests,
+          args.best_of,
+          args.use_beam_search,
+          args.request_rate,
+          args.top_k,
+          tokenizer,
+          args.sax_model,
+      )
+  )
+  benchmark_end_time = time.time()
+  benchmark_time = benchmark_end_time - benchmark_start_time
+  print(f"Total time: {benchmark_time:.2f} s")
+  print(f"Requests/min: {60 * args.num_prompts / benchmark_time:.2f}")
+
+  total_output_tokens = np.sum([output_len for _, output_len, _ in
+                                REQUEST_LATENCY])
+  output_tokens_per_min = 60 * total_output_tokens / benchmark_time
+  print(f"Output_tokens/min: {output_tokens_per_min:.2f}")
+
+  total_input_tokens = np.sum([prompt_len for prompt_len, _, _ in
+                               REQUEST_LATENCY])
+  input_tokens_per_min = 60 * total_input_tokens / benchmark_time
+  print(f"Input_tokens/min: {input_tokens_per_min:.2f}")
+
+  total_tokens = total_input_tokens + total_output_tokens
+  tokens_per_min = 60 * total_tokens / benchmark_time
+  print(f"Tokens/min: {tokens_per_min:.2f}")
+
+  if args.machine_cost:
+    print(
+        "Cost $/1k tokens:"
+        f" {args.machine_cost * 1000 / (60 * output_tokens_per_min)}"
+    )
+  # NOTE: The latency below includes requests awaiting time on server side.
+  # It's not comparable with the model inference latency for batch size 1.
+  avg_latency = np.mean([latency for _, _, latency in REQUEST_LATENCY])
+  print(
+      "Average seconds/request (includes waiting time on server):"
+      f" {avg_latency:.2f}"
+  )
+
+  avg_per_token_latency = np.mean([
+      latency / (prompt_len + output_len)
+      for prompt_len, output_len, latency in REQUEST_LATENCY
+  ])
+  print(
+      "Average milliseconds/token (includes waiting time on server):"
+      f" {1000 * avg_per_token_latency:.2f}"
+  )
+
+  avg_per_output_token_latency = np.mean(
+      [latency / output_len for _, output_len, latency in REQUEST_LATENCY]
+  )
+  print(
+      "Average milliseconds/output_token (includes waiting time on server):"
+      f" {1000 * avg_per_output_token_latency:.2f}"
+  )
+
+  avg_input_len = np.mean(
+      [prompt_len for prompt_len, _, _ in REQUEST_LATENCY]
+  )
+  print(
+      "Average input length:"
+      f" {avg_input_len:.2f}"
+  )
+
+  avg_output_len = np.mean(
+      [output_len for _, output_len, _ in REQUEST_LATENCY]
+  )
+  print(
+      "Average output length:"
+      f" {avg_output_len:.2f}"
+  )
+
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(
+      description="Benchmark the online serving throughput."
+  )
+  parser.add_argument(
+      "--backend",
+      type=str,
+      default="vllm",
+      choices=[
+          "vllm",
+          "tgi",
+          "naive_transformers",
+          "tensorrt_llm_triton",
+          "sax",
+      ],
+  )
+  parser.add_argument(
+      "--sax_model",
+      type=str,
+      default="",
+      help="Model name to send request to at API server for SAX model server.",
+  )
+  parser.add_argument("--endpoint", type=str, default="generate")
+  parser.add_argument("--host", type=str, default="localhost")
+  parser.add_argument("--port", type=int, default=7080)
+  parser.add_argument("--dataset", type=str, help="Path to the dataset.")
+  parser.add_argument(
+      "--tokenizer",
+      type=str,
+      required=True,
+      help="Name or path of the tokenizer.",
+  )
+  parser.add_argument(
+      "--best-of",
+      type=int,
+      default=1,
+      help="Generates `best_of` sequences per prompt and returns the best one.",
+  )
+  parser.add_argument("--use-beam-search", action="store_true")
+  parser.add_argument(
+      "--num-prompts",
+      type=int,
+      default=1000,
+      help="Number of prompts to process.",
+  )
+  parser.add_argument(
+      "--max-input-length",
+      type=int,
+      default=1024,
+      help=(
+          "Maximum number of input tokens for filtering the benchmark dataset."
+      ),
+  )
+  parser.add_argument(
+      "--max-output-length",
+      type=int,
+      default=1024,
+      help=(
+          "Maximum number of input tokens for filtering the benchmark dataset."
+      ),
+  )
+  parser.add_argument(
+      "--top-k",
+      type=int,
+      default=32000,
+      help=(
+          "Number of candidate tokens that are considered at each step of the"
+          " generation process. 32000 is the vocab_size of Open-LLaMA and"
+          " LLaMA2 models."
+      ),
+  )
+  parser.add_argument(
+      "--request-rate",
+      type=float,
+      default=float("inf"),
+      help=(
+          "Number of requests per second. If this is inf, "
+          "then all the requests are sent at time 0. "
+          "Otherwise, we use Poisson process to synthesize "
+          "the request arrival times."
+      ),
+  )
+  parser.add_argument("--seed", type=int, default=0)
+  parser.add_argument(
+      "--trust-remote-code",
+      action="store_true",
+      help="trust remote code from huggingface",
+  )
+  parser.add_argument(
+      "--machine-cost",
+      type=float,
+      default=None,
+      help="Machine cost per hour including accelerators (if any)",
+  )
+  parser.add_argument(
+      "--use-dummy-text",
+      action="store_true",
+      help=(
+          "Whether to use dummy text with length defined by max_input_length"
+          " and max_output_length."
+      ),
+  )
+  cmd_args = parser.parse_args()
+  main(cmd_args)

--- a/benchmarks/benchmark/tools/latency-profile/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/latency-profile/container/latency_throughput_curve.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Copyright 2024 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -o xtrace
+
+export IP=$IP
+
+huggingface-cli login --token "$HF_TOKEN" --add-to-git-credential
+
+timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
+output_file="latency-profile-${timestamp}.txt"
+for ((i = 1 ; i <= 256 ; i*=2 )); do
+  python3 benchmark_serving.py   --host="$IP"   --port=80   --dataset=ShareGPT_V3_unfiltered_cleaned_split.json   --tokenizer="$TOKENIZER" --request-rate=$i --backend="$BACKEND" --num-prompts=256 --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH > $output_file
+done
+
+curl -H "Metadata-Flavor:Google" http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/email
+
+gsutil cp $output_file "gs://$OUTPUT_BUCKET/$output_file"

--- a/benchmarks/benchmark/tools/latency-profile/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/latency-profile/container/latency_throughput_curve.sh
@@ -21,10 +21,11 @@ huggingface-cli login --token "$HF_TOKEN" --add-to-git-credential
 
 timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
 output_file="latency-profile-${timestamp}.txt"
-for ((i = 1 ; i <= 256 ; i*=2 )); do
-  python3 benchmark_serving.py   --host="$IP"   --port=80   --dataset=ShareGPT_V3_unfiltered_cleaned_split.json   --tokenizer="$TOKENIZER" --request-rate=$i --backend="$BACKEND" --num-prompts=256 --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH > $output_file
+for ((i = 1 ; i <= 2 ; i*=2 )); do
+  python3 benchmark_serving.py   --host="$IP"   --port=80   --dataset=ShareGPT_V3_unfiltered_cleaned_split.json   --tokenizer="$TOKENIZER" --request-rate=$i --backend="$BACKEND" --num-prompts=2 --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH > $output_file
 done
 
-curl -H "Metadata-Flavor:Google" http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/email
+TOKEN=$(curl -s -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/service-accounts/default/token | jq -r .access_token)
+gsutil config -e -o Credentials:gs_oauth2_refresh_token=$TOKEN
 
 gsutil cp $output_file "gs://$OUTPUT_BUCKET/$output_file"

--- a/benchmarks/benchmark/tools/latency-profile/container/requirements.txt
+++ b/benchmarks/benchmark/tools/latency-profile/container/requirements.txt
@@ -1,0 +1,37 @@
+# formatting
+yapf==0.32.0
+toml==0.10.2
+ruff==0.1.5
+
+# type checking
+mypy==0.991
+types-PyYAML
+types-requests
+types-setuptools
+
+# testing
+pytest
+pytest-forked
+pytest-asyncio
+httpx
+einops # required for MPT
+flash_attn # required for HuggingFace's llama implementation
+openai
+requests
+
+# run
+ninja  # For faster builds.
+psutil
+ray >= 2.9
+sentencepiece  # Required for LLaMA tokenizer.
+numpy
+torch == 2.1.1
+transformers >= 4.37.0 # Required for Qwen2
+xformers == 0.0.23
+fastapi
+uvicorn[standard]
+pydantic >= 2.0  # Required for OpenAI server.
+aioprometheus[starlette]
+pynvml == 11.5.0
+accelerate
+aiohttp

--- a/benchmarks/benchmark/tools/latency-profile/main.tf
+++ b/benchmarks/benchmark/tools/latency-profile/main.tf
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+locals {
+  templates = [
+    for f in fileset(local.templates_path, "*tpl") :
+    "${local.templates_path}/${f}"
+  ]
+  templates_path = (
+    var.templates_path == null
+    ? "${path.module}/manifest-templates"
+    : pathexpand(var.templates_path)
+  )
+  hugging_face_token_secret = (
+    var.hugging_face_secret == null || var.hugging_face_secret_version == null
+    ? null
+    : "${var.hugging_face_secret}/versions/${var.hugging_face_secret_version}"
+  )
+
+  all_manifests = flatten([for manifest_file in local.templates :
+    [for data in split("---", templatefile(manifest_file, {
+      artifact_registry                          = var.artifact_registry
+      namespace                                  = var.namespace
+      inference_server_service                   = var.inference_server_service
+      inference_server_framework                 = var.inference_server_framework
+      ksa                                        = var.ksa
+      latency_profile_kubernetes_service_account = var.latency_profile_kubernetes_service_account
+      max_num_prompts                            = var.max_num_prompts
+      max_output_len                             = var.max_output_len
+      max_prompt_len                             = var.max_prompt_len
+      tokenizer                                  = var.tokenizer
+      hugging_face_token_secret_list             = local.hugging_face_token_secret == null ? [] : [local.hugging_face_token_secret]
+      k8s_hf_secret_list                         = var.k8s_hf_secret == null ? [] : [var.k8s_hf_secret]
+      output_bucket                              = var.output_bucket
+    })) : data]
+  ])
+}
+
+resource "google_project_service" "cloudbuild" {
+  project = var.project_id
+  service = "cloudbuild.googleapis.com"
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_on_destroy = false
+}
+
+resource "kubernetes_manifest" "default" {
+  for_each   = toset(local.all_manifests)
+  depends_on = [resource.null_resource.build_and_push_image]
+  manifest   = yamldecode(each.value)
+  timeouts {
+    create = "30m"
+  }
+}

--- a/benchmarks/benchmark/tools/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
+++ b/benchmarks/benchmark/tools/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
@@ -1,0 +1,43 @@
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: lantency-profile-generator
+  namespace: ${namespace}
+  labels:
+    name: lantency-profile-generator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: lantency-profile-generator
+  template:
+    metadata:
+      labels:
+        app: lantency-profile-generator
+        examples.ai.gke.io/source: ai-on-gke-benchmarks
+    spec:
+      serviceAccountName: ${latency_profile_kubernetes_service_account}
+      containers:
+        - name: lantency-profile-generator
+          image: ${artifact_registry}/latency-profile:latest
+          command: ["bash", "-c", "./latency_throughput_curve.sh"]
+          env:
+            - name: TOKENIZER
+              value: ${tokenizer}
+            - name: IP
+              value: ${inference_server_service}
+            - name: BACKEND
+              value: ${inference_server_framework}
+            - name: INPUT_LENGTH
+              value: ${max_prompt_len}
+            - name: OUTPUT_LENGTH
+              value: ${max_output_len}
+            - name: OUTPUT_BUCKET
+              value: ${output_bucket}
+%{ for hugging_face_token_secret in hugging_face_token_secret_list ~}
+            - name: HF_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: hf-token
+                  key: HF_TOKEN
+%{ endfor ~}

--- a/benchmarks/benchmark/tools/latency-profile/providers.tf
+++ b/benchmarks/benchmark/tools/latency-profile/providers.tf
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+data "google_client_config" "identity" {
+  count = var.credentials_config.fleet_host != null ? 1 : 0
+}
+
+provider "kubernetes" {
+  config_path = (
+    var.credentials_config.kubeconfig == null
+    ? null
+    : pathexpand(var.credentials_config.kubeconfig.path)
+  )
+  config_context = try(
+    var.credentials_config.kubeconfig.context, null
+  )
+  host = (
+    var.credentials_config.fleet_host == null
+    ? null
+    : var.credentials_config.fleet_host
+  )
+  token = try(data.google_client_config.identity.0.access_token, null)
+}

--- a/benchmarks/benchmark/tools/latency-profile/sample.tfvars
+++ b/benchmarks/benchmark/tools/latency-profile/sample.tfvars
@@ -9,7 +9,7 @@ ksa       = "benchmark-ksa"
 
 k8s_hf_secret = "hf-token"
 
-# Locust service configuration
+# Latency profile generator service configuration
 artifact_registry                          = "us-central1-docker.pkg.dev/$PROJECT_ID/ai-benchmark"
 inference_server_service                   = "tgi" # inference server service name
 latency_profile_kubernetes_service_account = "sample-runner-ksa"

--- a/benchmarks/benchmark/tools/latency-profile/sample.tfvars
+++ b/benchmarks/benchmark/tools/latency-profile/sample.tfvars
@@ -1,0 +1,21 @@
+credentials_config = {
+  fleet_host = "https://connectgateway.googleapis.com/v1/projects/$PROJECT_NUM/locations/global/gkeMemberships/ai-benchmark"
+}
+
+project_id = "$PROJECT_ID"
+
+namespace = "benchmark"
+ksa       = "benchmark-ksa"
+
+k8s_hf_secret = "hf-token"
+
+# Locust service configuration
+artifact_registry                          = "us-central1-docker.pkg.dev/$PROJECT_ID/ai-benchmark"
+inference_server_service                   = "tgi" # inference server service name
+latency_profile_kubernetes_service_account = "sample-runner-ksa"
+output_bucket                              = "${PROJECT_ID}-benchmark-output"
+gcs_path                                   = "gs://${PROJECT_ID}-ai-gke-benchmark-fuse/ShareGPT_V3_unfiltered_cleaned_split_filtered_prompts.txt"
+
+# Benchmark configuration for Locust Docker accessing inference server
+inference_server_framework = "tgi"
+tokenizer                  = "tiiuae/falcon-7b"

--- a/benchmarks/benchmark/tools/latency-profile/variables.tf
+++ b/benchmarks/benchmark/tools/latency-profile/variables.tf
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "credentials_config" {
+  description = "Configure how Terraform authenticates to the cluster."
+  type = object({
+    fleet_host = optional(string)
+    kubeconfig = optional(object({
+      context = optional(string)
+      path    = optional(string, "~/.kube/config")
+    }))
+  })
+  nullable = false
+  validation {
+    condition = (
+      (var.credentials_config.fleet_host != null) !=
+      (var.credentials_config.kubeconfig != null)
+    )
+    error_message = "Exactly one of fleet host or kubeconfig must be set."
+  }
+}
+
+variable "namespace" {
+  description = "Namespace used for model and benchmarking deployments."
+  type        = string
+  nullable    = false
+  default     = "default"
+}
+
+variable "project_id" {
+  description = "Project id of existing or created project."
+  type        = string
+  nullable    = false
+}
+
+variable "ksa" {
+  description = "Kubernetes Service Account used for workload."
+  type        = string
+  nullable    = false
+  default     = "default"
+}
+
+variable "templates_path" {
+  description = "Path where manifest templates will be read from. Set to null to use the default manifests"
+  type        = string
+  default     = null
+}
+
+variable "artifact_registry" {
+  description = "Artifact registry for storing Locust container."
+  type        = string
+  default     = null
+}
+
+variable "inference_server_service" {
+  description = "Inference server service"
+  type        = string
+  nullable    = false
+}
+
+variable "inference_server_framework" {
+  description = "Benchmark server configuration for inference server framework. Can be one of: vllm, tgi, tensorrt_llm_triton, sax"
+  type        = string
+  nullable    = false
+  default     = "tgi"
+  validation {
+    condition     = var.inference_server_framework == "vllm" || var.inference_server_framework == "tgi" || var.inference_server_framework == "tensorrt_llm_triton" || var.inference_server_framework == "sax" || var.inference_server_framework == "jetstream"
+    error_message = "The inference_server_framework must be one of: vllm, tgi, tensorrt_llm_triton, sax, or jetstream."
+  }
+}
+
+variable "max_num_prompts" {
+  description = "Benchmark server configuration for max number of prompts."
+  type        = number
+  default     = 1000
+  validation {
+    condition     = var.max_num_prompts > 0
+    error_message = "The max_num_prompts value must be greater than 0."
+  }
+}
+
+variable "max_output_len" {
+  description = "Benchmark server configuration for max output length."
+  type        = number
+  default     = 256
+  validation {
+    condition     = var.max_output_len > 4
+    error_message = "The max_output_len value must be greater than 4. TGI framework throws an error for too short of sequences."
+  }
+}
+
+variable "max_prompt_len" {
+  description = "Benchmark server configuration for max prompt length."
+  type        = number
+  default     = 256
+  validation {
+    condition     = var.max_prompt_len > 4
+    error_message = "The max_prompt_len value must be greater than 4. TGI framework throws an error for too short of sequences."
+  }
+}
+
+variable "tokenizer" {
+  description = "Benchmark server configuration for tokenizer."
+  type        = string
+  nullable    = false
+  default     = "tiiuae/falcon-7b"
+}
+
+variable "output_bucket" {
+  description = "Bucket name for storing results"
+  type        = string
+}
+
+variable "latency_profile_kubernetes_service_account" {
+  description = "Kubernetes Service Account to be used for the latency profile generator tool"
+  type        = string
+  default     = "sample-runner-ksa"
+}
+
+// TODO: add validation to make k8s_hf_secret & hugging_face_secret mutually exclusive once terraform is updated with: https://discuss.hashicorp.com/t/experiment-feedback-input-variable-validation-can-cross-reference-other-objects/66644
+variable "k8s_hf_secret" {
+  description = "Name of secret for huggingface token; stored in k8s "
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "hugging_face_secret" {
+  description = "name of the kubectl huggingface secret token; stored in Secret Manager. Security considerations: https://kubernetes.io/docs/concepts/security/secrets-good-practices/"
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "hugging_face_secret_version" {
+  description = "Secret version in Secret Manager"
+  type        = string
+  nullable    = true
+  default     = null
+}

--- a/benchmarks/benchmark/tools/latency-profile/variables.tf
+++ b/benchmarks/benchmark/tools/latency-profile/variables.tf
@@ -60,7 +60,7 @@ variable "templates_path" {
 }
 
 variable "artifact_registry" {
-  description = "Artifact registry for storing Locust container."
+  description = "Artifact registry for storing Latency Profile Generator container."
   type        = string
   default     = null
 }


### PR DESCRIPTION
This change adds a new benchmarking suite called latency-profile-generator which runs serving benchmarks at different request rates to produce latency and throughput numbers at different QPS. This can be used to identify how different models and model servers perform depending on incoming traffic.