### PR TITLE
fix: add delays in ray application cloud build test

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -102,9 +102,11 @@ steps:
 
         # Make sure pods are running
         kubectl wait --all pods -n ml-$SHORT_SHA-$_BUILD_ID-ray --for=condition=Ready --timeout=1200s
+        # Wait for pods to be stable
+        sleep 5s
         kubectl port-forward -n ml-$SHORT_SHA-$_BUILD_ID-ray service/ray-cluster-kuberay-head-svc 8265:8265 &
         # Wait port-forwarding to take its place
-        sleep 5s
+        sleep 10s
 
         ray job submit \
         --address=http://127.0.0.1:8265 -- python -c "import ray; ray.init(); print(ray.cluster_resources())"


### PR DESCRIPTION
The ray application is quite flaky with the following error, adding sleep to wait for pods to be more stable.

Forwarding from 127.0.0.1:8265 -> 8265
Handling connection for 8265
E0828 07:18:32.742675     386 portforward.go:409] an error occurred forwarding 8265 -> 8265: error forwarding port 8265 to pod 3f1f339204911c524c01d65e02ec3e19e20b2c3fdb5dcbb900d80be80ba97a11, uid : failed to execute portforward in network namespace "/var/run/netns/cni-a9192461-40d0-574a-1a1a-756308c62f70": failed to connect to localhost:8265 inside namespace "3f1f339204911c524c01d65e02ec3e19e20b2c3fdb5dcbb900d80be80ba97a11", IPv4: dial tcp4 127.0.0.1:8265: connect: connection refused IPv6 dial tcp6 [::1]:8265: connect: cannot assign requested address 
error: lost connection to pod