### PR TITLE
Allow TPU Provisioner to be configured to copy Pod labels to Node labels

### DIFF
--- a/tpu-provisioner/cmd/main.go
+++ b/tpu-provisioner/cmd/main.go
@@ -80,6 +80,7 @@ func main() {
 		GCPNodeServiceAccount string `envconfig:"GCP_NODE_SERVICE_ACCOUNT"`
 
 		GCPNodeTags          []string `envconfig:"GCP_NODE_TAGS"`
+		GCPPodToNodeLabels   []string `envconfig:"GCP_POD_TO_NODE_LABELS"`
 		GCPNodeSecondaryDisk string   `envconfig:"GCP_NODE_SECONDARY_DISK" default:""`
 		GCPNodeSecureBoot    bool     `envconfig:"GCP_NODE_SECURE_BOOT" default:"true"`
 
@@ -189,6 +190,7 @@ func main() {
 			"zone", cfg.GCPZone,
 			"nodeServiceAccount", cfg.GCPNodeServiceAccount,
 			"nodeTags", cfg.GCPNodeTags,
+			"podToNodeLabels", cfg.GCPPodToNodeLabels,
 		)
 
 		containers, err := containerv1beta1.NewService(context.Background() /*, option.WithCredentials(creds)*/)
@@ -206,6 +208,7 @@ func main() {
 				NodeServiceAccount: cfg.GCPNodeServiceAccount,
 				NodeSecondaryDisk:  cfg.GCPNodeSecondaryDisk,
 				NodeTags:           cfg.GCPNodeTags,
+				PodToNodeLabels:    cfg.GCPPodToNodeLabels,
 				NodeSecureBoot:     cfg.GCPNodeSecureBoot,
 				ForceOnDemand:      cfg.GCPForceOnDemand,
 			},

--- a/tpu-provisioner/internal/cloud/common.go
+++ b/tpu-provisioner/internal/cloud/common.go
@@ -24,6 +24,9 @@ const (
 
 	LabelProvisionerNodepoolID = "provisioner-nodepool-id"
 
+	// AnnotationCopyLabels is a comma-separated list of labels to copy from the Pod to the node pool config (Nodes).
+	AnnotationCopyLabels = "tpu-provisioner.cloud.google.com/copy-labels"
+
 	EventNodePoolCreationStarted   = "NodePoolCreationStarted"
 	EventNodePoolCreationSucceeded = "NodePoolCreationSucceeded"
 	EventNodePoolCreationFailed    = "NodePoolCreationFailed"

--- a/tpu-provisioner/internal/cloud/gke.go
+++ b/tpu-provisioner/internal/cloud/gke.go
@@ -269,6 +269,17 @@ func (g *GKE) nodePoolForPod(name string, p *corev1.Pod) (*containerv1beta1.Node
 		}
 	}
 
+	// Copy labels specified by annotation to the Node.
+	for _, key := range strings.Split(getAnnotation(p, AnnotationCopyLabels), ",") {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		if val, ok := p.Labels[key]; ok {
+			labels[key] = val
+		}
+	}
+
 	for labelKey, labelValue := range p.Spec.NodeSelector {
 		switch labelKey {
 		case ICIResiliencyLabel:
@@ -491,4 +502,11 @@ func min(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func getAnnotation(p *corev1.Pod, key string) string {
+	if p.Annotations == nil {
+		return ""
+	}
+	return p.Annotations[key]
 }

--- a/tpu-provisioner/internal/cloud/gke.go
+++ b/tpu-provisioner/internal/cloud/gke.go
@@ -262,6 +262,13 @@ func (g *GKE) nodePoolForPod(name string, p *corev1.Pod) (*containerv1beta1.Node
 		LabelJobSetNamespace: p.Namespace,
 	}
 
+	// Copy configured labels from the Pod to the Node.
+	for _, key := range g.ClusterContext.PodToNodeLabels {
+		if val, ok := p.Labels[key]; ok {
+			labels[key] = val
+		}
+	}
+
 	for labelKey, labelValue := range p.Spec.NodeSelector {
 		switch labelKey {
 		case ICIResiliencyLabel:

--- a/tpu-provisioner/internal/cloud/gke_context.go
+++ b/tpu-provisioner/internal/cloud/gke_context.go
@@ -10,8 +10,11 @@ type GKEContext struct {
 	NodeServiceAccount string
 	NodeSecondaryDisk  string
 	NodeTags           []string
-	NodeSecureBoot     bool
-	ForceOnDemand      bool
+	// PodToNodeLabels is a list of key=value pairs that will be copied from the Pod
+	// to the Node.
+	PodToNodeLabels []string
+	NodeSecureBoot  bool
+	ForceOnDemand   bool
 }
 
 func (c GKEContext) ClusterName() string {

--- a/tpu-provisioner/internal/cloud/gke_test.go
+++ b/tpu-provisioner/internal/cloud/gke_test.go
@@ -220,11 +220,12 @@ func TestPodToNodePoolName(t *testing.T) {
 func TestNodePoolForPod(t *testing.T) {
 	trueVar := true
 	tests := []struct {
-		desc             string
-		gkeContext       GKEContext
-		additionalLabels map[string]string
-		selector         map[string]string
-		want             *containerv1beta1.NodePool
+		desc                  string
+		gkeContext            GKEContext
+		additionalLabels      map[string]string
+		additionalAnnotations map[string]string
+		selector              map[string]string
+		want                  *containerv1beta1.NodePool
 	}{
 		{
 			desc: "simple case",
@@ -469,6 +470,38 @@ func TestNodePoolForPod(t *testing.T) {
 						"google.com/tpu-provisioner-parent-name":      "jobset-test-job-1-0",
 						"google.com/tpu-provisioner-parent-namespace": "default",
 						"should-be-copied":                            "val-a",
+					},
+					MachineType:            "ct5p-hightpu-4t",
+					ShieldedInstanceConfig: &container.ShieldedInstanceConfig{EnableIntegrityMonitoring: true},
+				},
+				InitialNodeCount:  512,
+				Locations:         []string{""},
+				Management:        &container.NodeManagement{AutoRepair: true, AutoUpgrade: false},
+				MaxPodsConstraint: &container.MaxPodsConstraint{MaxPodsPerNode: 15},
+				Name:              "test-pool",
+				PlacementPolicy:   &container.PlacementPolicy{TpuTopology: "8x16x16", Type: "COMPACT"},
+				UpgradeSettings:   &container.UpgradeSettings{MaxSurge: 1},
+			},
+		},
+		{
+			desc: "labels to copy from pod to node by annotation",
+			additionalLabels: map[string]string{
+				"copy-me":      "val-x",
+				"dont-copy-me": "val-y",
+			},
+			additionalAnnotations: map[string]string{
+				"tpu-provisioner.cloud.google.com/copy-labels": "copy-me",
+			},
+			want: &containerv1beta1.NodePool{
+				Config: &container.NodeConfig{
+					Labels: map[string]string{
+						"google.com/nodepool-manager":                 "tpu-provisioner",
+						"google.com/tpu-provisioner-jobset-name":      "jobset-test",
+						"google.com/tpu-provisioner-jobset-namespace": "default",
+						"google.com/tpu-provisioner-parent-kind":      "job",
+						"google.com/tpu-provisioner-parent-name":      "jobset-test-job-1-0",
+						"google.com/tpu-provisioner-parent-namespace": "default",
+						"copy-me": "val-x",
 					},
 					MachineType:            "ct5p-hightpu-4t",
 					ShieldedInstanceConfig: &container.ShieldedInstanceConfig{EnableIntegrityMonitoring: true},

--- a/tpu-provisioner/internal/cloud/gke_test.go
+++ b/tpu-provisioner/internal/cloud/gke_test.go
@@ -537,26 +537,32 @@ func TestNodePoolForPod(t *testing.T) {
 			for k, v := range tc.additionalLabels {
 				labels[k] = v
 			}
+
+			annotations := map[string]string{
+				"alpha.jobset.sigs.k8s.io/exclusive-topology": "cloud.google.com/gke-nodepool",
+				"batch.kubernetes.io/job-completion-index":    "0",
+				"jobset.sigs.k8s.io/job-index":                "0",
+				"jobset.sigs.k8s.io/job-key":                  "random-key",
+				"jobset.sigs.k8s.io/jobset-name":              "jobset-test",
+				"jobset.sigs.k8s.io/replicatedjob-name":       "job-1",
+				"jobset.sigs.k8s.io/replicatedjob-replicas":   "1",
+				"jobset.sigs.k8s.io/restart-attempt":          "0",
+			}
+			for k, v := range tc.additionalAnnotations {
+				annotations[k] = v
+			}
+
 			pod := &v1.Pod{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "v1",
 					Kind:       "Pod",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						"alpha.jobset.sigs.k8s.io/exclusive-topology": "cloud.google.com/gke-nodepool",
-						"batch.kubernetes.io/job-completion-index":    "0",
-						"jobset.sigs.k8s.io/job-index":                "0",
-						"jobset.sigs.k8s.io/job-key":                  "random-key",
-						"jobset.sigs.k8s.io/jobset-name":              "jobset-test",
-						"jobset.sigs.k8s.io/replicatedjob-name":       "job-1",
-						"jobset.sigs.k8s.io/replicatedjob-replicas":   "1",
-						"jobset.sigs.k8s.io/restart-attempt":          "0",
-					},
-					Labels:     labels,
-					Finalizers: []string{"batch.kubernetes.io/job-tracking"},
-					Name:       "job-test-6gfwq",
-					Namespace:  "default",
+					Annotations: annotations,
+					Labels:      labels,
+					Finalizers:  []string{"batch.kubernetes.io/job-tracking"},
+					Name:        "job-test-6gfwq",
+					Namespace:   "default",
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion:         "batch/v1",


### PR DESCRIPTION
Copy configured Pod labels to Node config at Node Pool creation-time.

Configured via `GCP_POD_TO_NODE_LABELS`, a comma-separated list of label keys.

```bash
# NOTE: See the log message to confirm that "abc" and "xyz" are parse to be copied (see "podToNodeLabels" in log message).
GCP_POD_TO_NODE_LABELS=abc,xyz go run ./cmd/main.go
2024-08-28T17:55:00-04:00       INFO    setup   creating gke client     {"project": "", "clusterLocation": "", "cluster": "", "zone": "", "nodeServiceAccount": "", "nodeTags": [], "podToNodeLabels": ["abc", "xyz"]}
2024-08-28T17:55:00-04:00       INFO    setup   starting manager
```