### PR TITLE
update lpg to deploy latest build on new build

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/main.tf
+++ b/benchmarks/benchmark/tools/profile-generator/main.tf
@@ -51,6 +51,7 @@ resource "google_project_service" "cloudbuild" {
 #  ----- Manual Benchmarking -----
 
 module "latency-profile" {
+  depends_on = [resource.null_resource.build_and_push_image]
   count  = var.targets.manual != null ? 1 : 0
   source = "./modules/latency-profile"
 

--- a/benchmarks/benchmark/tools/profile-generator/main.tf
+++ b/benchmarks/benchmark/tools/profile-generator/main.tf
@@ -52,8 +52,8 @@ resource "google_project_service" "cloudbuild" {
 
 module "latency-profile" {
   depends_on = [resource.null_resource.build_and_push_image]
-  count  = var.targets.manual != null ? 1 : 0
-  source = "./modules/latency-profile"
+  count      = var.targets.manual != null ? 1 : 0
+  source     = "./modules/latency-profile"
 
   credentials_config = var.credentials_config
   namespace          = var.namespace

--- a/benchmarks/benchmark/tools/profile-generator/sample.tfvars
+++ b/benchmarks/benchmark/tools/profile-generator/sample.tfvars
@@ -25,6 +25,7 @@ project_id = "your_project_id"
 namespace = "benchmark"
 
 # Latency profile generator service configuration
+# set build_latency_profile_generator_image to false to save 20 min build if no rebuild needed, eg.
 # build_latency_profile_generator_image      = false
 latency_profile_kubernetes_service_account = "prom-frontend-sa"
 output_bucket                              = "your_project_id-benchmark-output-bucket"

--- a/benchmarks/benchmark/tools/profile-generator/sample.tfvars
+++ b/benchmarks/benchmark/tools/profile-generator/sample.tfvars
@@ -22,8 +22,10 @@ credentials_config = {
 
 project_id = "your_project_id"
 
+namespace = "benchmark"
+
 # Latency profile generator service configuration
-build_latency_profile_generator_image      = false
+# build_latency_profile_generator_image      = false
 latency_profile_kubernetes_service_account = "prom-frontend-sa"
 output_bucket                              = "your_project_id-benchmark-output-bucket"
 k8s_hf_secret                              = "hf-token"


### PR DESCRIPTION
- wait to finish latest build before deploying manifests - fixes any issues seen with latest container not being deployed when expected.

- update sample.tfvars to ensure build happens first try