### PR TITLE
Set an explicit logs bucket in the cloud build.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -384,6 +384,7 @@ substitutions:
   _USER_NAME: github
   _AUTOPILOT_CLUSTER: "false"
   _BUILD_ID: ${BUILD_ID:0:8}
+logsBucket: gs://ai-on-gke-build-logs
 options:
   substitutionOption: 'ALLOW_LOOSE'
   machineType: 'E2_HIGHCPU_8'


### PR DESCRIPTION
This is so that we can make logs for CI visible to non-Googlers that don't have access to the cloud build dashboard.

Work on #786. 