### PR TITLE
Allow benchmark to write json output

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -353,20 +353,20 @@ def main(args: argparse.Namespace):
                                 REQUEST_LATENCY])
   output_tokens_per_min = 60 * total_output_tokens / benchmark_time
   print(f"Output_tokens/min: {output_tokens_per_min:.2f}")
-  benchmark_result['total_output_token'] = total_output_tokens
+  benchmark_result['total_output_token'] = int(total_output_tokens)
   benchmark_result['output_tokens_per_min'] = output_tokens_per_min
 
   total_input_tokens = np.sum([prompt_len for prompt_len, _, _ in
                                REQUEST_LATENCY])
   input_tokens_per_min = 60 * total_input_tokens / benchmark_time
   print(f"Input_tokens/min: {input_tokens_per_min:.2f}")
-  benchmark_result['total_input_tokens'] = total_input_tokens
+  benchmark_result['total_input_tokens'] = int(total_input_tokens)
   benchmark_result['input_tokens_per_min'] = input_tokens_per_min
 
   total_tokens = total_input_tokens + total_output_tokens
   tokens_per_min = 60 * total_tokens / benchmark_time
   print(f"Tokens/min: {tokens_per_min:.2f}")
-  benchmark_result['total_tokens'] = total_tokens
+  benchmark_result['total_tokens'] = int(total_tokens)
   benchmark_result['tokens_per_min'] = tokens_per_min
 
   if args.machine_cost:

--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -7,6 +7,7 @@ It currently supports TGI, vLLM, Triton TensorRT-LLM and Saxml.
 
 import argparse
 import asyncio
+from datetime import datetime
 import json
 import random
 import time
@@ -420,7 +421,7 @@ def main(args: argparse.Namespace):
   benchmark_result['avg_output_len'] = avg_output_len
 
   if args.save_json_results:
-    save_json_results()
+    save_json_results(args, benchmark_result)
 
 
 if __name__ == "__main__":
@@ -533,8 +534,7 @@ if __name__ == "__main__":
   )
   parser.add_argument(
       "--save-json-results",
-      type=bool,
-      default=False,
+      action="store_true",
       help="Whether to save benchmark results to a json file.",
   )
   parser.add_argument(


### PR DESCRIPTION
Modify the serving benchmark to write json output similar to Jetstream benchmark: https://github.com/richardsliu/JetStream/blob/vllm-benchmark/benchmarks/benchmark_serving.py#L648

This will allow the benchmark to integrate with XLML dashboard.