### PR TITLE
Add server metrics promql scraping

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/README.md
+++ b/benchmarks/benchmark/tools/profile-generator/README.md
@@ -1,17 +1,18 @@
 # AI on GKE Benchmark Latency Profile Generator
 
 <!-- TOC -->
-* [AI on GKE Benchmark Latency Profile Generator](#ai-on-gke-benchmark-latency-profile-generator)
-  * [Overview](#overview)
-  * [Instructions](#instructions)
-    * [Step 1: create output bucket](#step-1--create-output-bucket)
-    * [Step 2: create and give service account access to write to output gcs bucket](#step-2--create-and-give-service-account-access-to-write-to-output-gcs-bucket)
-    * [Step 3: create artifact repository for automated Latency Profile Generator docker build](#step-3--create-artifact-repository-for-automated-latency-profile-generator-docker-build)
-    * [Step 4: create and configure terraform.tfvars](#step-4--create-and-configure-terraformtfvars)
-      * [[optional] set-up credentials config with kubeconfig](#optional-set-up-credentials-config-with-kubeconfig)
-      * [[optional] set up secret token in Secret Manager](#optional-set-up-secret-token-in-secret-manager)
-    * [Step 6: terraform initialize, plan and apply](#step-6--terraform-initialize-plan-and-apply)
-  * [Inputs](#inputs)
+- [AI on GKE Benchmark Latency Profile Generator](#ai-on-gke-benchmark-latency-profile-generator)
+  - [Overview](#overview)
+  - [Instructions](#instructions)
+    - [Step 1: create output bucket](#step-1-create-output-bucket)
+    - [Step 2: create and give service account access to write to output gcs bucket](#step-2-create-and-give-service-account-access-to-write-to-output-gcs-bucket)
+      - [\[optional\] give service account access to read Cloud Monitoring metrics](#optional-give-service-account-access-to-read-cloud-monitoring-metrics)
+    - [Step 3: create artifact repository for automated Latency Profile Generator docker build](#step-3-create-artifact-repository-for-automated-latency-profile-generator-docker-build)
+    - [Step 4: create and configure terraform.tfvars](#step-4-create-and-configure-terraformtfvars)
+      - [\[optional\] set-up credentials config with kubeconfig](#optional-set-up-credentials-config-with-kubeconfig)
+      - [\[optional\] set up secret token in Secret Manager](#optional-set-up-secret-token-in-secret-manager)
+    - [Step 5: login to gcloud](#step-5-login-to-gcloud)
+    - [Step 6: terraform initialize, plan and apply](#step-6-terraform-initialize-plan-and-apply)
 <!-- TOC -->
 
 ## Overview
@@ -61,6 +62,15 @@ Your kubernetes service account will inherit the reader permissions.
 
 You will set the `latency_profile_kubernetes_service_account` in your
 `terraform.tfvars` to the kubernetes service account name.
+
+#### [optional] give service account access to read Cloud Monitoring metrics
+
+If `scrape-server-metrics` is set to True, you will need to give the service account access to read
+the Cloud Monitoring metrics. You can do so with the following command:
+
+```
+gcloud projects add-iam-policy-binding $PROJECT_ID   --member=serviceAccount:$GOOGLE_SERVICE_ACCOUNT@$PROJECT_ID.iam.gserviceaccount.com   --role=roles/monitoring.viewer
+```
 
 ### Step 3: create artifact repository for automated Latency Profile Generator docker build
 

--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -609,8 +609,7 @@ if __name__ == "__main__":
   )
   parser.add_argument(
       "--scrape-server-metrics",
-      type=bool,
-      default=False,
+      action="store_true",
       help="Whether to scrape server metrics.",
   )
   cmd_args = parser.parse_args()

--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -10,8 +10,12 @@ import asyncio
 from datetime import datetime
 import json
 import random
+import requests
 import time
 from typing import AsyncGenerator, List, Tuple
+
+import google.auth
+import google.auth.transport.requests
 
 import aiohttp
 import numpy as np
@@ -302,6 +306,54 @@ def save_json_results(args: argparse.Namespace, benchmark_result):
   with open(file_name, "w", encoding="utf-8") as outfile:
     json.dump(final_json, outfile)
 
+def metrics_to_scrape(backend: str) -> List[str]:
+  if backend == "vllm":
+    return ["vllm:gpu_cache_usage_perc", "vllm:num_requests_waiting"]
+  elif backend == "jetstream":
+    return ["jetstream_slots_used_percentage", "jetstream_prefill_backlog_size"]
+  else:
+    return []
+
+def print_metrics(metrics: List[str], duration: str, backend: str) -> None:
+  # Creates a credentials object from the default service account file
+  # Assumes that script has appropriate default credentials set up, ref:
+  # https://googleapis.dev/python/google-auth/latest/user-guide.html#application-default-credentials
+  credentials, project_id = google.auth.default()
+  # Prepare an authentication request - helps format the request auth token
+  auth_req = google.auth.transport.requests.Request()
+
+  for metric in metrics:
+    print("Metric Name: %s" % (metric))
+
+    # Queries scrape all metrics collected from the last $DURATION seconds from the backend's related
+    # podmonitoring spec assumed to be named "$BACKEND-podmonitoring"
+    queries = {
+      "Mean": "avg_over_time(%s{job='%s-podmonitoring'}[%ss])" % (metric, backend, duration),
+      "Median": "quantile_over_time(0.5, %s{job='%s-podmonitoring'}[%ss])" % (metric, backend, duration),
+      "Min": "min_over_time(%s{job='%s-podmonitoring'}[%ss])" % (metric, backend, duration),
+      "Max": "max_over_time(%s{job='%s-podmonitoring'}[%ss])" % (metric, backend, duration),
+      "P90": "quantile_over_time(0.9, %s{job='%s-podmonitoring'}[%ss])" % (metric, backend, duration),
+      "P99": "quantile_over_time(0.99, %s{job='%s-podmonitoring'}[%ss])" % (metric, backend, duration),
+    }
+    for query_name, query in queries.items():
+      # Request refresh tokens
+      credentials.refresh(auth_req)
+
+      # Configure respective query
+      url='https://monitoring.googleapis.com/v1/projects/%s/location/global/prometheus/api/v1/query' % (project_id)
+      headers_api = {'Authorization': 'Bearer ' + credentials.token}
+      params = {'query': query}
+      response = requests.get(url=url, headers=headers_api, params=params)
+
+      # handle response
+      if response.ok:
+        if response["status"] == "success":
+          print("%s: %s" % (query_name, response["data"]["result"][0]["value"][1]))
+        else:
+          print("Cloud Monitoring PromQL Error: %s" % (response["error"]))
+      else:
+        print("HTTP Error: %s" % (response.text))
+
 
 def main(args: argparse.Namespace):
   print(args)
@@ -419,6 +471,15 @@ def main(args: argparse.Namespace):
       f" {avg_output_len:.2f}"
   )
   benchmark_result['avg_output_len'] = avg_output_len
+
+  '''
+  TODO: Add flag for enabling model server scraping
+  Scrape and print model server metrics
+  1. map model server to metrics list
+  2. loop through metrics list, call the same promql queries on each metric, print out the data received
+  '''
+  metrics = metrics_to_scrape(args.backend)
+  print_metrics(metrics, benchmark_time, args.backend)
 
   if args.save_json_results:
     save_json_results(args, benchmark_result)

--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -19,11 +19,17 @@ export IP=$IP
 
 huggingface-cli login --token "$HF_TOKEN" --add-to-git-credential
 
+PYTHON="python3"
+PYTHON_OPTS="benchmark_serving.py "
 for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
   # TODO: Check if profile already exists, if so then skip
   timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
   output_file="latency-profile-${timestamp}.txt"
-  python3 benchmark_serving.py   --host="$IP"   --port="$PORT"   --model="$TOKENIZER" --dataset=ShareGPT_V3_unfiltered_cleaned_split.json   --tokenizer="$TOKENIZER" --request-rate=$request_rate --backend="$BACKEND" --num-prompts=$((request_rate * 30)) --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --scrape-server-metrics=$SCRAPE_SERVER_METRICS > $output_file
+  PYTHON_OPTS="$PYTHON_OPTS --host=$IP   --port=$PORT   --model=$TOKENIZER --dataset=ShareGPT_V3_unfiltered_cleaned_split.json --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$((request_rate * 30)) --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH"
+  if [[ "$SCRAPE_SERVER_METRICS" = "true" ]]; then
+    PYTHON_OPTS="$PYTHON_OPTS --scrape-server-metrics"
+  fi
+  $PYTHON $PYTHON_OPTS > $output_file
   cat $output_file
   sleep 5 # wait 5 seconds before next run
 done

--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -23,7 +23,7 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
   # TODO: Check if profile already exists, if so then skip
   timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
   output_file="latency-profile-${timestamp}.txt"
-  python3 benchmark_serving.py   --host="$IP"   --port="$PORT"   --model="$TOKENIZER" --dataset=ShareGPT_V3_unfiltered_cleaned_split.json   --tokenizer="$TOKENIZER" --request-rate=$request_rate --backend="$BACKEND" --num-prompts=$((request_rate * 30)) --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH > $output_file
+  python3 benchmark_serving.py   --host="$IP"   --port="$PORT"   --model="$TOKENIZER" --dataset=ShareGPT_V3_unfiltered_cleaned_split.json   --tokenizer="$TOKENIZER" --request-rate=$request_rate --backend="$BACKEND" --num-prompts=$((request_rate * 30)) --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --scrape-server-metrics=$SCRAPE_SERVER_METRICS > $output_file
   cat $output_file
   sleep 5 # wait 5 seconds before next run
 done

--- a/benchmarks/benchmark/tools/profile-generator/container/requirements.txt
+++ b/benchmarks/benchmark/tools/profile-generator/container/requirements.txt
@@ -35,3 +35,4 @@ aioprometheus[starlette]
 pynvml == 11.5.0
 accelerate
 aiohttp
+google-auth

--- a/benchmarks/benchmark/tools/profile-generator/main.tf
+++ b/benchmarks/benchmark/tools/profile-generator/main.tf
@@ -77,4 +77,5 @@ module "latency-profile" {
   k8s_hf_secret                              = var.k8s_hf_secret
   hugging_face_secret                        = var.hugging_face_secret
   hugging_face_secret_version                = var.hugging_face_secret_version
+  scrape_server_metrics                      = var.scrape_server_metrics
 }

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
@@ -61,5 +61,6 @@ resource "kubernetes_manifest" "latency-profile-generator" {
     hugging_face_token_secret_list             = local.hugging_face_token_secret == null ? [] : [local.hugging_face_token_secret]
     k8s_hf_secret_list                         = var.k8s_hf_secret == null ? [] : [var.k8s_hf_secret]
     output_bucket                              = var.output_bucket
+    scrape_server_metrics                      = var.scrape_server_metrics
   }))
 }

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
@@ -34,6 +34,8 @@ spec:
               value: ${request_rates}
             - name: OUTPUT_BUCKET
               value: ${output_bucket}
+            - name: SCRAPE_SERVER_METRICS
+              value: ${scrape_server_metrics}
 %{ for hugging_face_token_secret in hugging_face_token_secret_list ~}
             - name: HF_TOKEN
               valueFrom:

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/variables.tf
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/variables.tf
@@ -153,3 +153,9 @@ variable "hugging_face_secret_version" {
   nullable    = true
   default     = null
 }
+
+variable "scrape_server_metrics" {
+  description = "Whether to scrape server metrics."
+  type        = bool
+  default     = false
+}

--- a/benchmarks/benchmark/tools/profile-generator/variables.tf
+++ b/benchmarks/benchmark/tools/profile-generator/variables.tf
@@ -145,3 +145,9 @@ variable "targets" {
     })
   })
 }
+
+variable "scrape_server_metrics" {
+  description = "Whether to scrape server metrics."
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Add initial implementation for scraping server side metrics for analysis.

Initial implementation includes support for vLLM and Jetstream.

Validated end to end, example output at end of output file:
```
Metric Name: vllm:gpu_cache_usage_perc
Mean: 0.6996527777777777
Median: 0.8744212962962963
Min: 0.05439814814814814
Max: 0.9953703703703703
P90: 0.9936342592592593
P99: 0.9951967592592592
Metric Name: vllm:num_requests_waiting
Mean: 25.75
Median: 2.5
Min: 0
Max: 98
P90: 70.10000000000002
P99: 95.20999999999998
```