### PR TITLE
fix: upgrade gke module to avoid TPGv5.44.0 with Autopilot

### DIFF
--- a/infrastructure/versions.tf
+++ b/infrastructure/versions.tf
@@ -18,7 +18,8 @@ terraform {
       source = "hashicorp/google"
     }
     google-beta = {
-      source = "hashicorp/google-beta"
+      source  = "hashicorp/google-beta"
+      version = ">= 5.40.0, != 5.44.0, !=6.2.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/infrastructure/versions.tf
+++ b/infrastructure/versions.tf
@@ -18,8 +18,9 @@ terraform {
       source = "hashicorp/google"
     }
     google-beta = {
-      source  = "hashicorp/google-beta"
-      version = ">= 5.40.0, != 5.44.0, !=6.2.0"
+      source = "hashicorp/google-beta"
+      # Creating Autopilot using GKE submodule is broken in v6.2.0.
+      version = ">= 5.40.0, !=6.2.0"
     }
     helm = {
       source  = "hashicorp/helm"

--- a/modules/gke-autopilot-private-cluster/main.tf
+++ b/modules/gke-autopilot-private-cluster/main.tf
@@ -14,7 +14,7 @@
 
 module "gke" {
   source                  = "terraform-google-modules/kubernetes-engine/google//modules/beta-autopilot-private-cluster"
-  version                 = "32.0.1"
+  version                 = "33.0.0"
   project_id              = var.project_id
   regional                = var.cluster_regional
   name                    = var.cluster_name

--- a/modules/gke-autopilot-public-cluster/main.tf
+++ b/modules/gke-autopilot-public-cluster/main.tf
@@ -14,7 +14,7 @@
 
 module "gke" {
   source                     = "terraform-google-modules/kubernetes-engine/google//modules/beta-autopilot-public-cluster"
-  version                    = "32.0.1"
+  version                    = "33.0.0"
   project_id                 = var.project_id
   regional                   = var.cluster_regional
   name                       = var.cluster_name

--- a/modules/gke-standard-private-cluster/main.tf
+++ b/modules/gke-standard-private-cluster/main.tf
@@ -18,7 +18,7 @@ locals {
 
 module "gke" {
   source                               = "terraform-google-modules/kubernetes-engine/google//modules/private-cluster"
-  version                              = "32.0.1"
+  version                              = "33.0.0"
   project_id                           = var.project_id
   regional                             = var.cluster_regional
   name                                 = var.cluster_name

--- a/modules/gke-standard-public-cluster/main.tf
+++ b/modules/gke-standard-public-cluster/main.tf
@@ -18,7 +18,7 @@ locals {
 
 module "gke" {
   source                               = "terraform-google-modules/kubernetes-engine/google"
-  version                              = "32.0.1"
+  version                              = "33.0.0"
   project_id                           = var.project_id
   regional                             = var.cluster_regional
   name                                 = var.cluster_name


### PR DESCRIPTION
Upgrade gke submoduel version to patch the fix in latest release
https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/releases/tag/v33.0.0
