### PR TITLE
Make LPG results collectable

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -25,7 +25,7 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
   # TODO: Check if profile already exists, if so then skip
   timestamp=$(date +"%Y-%m-%d_%H-%M-%S")
   output_file="latency-profile-${timestamp}.txt"
-  PYTHON_OPTS="$PYTHON_OPTS --host=$IP   --port=$PORT   --model=$TOKENIZER --dataset=ShareGPT_V3_unfiltered_cleaned_split.json --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$((request_rate * 30)) --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH"
+  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP   --port=$PORT   --model=$TOKENIZER --dataset=ShareGPT_V3_unfiltered_cleaned_split.json --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$((request_rate * 30)) --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH"
   if [[ "$SCRAPE_SERVER_METRICS" = "true" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --scrape-server-metrics"
   fi

--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -34,3 +34,5 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
   sleep 5 # wait 5 seconds before next run
 done
 
+export LPG_FINISHED="true"
+sleep infinity

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
@@ -1,15 +1,20 @@
-apiVersion: batch/v1
-kind: Job
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: latency-profile-generator
   namespace: ${namespace}
   labels:
     name: latency-profile-generator
 spec:
+  selector:
+    matchLabels:
+      name: latency-profile-generator
   template:
+    metadata:
+      labels:
+        name: latency-profile-generator
     spec:
       serviceAccountName: ${latency_profile_kubernetes_service_account}
-      restartPolicy: Never
       containers:
         - name: latency-profile-generator
           image: ${artifact_registry}/latency-profile:latest


### PR DESCRIPTION
Two things preventing collecting results:
- LPG is a Job so pod dies immediately after command finishes, changed to Deployment prevent this.
- `--save-json-results` is not enabled by default, changed to enabled by default