### PR TITLE
Updating the pause container image location.

### DIFF
--- a/scripts/network-setup/v6e-network-optimization.yaml
+++ b/scripts/network-setup/v6e-network-optimization.yaml
@@ -168,5 +168,5 @@ spec:
             path: /
             type: Directory
       containers:
-      - image: "pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830"
+      - image: "gke.gcr.io/pause:3.8@sha256:880e63f94b145e46f1b1082bb71b85e21f16b99b180b9996407d61240ceb9830"
         name: pause


### PR DESCRIPTION
This worked internally but does not seem to be working when pulling the script via kubectl.

EDIT: to clarify, it *used to* work internally, but does not anymore. This proposed fix has been verified to work and should be more stable.