### PR TITLE
fix: remove gke cluster version

### DIFF
--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -79,10 +79,7 @@ module "infra" {
   enable_gpu        = true
   gpu_pools         = var.gpu_pools
   ray_addon_enabled = true
-  # TODO(genlu): remove channel and k8s_version after ray addon is in REGULAR channel
-  release_channel    = "RAPID"
-  kubernetes_version = "1.30.3-gke.1969000"
-  depends_on         = [module.project-services]
+  depends_on        = [module.project-services]
 }
 
 data "google_container_cluster" "default" {

--- a/applications/ray/main.tf
+++ b/applications/ray/main.tf
@@ -74,10 +74,7 @@ module "infra" {
   enable_gpu        = var.enable_gpu
   gpu_pools         = var.gpu_pools
   ray_addon_enabled = true
-  # TODO(genlu): remove channel and k8s_version after ray addon is in REGULAR channel
-  release_channel    = "RAPID"
-  kubernetes_version = "1.30.3-gke.1969000"
-  depends_on         = [module.project-services]
+  depends_on        = [module.project-services]
 }
 
 data "google_container_cluster" "default" {

--- a/infrastructure/tfvars_tests/standard-gke-public.platform.tfvars
+++ b/infrastructure/tfvars_tests/standard-gke-public.platform.tfvars
@@ -37,9 +37,6 @@ cluster_name        = "test-cluster"
 cluster_location    = "us-east4"
 gcs_fuse_csi_driver = true
 ray_addon_enabled   = true
-# TODO(genlu): remove release_channel and kubernetes_version after 1.30.3-gke.1969000 is in REGULAR channel
-release_channel    = "RAPID"
-kubernetes_version = "1.30.3-gke.1969000"
 
 cpu_pools = [{
   name         = "cpu-pool"

--- a/infrastructure/versions.tf
+++ b/infrastructure/versions.tf
@@ -20,7 +20,7 @@ terraform {
     google-beta = {
       source = "hashicorp/google-beta"
       # Creating Autopilot using GKE submodule is broken in v6.2.0.
-      version = ">= 5.40.0, !=6.2.0"
+      version = ">= 5.40.0, <= 6.1.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
The pinged version has reached to REGULAR channel. 
The default GKE version used in our TF is 1.30, which will pick the highest version in REGULAR channel. 