### PR TITLE
Missing JSON fields

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -538,7 +538,6 @@ def main(args: argparse.Namespace):
   server_metrics = {}
   if args.scrape_server_metrics:
     server_metrics = print_metrics(metrics_to_scrape(args.backend), benchmark_time, args.backend)
-  print(benchmark_result)
   if args.save_json_results:
     save_json_results(args, benchmark_result, server_metrics)
 


### PR DESCRIPTION
[PR #832 ](https://github.com/GoogleCloudPlatform/ai-on-gke/pull/832) introduced a bug where the folllowing keys werent set on 'metrics', this PR fixes this.

```
    "benchmark_time": 44.91958165168762,
    "total_output_token": 58986,
    "output_tokens_per_min": 78788.80145062602,
    "total_input_tokens": 39871,
    "input_tokens_per_min": 53256.506673412514,
    "total_tokens": 98857,
    "tokens_per_min": 132045.30812403854,
    "avg_latency": 7.175992427666982,
    "avg_per_token_latency": 0.06020041991300422,
    "avg_per_output_token_latency": 0.35792783426739533,
    "avg_input_len": 66.45166666666667,
    "avg_output_len": 98.31
```

Example fixed output JSON:

```
{
  "metrics": {
    "num_prompts": 600,
    "request_rate": 20,
    "server_metrics": {
      "jetstream_slots_used_percentage": {
        "Mean": "0.80625",
        "Median": "1",
        "Std": "0.3875",
        "Min": "0.03125",
        "Max": "1",
        "P90": "1",
        "P99": "1"
      },
      "jetstream_prefill_backlog_size": {
        "Mean": "55.4",
        "Median": "59",
        "Std": "42.846703490467036",
        "Min": "0",
        "Max": "124",
        "P90": "103.2",
        "P99": "121.91999999999999"
      },
      "jetstream_time_to_first_token": {
        "Mean": "0.13120518984972915",
        "Median": "0.16634615384615387",
        "Min": "0.01",
        "Max": "0.25",
        "P90": "0.23326923076923076",
        "P99": "0.24832692307692308"
      },
      "jetstream_time_per_output_token": {
        "Mean": "0",
        "Median": "0.028433476394849787",
        "Min": "0.01",
        "Max": "2.5",
        "P90": "0.06770270270270269",
        "P99": "2.5"
      },
      "jetstream_time_per_request": {
        "Mean": "2.4746437307432325",
        "Median": "2.1858638743455496",
        "Min": "1",
        "Max": "10",
        "P90": "5.3442622950819665",
        "P99": "9.5344262295082"
      }
    },
    "benchmark_time": 44.91958165168762,
    "total_output_token": 58986,
    "output_tokens_per_min": 78788.80145062602,
    "total_input_tokens": 39871,
    "input_tokens_per_min": 53256.506673412514,
    "total_tokens": 98857,
    "tokens_per_min": 132045.30812403854,
    "avg_latency": 7.175992427666982,
    "avg_per_token_latency": 0.06020041991300422,
    "avg_per_output_token_latency": 0.35792783426739533,
    "avg_input_len": 66.45166666666667,
    "avg_output_len": 98.31
  },
  "dimensions": {
    "date": "20240925-163414",
    "backend": "jetstream",
    "model_id": "google/gemma-7b",
    "tokenizer_id": "google/gemma-7b"
  },
  "config": {
    "model": "google/gemma-7b",
    "model_server": "jetstream",
    "start_time": "2024-09-25T16:34:14.365Z"
  },
  "summary_stats": {
    "stats": {
      "ttft": {
        "Mean": "0.13120518984972915",
        "Median": "0.16634615384615387",
        "Min": "0.01",
        "Max": "0.25",
        "P90": "0.23326923076923076",
        "P99": "0.24832692307692308"
      },
      "tpot": {
        "Mean": "0",
        "Median": "0.028433476394849787",
        "Min": "0.01",
        "Max": "2.5",
        "P90": "0.06770270270270269",
        "P99": "2.5"
      },
      "request_latency": {
        "Mean": "2.4746437307432325",
        "Median": "2.1858638743455496",
        "Min": "1",
        "Max": "10",
        "P90": "5.3442622950819665",
        "P99": "9.5344262295082"
      }
    }
  }
}
```