### PR TITLE
Rely on script to gather data, not Prometheus

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -300,7 +300,7 @@ def save_json_results(args: argparse.Namespace, benchmark_result, server_metrics
     "config": {
       "model": args.model,
       "model_server": args.backend,
-      "start_time": start_dt_proto.ToJsonString(),
+      # "start_time": start_dt_proto.ToJsonString(), TODO: Marshall this such that the unmarshaller doesnt error
     },
     "summary_stats": {
       "stats": [{


### PR DESCRIPTION
The metrics the benchmarking script gathers will be the closest to what an end user would see, as such we should use these for generating profiles. `start_time` has been temporarily removed since more investigation is needed to correctly implement this, this will be re-added in a follow up PR/