### PR TITLE
Added Prometheus Server to LPG

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/container/requirements.txt
+++ b/benchmarks/benchmark/tools/profile-generator/container/requirements.txt
@@ -35,3 +35,4 @@ pynvml == 11.5.0
 accelerate
 aiohttp
 google-auth
+prometheus_client >= 0.21.0

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
@@ -23,7 +23,8 @@ locals {
     ? "${path.module}/manifest-templates"
     : pathexpand(var.templates_path)
   )
-  latency-profile-generator-template = "${path.module}/manifest-templates/latency-profile-generator.yaml.tpl"
+  latency-profile-generator-template                = "${path.module}/manifest-templates/latency-profile-generator.yaml.tpl"
+  latency-profile-generator-podmonitoring-template  = "${path.module}/manifest-templates/latency-profile-generator-podmonitoring.yaml.tpl"
   hugging_face_token_secret = (
     var.hugging_face_secret == null || var.hugging_face_secret_version == null
     ? null
@@ -68,4 +69,10 @@ resource "kubernetes_manifest" "latency-profile-generator" {
     save_aggregated_result                     = var.save_aggregated_result
     models                                     = var.models
   }))
+}
+
+resource "kubernetes_manifest" "latency-profile-generator-podmonitoring" {
+   manifest = yamldecode(templatefile(local.latency-profile-generator-podmonitoring-template, {
+     namespace = var.namespace
+   }))
 }

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
@@ -23,8 +23,8 @@ locals {
     ? "${path.module}/manifest-templates"
     : pathexpand(var.templates_path)
   )
-  latency-profile-generator-template                = "${path.module}/manifest-templates/latency-profile-generator.yaml.tpl"
-  latency-profile-generator-podmonitoring-template  = "${path.module}/manifest-templates/latency-profile-generator-podmonitoring.yaml.tpl"
+  latency-profile-generator-template               = "${path.module}/manifest-templates/latency-profile-generator.yaml.tpl"
+  latency-profile-generator-podmonitoring-template = "${path.module}/manifest-templates/latency-profile-generator-podmonitoring.yaml.tpl"
   hugging_face_token_secret = (
     var.hugging_face_secret == null || var.hugging_face_secret_version == null
     ? null
@@ -72,7 +72,7 @@ resource "kubernetes_manifest" "latency-profile-generator" {
 }
 
 resource "kubernetes_manifest" "latency-profile-generator-podmonitoring" {
-   manifest = yamldecode(templatefile(local.latency-profile-generator-podmonitoring-template, {
-     namespace = var.namespace
-   }))
+  manifest = yamldecode(templatefile(local.latency-profile-generator-podmonitoring-template, {
+    namespace = var.namespace
+  }))
 }

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator-podmonitoring.yaml.tpl
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator-podmonitoring.yaml.tpl
@@ -1,0 +1,12 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: "lpg-driver-podmonitoring"
+  namespace: ${namespace}
+spec:
+  selector:
+    matchLabels:
+      name: latency-profile-generator
+  endpoints:
+  - port: 9090
+    interval: 15s

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
@@ -64,3 +64,15 @@ spec:
                   name: hf-token
                   key: HF_TOKEN
 %{ endfor ~}
+---
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: "lpg-driver-podmonitoring"
+spec:
+  selector:
+    matchLabels:
+      name: latency-profile-generator
+  endpoints:
+  - port: 9090
+    interval: 15s

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
@@ -64,15 +64,3 @@ spec:
                   name: hf-token
                   key: HF_TOKEN
 %{ endfor ~}
----
-apiVersion: monitoring.googleapis.com/v1
-kind: PodMonitoring
-metadata:
-  name: "lpg-driver-podmonitoring"
-spec:
-  selector:
-    matchLabels:
-      name: latency-profile-generator
-  endpoints:
-  - port: 9090
-    interval: 15s


### PR DESCRIPTION
- Added a Prometheus server running on port 9090
- Added the `LatencyProfileGenerator:prompt_length`, `"LatencyProfileGenerator:response_length`, and `LatencyProfileGenerator:time_per_output_token` metrics.
- Added PodMonitoring resource in Terraform automation.

Example results in GMP:
<img width="1175" alt="Screenshot 2024-10-24 at 15 26 52" src="https://github.com/user-attachments/assets/11804c6b-d74f-4458-addf-69ff22dad8d7">
<img width="1179" alt="Screenshot 2024-10-24 at 15 27 36" src="https://github.com/user-attachments/assets/1fa28855-2764-43a3-8000-b4a03d0745c6">
<img width="1185" alt="Screenshot 2024-10-24 at 15 26 13" src="https://github.com/user-attachments/assets/ab764ed6-0b89-4910-bcc6-4de7581d2f04">

