### PR TITLE
Fix Webhook Assigning Identical `TPU_WORKER_ID`s

### DIFF
--- a/ray-on-gke/tpu/kuberay-tpu-webhook/Troubleshooting.md
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/Troubleshooting.md
@@ -2,6 +2,14 @@
 Common issues and their solutions when deploying Ray TPU worker groups with the webhook.
 Solutions will be added as new issues are encountered.
 
+## `TPU_WORKER_ID` assigned to multiple TPU workers in slice
+
+### Symptoms
+The webhook outputs the error message `Identical TPU_WORKER_ID assigned to multiple TPU workers in slice`.
+
+### Solution #1
+The Ray TPU webhook relies on a PodInformer cache to retrieve the current state of TPU worker Pods in a RayCluster and assign `TPU_WORKER_ID`s. This informer is synced prior to each Pod mutation. However, when quickly deleting and and re-creating RayClusters (especially for larger worker groups), it's possible for the PodLister to retrieve stale information and incorrectly assign `TPU_WORKER_ID`s. This issue is more likely to occur with a large number of worker nodes. The easiest solution in this case is to just delete the Ray custom resource and create it again with `kubectl apply`.
+
 ## `TPU_WORKER_HOSTNAMES` aren't injected into the Pod environment
 
 ### Symptoms
@@ -55,8 +63,3 @@ workerGroupSpecs:
           requests:
             google.com/tpu: "{$TPU_CHIPS_PER_WORKER}"
 ```
-
-## `TPU_WORKER_ID`s incorrectly assigned when re-creating a RayCluster of the same name
-
-### Solution #1
-A limitation of the webhook is that it relies on RayCluster and Pod creation/deletion requests to be intercepted in-order, which isn't necessarily true when deleting a RayCluster and re-creating it too quickly. It's possible for the second creation request to be intercepted before the deletion request, causing the webhook to incorrectly assign `TPU_WORKER_ID`s for the new Pods. A solution for this issue is to wait a few seconds before creating a RayCluster of the same name, or to change the name of the RayCluster before re-creating it.

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/Troubleshooting.md
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/Troubleshooting.md
@@ -2,14 +2,6 @@
 Common issues and their solutions when deploying Ray TPU worker groups with the webhook.
 Solutions will be added as new issues are encountered.
 
-## `TPU_WORKER_ID` assigned to multiple TPU workers in slice
-
-### Symptoms
-The webhook outputs the error message `Identical TPU_WORKER_ID assigned to multiple TPU workers in slice`.
-
-### Solution #1
-The Ray TPU webhook relies on a PodInformer cache to retrieve the current state of TPU worker Pods in a RayCluster and assign `TPU_WORKER_ID`s. This informer is synced prior to each Pod mutation. However, when quickly deleting and and re-creating RayClusters (especially for larger worker groups), it's possible for the PodLister to retrieve stale information and incorrectly assign `TPU_WORKER_ID`s. This issue is more likely to occur with a large number of worker nodes. The easiest solution in this case is to just delete the Ray custom resource and create it again with `kubectl apply`.
-
 ## `TPU_WORKER_HOSTNAMES` aren't injected into the Pod environment
 
 ### Symptoms

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/main.go
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/main.go
@@ -627,7 +627,6 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 	numOfHosts, _ := getNumTPUHostsFromTopology(clusterName, groupName, namespace, topology, chipsPerHost) // ignore error here because topology may not be set yet
 
 	// Wait for PodInformer cache to update from previous requests or timeout
-	waitTimeout(&t.wg, time.Second*1)
 	if waitTimeout(&t.wg, time.Second*1) {
 		klog.V(1).Info("MutatePod", "PodInformer AddFunc called for prior admission request")
 	} else {

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/main.go
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/main.go
@@ -29,6 +29,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	ray "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -40,6 +41,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	listersv1 "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 )
@@ -56,7 +58,8 @@ type slice struct {
 // TPUWebhookServer is a KubeRay TPU webhook server instance.
 type TPUWebhookServer struct {
 	// podLister is used to query Pods from an informer cache.
-	podLister listersv1.PodLister
+	podLister  listersv1.PodLister
+	cacheMutex sync.Mutex
 }
 
 // patch is a JSON patch describing mutate operation(s) for an incoming object.
@@ -86,6 +89,9 @@ func NewTPUWebhookServer(podLister listersv1.PodLister) *TPUWebhookServer {
 
 // Mutate handles http Request for Pod creation and writes a response
 func (t *TPUWebhookServer) Mutate(w http.ResponseWriter, r *http.Request) {
+	t.cacheMutex.Lock()
+	defer t.cacheMutex.Unlock()
+
 	admissionReview := &admissionv1.AdmissionReview{}
 	if err := json.NewDecoder(r.Body).Decode(admissionReview); err != nil {
 		http.Error(w, "Error decoding request body", http.StatusBadRequest)
@@ -450,22 +456,30 @@ func getReplicaIndex(sliceToWorkerIDs map[slice][]int, clusterName string, group
 }
 
 // getNextWorkerID returns the next lowest TPU_WORKER_ID in the Pod Slice
-func getNextWorkerID(sliceToWorkerIDs map[slice][]int, podSlice slice, namespace string, replicaIndex int) int {
+func getNextWorkerID(sliceToWorkerIDs map[slice][]int, podSlice slice, namespace string, replicaIndex int) (int, error) {
 	tpuWorkerID := 0 // defaults to 0 (first Pod in slice)
 	if len(sliceToWorkerIDs) == 0 || len(sliceToWorkerIDs[podSlice]) == 0 {
-		return tpuWorkerID
+		return tpuWorkerID, nil
 	}
 	sort.Ints(sliceToWorkerIDs[podSlice])
 	// iterate through existing workers and get the next lowest, unused ID
-	for _, workerID := range sliceToWorkerIDs[podSlice] {
+	lastID := 0
+	for index, workerID := range sliceToWorkerIDs[podSlice] {
+		// check for incorrect assignment of IDs
+		if index == 0 {
+			lastID = workerID
+		} else if workerID == lastID {
+			return 0, errors.New("Identical TPU_WORKER_ID assigned to multiple TPU workers in slice")
+		}
+		// get the next lowest, valid TPU_WORKER_ID
 		if workerID != tpuWorkerID {
 			break
 		}
+		lastID = workerID
 		tpuWorkerID++
 	}
-
-	klog.V(1).InfoS("getNextWorkerID", "RayCluster", namespace+"/"+podSlice.clusterName, "Worker Group", podSlice.groupName, "TPU_WORKER_ID", tpuWorkerID)
-	return tpuWorkerID
+	klog.V(1).InfoS("getNextWorkerID", "RayCluster", namespace+"/"+podSlice.clusterName, "Worker Group", podSlice.groupName, "replicaIndex", replicaIndex, "TPU_WORKER_ID", tpuWorkerID)
+	return tpuWorkerID, nil
 }
 
 // getSliceToWorkerIDs returns a mapping representing the current RayCluster state of TPU pods using a PodLister
@@ -602,8 +616,10 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 	}
 	replicaIndex := getReplicaIndex(sliceToWorkerIDs, clusterName, groupName, namespace)
 	podSlice := slice{clusterName, groupName, namespace, replicaIndex, numOfHosts}
-	tpuWorkerID := getNextWorkerID(sliceToWorkerIDs, podSlice, namespace, replicaIndex) // defaults to 0 for single-host
-
+	tpuWorkerID, err := getNextWorkerID(sliceToWorkerIDs, podSlice, namespace, replicaIndex) // defaults to 0 for single-host
+	if err != nil {
+		return nil, err
+	}
 	// inject replica index label
 	injectReplicaLabel(clusterName, namespace, replicaIndex, groupName, &patches)
 
@@ -731,17 +747,23 @@ func main() {
 	tweakListOptionsFunc := func(options *metav1.ListOptions) {
 		options.LabelSelector = "ray.io/node-type=worker,app.kubernetes.io/created-by=kuberay-operator"
 	}
-	factory := informers.NewFilteredSharedInformerFactory(client, 5*time.Minute, metav1.NamespaceAll, tweakListOptionsFunc)
-	podLister := factory.Core().V1().Pods().Lister()
-
-	if podLister == nil {
-		klog.Fatal("Failed to initialize Pod Lister")
-	}
+	factory := informers.NewFilteredSharedInformerFactory(client, 1*time.Minute, metav1.NamespaceAll, tweakListOptionsFunc)
+	podInformer := factory.Core().V1().Pods().Informer()
 
 	// start the PodInformer and wait for cache sync
 	stopCh := make(chan struct{})
 	factory.Start(stopCh)
 	factory.WaitForCacheSync(stopCh)
+
+	if !cache.WaitForCacheSync(stopCh, podInformer.HasSynced) {
+		klog.Fatal("Timed out waiting for PodInformer to sync")
+	}
+
+	podLister := factory.Core().V1().Pods().Lister()
+
+	if podLister == nil {
+		klog.Fatal("Failed to initialize Pod Lister")
+	}
 
 	// close the PodInformer on exit
 	defer close(stopCh)

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/webhook_main_test.go
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/webhook_main_test.go
@@ -1195,19 +1195,21 @@ func Test_GetSliceToWorkerIDs(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			testClient := setupClient(tc.podsInGroup)
-			// set up TPUWebhookServer
-			tpuWebhookServer := NewTPUWebhookServer(testClient)
-
-			sliceToWorkerIDs, err := getSliceToWorkerIDs(tpuWebhookServer, "test-cluster", "test-group", "test-namespace", tc.numOfHosts)
+			podLister := setupInformer(tc.podsInGroup)
+			tpuWebhook := NewTPUWebhookServer(podLister)
+			sliceToWorkerIDs, err := tpuWebhook.getSliceToWorkerIDs("test-cluster", "test-group", "test-namespace", tc.numOfHosts)
 
 			// sliceToWorkerIDs should be populated with slices and unique TPU_WORKER_IDs for each Pod
 			assert.Equal(t, err, nil)
 			for slice, workerIDs := range sliceToWorkerIDs {
 				assert.Contains(t, tc.expectedSliceToWorkerIDs, slice)
 				assert.Equal(t, len(tc.expectedSliceToWorkerIDs[slice]), len(workerIDs))
+			for slice, workerIDs := range sliceToWorkerIDs {
+				assert.Contains(t, tc.expectedSliceToWorkerIDs, slice)
+				assert.Equal(t, len(tc.expectedSliceToWorkerIDs[slice]), len(workerIDs))
 				sort.Ints(workerIDs)
 				for index, value := range workerIDs {
+					assert.Equal(t, tc.expectedSliceToWorkerIDs[slice][index], value)
 					assert.Equal(t, tc.expectedSliceToWorkerIDs[slice][index], value)
 				}
 			}


### PR DESCRIPTION
This PR adds a `sync.WaitGroup` object and integer `waiting` var to each `TPUWebhookServer` object. All goroutine calls to `mutatePod` now `Wait()` before listing from the PodInformer cache, or timeout after 1 second, and then increment the waiting var and call `wg.Add(1)`. `wg.Done()` is called by the `AddFunc` `EventHandler`, which indicates the PodInformer has updated with the last Pod admitted by that webhook replica. This ensures the PodInformer cache is available and updating prior to listing from the cache. To support multiple webhook replicas, `wg.Done()` is only called if the int `waiting` var on the `TPUWebhookServer` object is greater than 1. This allows the webhook to block on previous `TPUWebhookServer.Mutate` calls until the PodInformer cache updates at least once.  I also added error checking for identical `TPU_WORKER_ID`s being assigned within the same slice (as opposed to just letting the Jax initialization time out).

Testing:
- [x] Unit Tests
- [x] Manual Tests: tested with a v6e-256 Ray TPU worker group for  1 and 3 webhook replicas respectively 

Related Issue #: [858](https://github.com/GoogleCloudPlatform/ai-on-gke/issues/858)