### PR TITLE
Adding streaming support to the benchmarking script

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/build.tf
+++ b/benchmarks/benchmark/tools/profile-generator/build.tf
@@ -3,6 +3,6 @@ resource "null_resource" "build_and_push_image" {
   depends_on = [resource.google_project_service.cloudbuild]
   provisioner "local-exec" {
     working_dir = path.module
-    command     = "gcloud builds submit --tag ${var.artifact_registry}/latency-profile:stream-test-v1 container"
+    command     = "gcloud builds submit --tag ${var.artifact_registry}/latency-profile:latest container"
   }
 }

--- a/benchmarks/benchmark/tools/profile-generator/build.tf
+++ b/benchmarks/benchmark/tools/profile-generator/build.tf
@@ -3,6 +3,6 @@ resource "null_resource" "build_and_push_image" {
   depends_on = [resource.google_project_service.cloudbuild]
   provisioner "local-exec" {
     working_dir = path.module
-    command     = "gcloud builds submit --tag ${var.artifact_registry}/latency-profile:latest container"
+    command     = "gcloud builds submit --tag ${var.artifact_registry}/latency-profile:stream-test-v1 container"
   }
 }

--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -191,23 +191,23 @@ async def send_stream_request(
     except aiohttp.client_exceptions.ClientConnectorError as client_err:
       errors["ClientConnectorError"] += 1
       print(f"ClientConnectorError: {client_err}")
-      return None, None,errors
+      return None, None, errors
     except asyncio.TimeoutError as timeout_err:
       errors["TimeoutError"] += 1
       print(f"TimeoutError: {timeout_err}")
-      return None, None,errors
+      return None, None, errors
     except aiohttp.client_exceptions.ClientOSError as e:
       errors["ClientOSError"] += 1
       print(f"ClientOSError: {e}")
-      return None, None,errors
+      return None, None, errors
     except aiohttp.client_exceptions.ContentTypeError as e:
       print(f"ContentTypeError: {e}, response: {response}")
       errors["ContentTypeError"] += 1
-      return None, None,errors
+      return None, None, errors
     except aiohttp.client_exceptions.ServerDisconnectedError as e:
       errors["ServerDisconnectedError"] += 1
       print(f"ServerDisconnectedError: {e}")
-      return None, None,errors
+      return None, None, errors
     except Exception as e: 
       print(f"Unknown error {e}")
       errors["unknown_error"] += 1
@@ -316,7 +316,7 @@ async def send_request(
       except aiohttp.client_exceptions.ClientConnectorError as client_err:
         errors["ClientConnectorError"] += 1
         print(f"ClientConnectorError: {client_err}")
-        return None, None,errors
+        return None, None, errors
       except asyncio.TimeoutError as timeout_err:
         errors["TimeoutError"] += 1
         print(f"TimeoutError: {timeout_err}")
@@ -328,15 +328,15 @@ async def send_request(
       except aiohttp.client_exceptions.ContentTypeError as e:
         print(f"ContentTypeError: {e}, response: {response}")
         errors["ContentTypeError"] += 1
-        return None, None,errors
+        return None, None, errors
       except aiohttp.client_exceptions.ServerDisconnectedError as e:
         errors["ServerDisconnectedError"] += 1
         print(f"ServerDisconnectedError: {e}")
-        return None, None,errors
+        return None, None, errors
       except Exception as e: 
         print(f"Unknown error {e}")
         errors["unknown_error"] += 1
-        return None, None,errors
+        return None, None, errors
 
   request_end_time = time.time()
   # Naive HF transformers generation and TensorRT-LLM generation stops at EOS
@@ -389,7 +389,6 @@ async def benchmark(
   )
   benchmark_start_time = time.time()
   tasks: List[asyncio.Task] = []
-  num_request = 0
   async for request in get_request(input_requests, args.request_rate):
     prompt, prompt_len, output_len = request
     if args.stream_request:
@@ -641,7 +640,7 @@ def get_stats_for_set(name, description, points):
     f'p99_{name}': p99,
   }
 
-def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_requests, model, request_latencies, ttfts,errors):
+def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_requests, model, request_latencies, ttfts, errors):
   benchmark_result = {}
 
   print(f"====Result for Model: {model}====")
@@ -761,7 +760,7 @@ async def main(args: argparse.Namespace):
   
   benchmark_duration_all_models = time.time() - benchmark_start_time
   if args.save_aggregated_result:
-    print_and_save_result(args, benchmark_duration_all_models, len(models)*args.num_prompts, f"ALL-{len(models)}-MODELS", combined_latencies, combined_ttfts,combined_errors)
+    print_and_save_result(args, benchmark_duration_all_models, len(models)*args.num_prompts, f"ALL-{len(models)}-MODELS", combined_latencies, combined_ttfts, combined_errors)
 
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(

--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -173,7 +173,6 @@ async def send_stream_request(
   st = time.perf_counter()
   output = ""
   timeout = aiohttp.ClientTimeout(total=CLIENT_TIMEOUT_SEC)
-  print("right before sending request")
   async with aiohttp.ClientSession(timeout=timeout,trust_env=True) as session:
     try:
       async with session.post(api_url, headers=headers, json=pload, ssl=False) as response:
@@ -394,7 +393,6 @@ async def benchmark(
   async for request in get_request(input_requests, args.request_rate):
     prompt, prompt_len, output_len = request
     if args.stream_request:
-      print("streaming request")
       task = asyncio.create_task(
         send_stream_request(
             args.backend,
@@ -428,7 +426,6 @@ async def benchmark(
       )
     tasks.append(task)
   results = await asyncio.gather(*tasks)
-  print("done waiting")
   combined_latencies = []
   combined_ttfts = []
   combined_errors = init_errors_map()
@@ -682,7 +679,14 @@ def print_and_save_result(args: argparse.Namespace, benchmark_duration, total_re
 
   if args.stream_request:
     mean_ttft=np.mean(ttfts)
-    print(f"Mean TTFT (ms): {mean_ttft:.2f}")
+    median_ttft=np.median(ttfts)
+    p99_ttft=np.percentile(ttfts, 99)
+    print(f"Mean TTFT (s): {mean_ttft:.2f}")
+    print(f"Median TTFT (s): {median_ttft:.2f}")
+    print(f"P99 TTFT (s): {p99_ttft:.2f}")
+    benchmark_result['mean_ttft'] = mean_ttft
+    benchmark_result['median_ttft'] = median_ttft
+    benchmark_result['p99_ttft'] = p99_ttft
 
   if args.machine_cost:
     print(

--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -37,12 +37,15 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
     num_prompts=$(awk "BEGIN {print int($request_rate * $BENCHMARK_TIME_SECONDS)}")
   fi
   echo "TOTAL prompts: $num_prompts"  # Output: 8
-  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP   --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS --stream-request=$STREAM_REQUEST"
+  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP   --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS
   if [[ "$SCRAPE_SERVER_METRICS" = "true" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --scrape-server-metrics"
   fi
   if [[ "$SAVE_AGGREGATED_RESULT" = "true" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --save-aggregated-result"
+  fi
+  if [[ "$STREAM_REQUEST" = "true"]]; then
+    PYTHON_OPTS="$PYTHON_OPTS --stream-request"
   fi
   $PYTHON $PYTHON_OPTS > $output_file
   cat $output_file

--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -37,14 +37,14 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
     num_prompts=$(awk "BEGIN {print int($request_rate * $BENCHMARK_TIME_SECONDS)}")
   fi
   echo "TOTAL prompts: $num_prompts"  # Output: 8
-  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP   --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS
+  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP   --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS"
   if [[ "$SCRAPE_SERVER_METRICS" = "true" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --scrape-server-metrics"
   fi
   if [[ "$SAVE_AGGREGATED_RESULT" = "true" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --save-aggregated-result"
   fi
-  if [[ "$STREAM_REQUEST" = "true"]]; then
+  if [[ "$STREAM_REQUEST" = "true" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --stream-request"
   fi
   $PYTHON $PYTHON_OPTS > $output_file

--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -37,7 +37,7 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
     num_prompts=$(awk "BEGIN {print int($request_rate * $BENCHMARK_TIME_SECONDS)}")
   fi
   echo "TOTAL prompts: $num_prompts"  # Output: 8
-  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP   --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS"
+  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP   --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS --stream-request=$STREAM_REQUEST"
   if [[ "$SCRAPE_SERVER_METRICS" = "true" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --scrape-server-metrics"
   fi

--- a/benchmarks/benchmark/tools/profile-generator/main.tf
+++ b/benchmarks/benchmark/tools/profile-generator/main.tf
@@ -83,4 +83,5 @@ module "latency-profile" {
   file_prefix                                = var.file_prefix
   save_aggregated_result                     = var.save_aggregated_result
   models                                     = var.models
+  stream_request                             = var.stream_request
 }

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
@@ -68,6 +68,7 @@ resource "kubernetes_manifest" "latency-profile-generator" {
     file_prefix                                = var.file_prefix
     save_aggregated_result                     = var.save_aggregated_result
     models                                     = var.models
+    stream_request = var.stream_request
   }))
 }
 

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
@@ -68,7 +68,7 @@ resource "kubernetes_manifest" "latency-profile-generator" {
     file_prefix                                = var.file_prefix
     save_aggregated_result                     = var.save_aggregated_result
     models                                     = var.models
-    stream_request = var.stream_request
+    stream_request                             = var.stream_request
   }))
 }
 

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: ${latency_profile_kubernetes_service_account}
       containers:
         - name: latency-profile-generator
-          image: ${artifact_registry}/latency-profile:latest
+          image: ${artifact_registry}/latency-profile:stream-test-v1
           command: ["bash", "-c", "./latency_throughput_curve.sh"]
           env:
             - name: MODELS
@@ -50,6 +50,8 @@ spec:
               value: ${file_prefix}
             - name: SAVE_AGGREGATED_RESULT
               value: ${save_aggregated_result}
+            - name: STREAM_REQUEST
+              value: ${stream_request}
 %{ for hugging_face_token_secret in hugging_face_token_secret_list ~}
             - name: HF_TOKEN
               valueFrom:

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: ${latency_profile_kubernetes_service_account}
       containers:
         - name: latency-profile-generator
-          image: ${artifact_registry}/latency-profile:stream-test-v1
+          image: ${artifact_registry}/latency-profile:latest
           command: ["bash", "-c", "./latency_throughput_curve.sh"]
           env:
             - name: MODELS

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/variables.tf
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/variables.tf
@@ -197,3 +197,9 @@ variable "save_aggregated_result" {
   type        = bool
   default     = false
 }
+
+variable "stream_request" {
+  description = "Whether to stream the request. Needed for TTFT metric"
+  type = bool
+  default = false
+}

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/variables.tf
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/variables.tf
@@ -200,6 +200,6 @@ variable "save_aggregated_result" {
 
 variable "stream_request" {
   description = "Whether to stream the request. Needed for TTFT metric"
-  type = bool
-  default = false
+  type        = bool
+  default     = false
 }

--- a/benchmarks/benchmark/tools/profile-generator/variables.tf
+++ b/benchmarks/benchmark/tools/profile-generator/variables.tf
@@ -189,3 +189,9 @@ variable "save_aggregated_result" {
   type        = bool
   default     = false
 }
+
+variable "stream_request" {
+  description = "Whether to stream the request. Needed for TTFT metric"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
Added new variable `stream_request` to determine whether or not to stream the request. Default value is false. Only vLLM is supported.

Also added TTFT metric.