### PR TITLE
GCS Bucket upload support

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -796,7 +796,8 @@ if __name__ == "__main__":
       "Specifies the destination path within the bucket provided by"
       " --output-bucket for uploading the JSON results. This argument requires"
       " --output-bucket to be set. If not specified, results will be uploaded "
-      " to the root of the bucket."
+      " to the root of the bucket. If the filepath doesnt exist, it will be"
+      " created for you."
     )
   )
   parser.add_argument(

--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -48,7 +48,7 @@ trace_config = aiohttp.TraceConfig()
 trace_config.on_request_start.append(on_request_start)
 trace_config.on_request_end.append(on_request_end)
 
-# Google Cloud Storage Bucket Clients
+# Google Cloud Storage Bucket Client
 gcs_client = storage.Client()
 gcs_bucket = None
 
@@ -776,7 +776,10 @@ if __name__ == "__main__":
     "--output-bucket",
     type=str,
     default=None,
-    help="If specified, results json will be uploaded to this Google Cloud Storage bucket",
+    help=(
+      "If specified, results in json format will be uploaded to the Google"
+      " Cloud Storage bucket specified here"
+    )
   )
   parser.add_argument(
     "--save-aggregated-result",

--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -17,6 +17,7 @@ from prometheus_client import start_http_server, Histogram, Gauge
 
 import google.auth
 import google.auth.transport.requests
+from google.cloud import storage
 
 import aiohttp
 import numpy as np
@@ -46,6 +47,10 @@ async def on_request_end(session, trace_config_ctx, params):
 trace_config = aiohttp.TraceConfig()
 trace_config.on_request_start.append(on_request_start)
 trace_config.on_request_end.append(on_request_end)
+
+# Google Cloud Storage Bucket Clients
+gcs_client = storage.Client()
+gcs_bucket = None
 
 def sample_requests(
     dataset_path: str,
@@ -337,7 +342,6 @@ async def benchmark(
   print_and_save_result(args, benchmark_duration, len(input_requests), model, combined_latencies, combined_errors)
   return combined_latencies, combined_errors
 
-
 def save_json_results(args: argparse.Namespace, benchmark_result, server_metrics, model, errors):
   # Setup
   start_dt_proto = Timestamp()
@@ -427,6 +431,9 @@ def save_json_results(args: argparse.Namespace, benchmark_result, server_metrics
   )
   with open(file_name, "w", encoding="utf-8") as outfile:
     json.dump(final_json, outfile)
+  if gcs_bucket is not None:
+    gcs_bucket.blob(file_name).upload_from_filename(file_name)
+    print(f"File {file_name} uploaded to {args.output_bucket}")
 
 def metrics_to_scrape(backend: str) -> List[str]:
   # Each key in the map is a metric, it has a corresponding 'stats' object
@@ -610,6 +617,12 @@ async def main(args: argparse.Namespace):
     if args.backend == "vllm"
     else args.endpoint
 )
+  
+  # Create GCS bucket client before benchmarking
+  # Should fail fast if client is misconfigured or missing permissions
+  if args.output_bucket is not None:
+    global gcs_bucket
+    gcs_bucket = gcs_client.bucket(args.output_bucket)
 
   print(f"Starting Prometheus Server on port {PROMETHEUS_PORT}")
   start_http_server(PROMETHEUS_PORT)
@@ -758,6 +771,12 @@ if __name__ == "__main__":
       "--save-json-results",
       action="store_true",
       help="Whether to save benchmark results to a json file.",
+  )
+  parser.add_argument(
+    "--output-bucket",
+    type=str,
+    default=None,
+    help="If specified, results json will be uploaded to this Google Cloud Storage bucket",
   )
   parser.add_argument(
     "--save-aggregated-result",

--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -49,7 +49,7 @@ trace_config.on_request_start.append(on_request_start)
 trace_config.on_request_end.append(on_request_end)
 
 # Google Cloud Storage Client
-gcs_client = storage.Client()
+gcs_client = None
 gcs_bucket = None
 
 def sample_requests(
@@ -621,6 +621,8 @@ async def main(args: argparse.Namespace):
   # Create GCS client before benchmarking
   # Should fail fast if client is misconfigured or missing permissions
   if args.output_bucket is not None:
+    global gcs_client
+    gcs_client = storage.Client()
     global gcs_bucket
     gcs_bucket = gcs_client.bucket(args.output_bucket)
 

--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -48,7 +48,7 @@ trace_config = aiohttp.TraceConfig()
 trace_config.on_request_start.append(on_request_start)
 trace_config.on_request_end.append(on_request_end)
 
-# Google Cloud Storage Bucket Client
+# Google Cloud Storage Client
 gcs_client = storage.Client()
 gcs_bucket = None
 
@@ -618,7 +618,7 @@ async def main(args: argparse.Namespace):
     else args.endpoint
 )
   
-  # Create GCS bucket client before benchmarking
+  # Create GCS client before benchmarking
   # Should fail fast if client is misconfigured or missing permissions
   if args.output_bucket is not None:
     global gcs_bucket

--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -23,7 +23,6 @@ if [[ "$PROMPT_DATASET" = "sharegpt" ]]; then
   PROMPT_DATASET_FILE="ShareGPT_V3_unfiltered_cleaned_split.json"
 fi
 
-echo "Output Bucket: ${OUTPUT_BUCKET}"
 PYTHON="python3"
 PYTHON_OPTS="benchmark_serving.py "
 for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do

--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -23,6 +23,7 @@ if [[ "$PROMPT_DATASET" = "sharegpt" ]]; then
   PROMPT_DATASET_FILE="ShareGPT_V3_unfiltered_cleaned_split.json"
 fi
 
+echo "Output Bucket: ${OUTPUT_BUCKET}"
 PYTHON="python3"
 PYTHON_OPTS="benchmark_serving.py "
 for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
@@ -37,7 +38,7 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
     num_prompts=$(awk "BEGIN {print int($request_rate * $BENCHMARK_TIME_SECONDS)}")
   fi
   echo "TOTAL prompts: $num_prompts"  # Output: 8
-  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP   --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS"
+  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --output-bucket=$OUTPUT_BUCKET --host=$IP  --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS"
   if [[ "$SCRAPE_SERVER_METRICS" = "true" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --scrape-server-metrics"
   fi

--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -37,7 +37,7 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
     num_prompts=$(awk "BEGIN {print int($request_rate * $BENCHMARK_TIME_SECONDS)}")
   fi
   echo "TOTAL prompts: $num_prompts"  # Output: 8
-  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --output-bucket=$OUTPUT_BUCKET --host=$IP  --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS"
+  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --output-bucket=$OUTPUT_BUCKET --output-bucket-filepath $OUTPUT_BUCKET_FILEPATH --host=$IP  --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS"
   if [[ "$SCRAPE_SERVER_METRICS" = "true" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --scrape-server-metrics"
   fi

--- a/benchmarks/benchmark/tools/profile-generator/container/requirements.txt
+++ b/benchmarks/benchmark/tools/profile-generator/container/requirements.txt
@@ -35,4 +35,5 @@ pynvml == 11.5.0
 accelerate
 aiohttp
 google-auth
+google-cloud-storage >= 2.18.2
 prometheus_client >= 0.21.0

--- a/benchmarks/benchmark/tools/profile-generator/main.tf
+++ b/benchmarks/benchmark/tools/profile-generator/main.tf
@@ -68,13 +68,16 @@ module "latency-profile" {
       port = var.targets.manual.service_port
     }
   }
-  prompt_dataset                             = var.prompt_dataset
-  max_num_prompts                            = var.max_num_prompts
-  max_output_len                             = var.max_output_len
-  max_prompt_len                             = var.max_prompt_len
-  request_rates                              = var.request_rates
-  benchmark_time_seconds                     = var.benchmark_time_seconds
-  output_bucket                              = var.output_bucket
+  prompt_dataset         = var.prompt_dataset
+  max_num_prompts        = var.max_num_prompts
+  max_output_len         = var.max_output_len
+  max_prompt_len         = var.max_prompt_len
+  request_rates          = var.request_rates
+  benchmark_time_seconds = var.benchmark_time_seconds
+  gcs_output = {
+    bucket   = var.output_bucket
+    filepath = var.output_bucket_filepath
+  }
   latency_profile_kubernetes_service_account = var.latency_profile_kubernetes_service_account
   k8s_hf_secret                              = var.k8s_hf_secret
   hugging_face_secret                        = var.hugging_face_secret

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/main.tf
@@ -63,7 +63,8 @@ resource "kubernetes_manifest" "latency-profile-generator" {
     request_rates                              = join(",", [for number in var.request_rates : tostring(number)])
     hugging_face_token_secret_list             = local.hugging_face_token_secret == null ? [] : [local.hugging_face_token_secret]
     k8s_hf_secret_list                         = var.k8s_hf_secret == null ? [] : [var.k8s_hf_secret]
-    output_bucket                              = var.output_bucket
+    output_bucket                              = var.gcs_output.bucket
+    output_bucket_filepath                     = var.gcs_output.filepath
     scrape_server_metrics                      = var.scrape_server_metrics
     file_prefix                                = var.file_prefix
     save_aggregated_result                     = var.save_aggregated_result

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/manifest-templates/latency-profile-generator.yaml.tpl
@@ -42,6 +42,8 @@ spec:
               value: ${benchmark_time_seconds}
             - name: OUTPUT_BUCKET
               value: ${output_bucket}
+            - name: OUTPUT_BUCKET_FILEPATH
+              value: ${output_bucket_filepath}
             - name: SCRAPE_SERVER_METRICS
               value: ${scrape_server_metrics}
             - name: MAX_NUM_PROMPTS

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/variables.tf
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/variables.tf
@@ -139,9 +139,13 @@ variable "models" {
   default     = "tiiuae/falcon-7b"
 }
 
-variable "output_bucket" {
-  description = "Bucket name for storing results"
-  type        = string
+variable "gcs_output" {
+  description = "Bucket name and filepath for storing results, if filepath not specified, results uploaded to root of bucket"
+  type = object({
+    bucket   = string
+    filepath = optional(string)
+  })
+  nullable = true
 }
 
 variable "latency_profile_kubernetes_service_account" {

--- a/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/variables.tf
+++ b/benchmarks/benchmark/tools/profile-generator/modules/latency-profile/variables.tf
@@ -140,7 +140,7 @@ variable "models" {
 }
 
 variable "gcs_output" {
-  description = "Bucket name and filepath for storing results, if filepath not specified, results uploaded to root of bucket"
+  description = "Bucket name and filepath for storing json results, if filepath not specified, results uploaded to root of bucket"
   type = object({
     bucket   = string
     filepath = optional(string)

--- a/benchmarks/benchmark/tools/profile-generator/variables.tf
+++ b/benchmarks/benchmark/tools/profile-generator/variables.tf
@@ -117,6 +117,12 @@ variable "output_bucket" {
   type        = string
 }
 
+variable "output_bucket_filepath" {
+  description = "Where in bucket to store results, will upload to root of bucket if not specified"
+  type        = string
+  nullable    = true
+}
+
 variable "latency_profile_kubernetes_service_account" {
   description = "Kubernetes Service Account to be used for the latency profile generator tool"
   type        = string

--- a/benchmarks/benchmark/tools/profile-generator/variables.tf
+++ b/benchmarks/benchmark/tools/profile-generator/variables.tf
@@ -118,7 +118,7 @@ variable "output_bucket" {
 }
 
 variable "output_bucket_filepath" {
-  description = "Where in bucket to store results, will upload to root of bucket if not specified"
+  description = "Where in bucket to store json results, will upload to root of bucket if not specified"
   type        = string
   nullable    = true
 }


### PR DESCRIPTION
Added the following two flags to benchmark_serving.py:
- `--output-bucket`: upload results in json format to this bucket
- `--output-bucket-filepath`: if specified, upload results to this path within bucket, otherwise upload to root

Requisite changes to terraform also included