### PR TITLE
Define ephemeral-storage in ClusterQueue

### DIFF
--- a/tutorials-and-examples/workflow-orchestration/dws-examples/dws-queues.yaml
+++ b/tutorials-and-examples/workflow-orchestration/dws-examples/dws-queues.yaml
@@ -30,7 +30,7 @@ metadata:
 spec:
   namespaceSelector: {} 
   resourceGroups:
-  - coveredResources: ["cpu", "memory", "nvidia.com/gpu"]
+  - coveredResources: ["cpu", "memory", "nvidia.com/gpu", "ephemeral-storage"]
     flavors:
     - name: "default-flavor"
       resources:
@@ -40,6 +40,8 @@ spec:
         nominalQuota: 10000Gi # Infinite quota.
       - name: "nvidia.com/gpu"
         nominalQuota: 10000  # Infinite quota.
+      - name: "ephemeral-storage"
+        nominalQuota: 10000Ti # Infinite quota.
   admissionChecks:
   - dws-prov
 ---


### PR DESCRIPTION
Support workloads requesting ephemeral-storage, and match the ResourceFlavor in https://cloud.google.com/kubernetes-engine/docs/tutorials/kueue-intro#create_the_resourceflavor