### PR TITLE
wait 30 seconds between each request rate run

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -46,7 +46,7 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
   fi
   $PYTHON $PYTHON_OPTS > $output_file
   cat $output_file
-  sleep 5 # wait 5 seconds before next run
+  sleep 30 # wait 30 seconds before next run to ensure metrics isolation (metrics pulled every 15s)
 done
 
 export LPG_FINISHED="true"


### PR DESCRIPTION
Currently latency profile generator only waits 5 seconds between each request rate run. 

Model server metrics are pulled every 15 seconds.

To ensure isolation of model server metrics scraped between each request rate run, wait 30 seconds. This allows related metrics to emit at least one "0" prior to the next run (which enables us to validate proper isolation).