### PR TITLE
Fix the jupyter hub helm chart version to avoid using the latest one which introduce error whan spawn a server

### DIFF
--- a/modules/jupyter/main.tf
+++ b/modules/jupyter/main.tf
@@ -108,6 +108,7 @@ resource "helm_release" "jupyterhub" {
   create_namespace = true
   cleanup_on_fail  = "true"
   timeout          = 600
+  version          = "3.3.8"
 
   values = var.autopilot_cluster ? [templatefile("${path.module}/jupyter_config/config-selfauth-autopilot.yaml", {
     password                          = var.add_auth ? "dummy" : random_password.generated_password[0].result


### PR DESCRIPTION
Jupyterhub helm chart has a [new release](https://hub.jupyter.org/helm-chart/) on 11/07. After than, all rag e2e tests started [failing](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1?query=trigger_id%3D%2266c7c11e-51cc-4b48-aca9-c1255f57958a%22&e=13803378&mods=getting_started_solutions_mock_data&project=gke-ai-eco-dev), which are caused by the below jupyterhub spawner error
```
2024-11-12 12:00:02.275 PST
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-12 12:00:02.275 PST
File "/usr/local/lib/python3.11/site-packages/kubespawner/spawner.py", line 1847, in <dictcomp>
2024-11-12 12:00:02.275 PST
return {k: self._expand_all(v) for k, v in src.items()}
2024-11-12 12:00:02.275 PST
^^^^^^^^^^^^^^^^^^^
2024-11-12 12:00:02.275 PST
File "/usr/local/lib/python3.11/site-packages/kubespawner/spawner.py", line 1849, in _expand_all
2024-11-12 12:00:02.275 PST
return self._expand_user_properties(src)
2024-11-12 12:00:02.275 PST
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-12 12:00:02.275 PST
File "/usr/local/lib/python3.11/site-packages/kubespawner/spawner.py", line 1827, in _expand_user_properties
2024-11-12 12:00:02.275 PST
rendered = template.format(
2024-11-12 12:00:02.275 PST
^^^^^^^^^^^^^^^^
2024-11-12 12:00:02.275 PST
    KeyError: 'user_server'
```
Without root cause the issue, this PR change it to use a fixed jupyterhub helm chart version to mitigate