### PR TITLE
Update the Jupyter notebook image version

### DIFF
--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -183,7 +183,7 @@ module "jupyterhub" {
   workload_identity_service_account = local.jupyter_service_account
 
   notebook_image     = "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image"
-  notebook_image_tag = "v1.1-rag"
+  notebook_image_tag = "sample-public-image-v1.2-rag"
 
   db_secret_name         = module.cloudsql.db_secret_name
   cloudsql_instance_name = local.cloudsql_instance

--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -183,7 +183,7 @@ module "jupyterhub" {
   workload_identity_service_account = local.jupyter_service_account
 
   notebook_image     = "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image"
-  notebook_image_tag = "sample-public-image-v1.2-rag"
+  notebook_image_tag = "sample-public-image-v1.1-rag"
 
   db_secret_name         = module.cloudsql.db_secret_name
   cloudsql_instance_name = local.cloudsql_instance

--- a/modules/jupyter/jupyter_image/notebook_image/Dockerfile
+++ b/modules/jupyter/jupyter_image/notebook_image/Dockerfile
@@ -1,3 +1,3 @@
-FROM jupyter/tensorflow-notebook:python-3.10
+FROM jupyter/tensorflow-notebook:python-3.11
 COPY requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r ./requirements.txt

--- a/modules/jupyter/jupyter_image/notebook_image/Dockerfile
+++ b/modules/jupyter/jupyter_image/notebook_image/Dockerfile
@@ -1,3 +1,3 @@
-FROM jupyter/tensorflow-notebook:python-3.11
+FROM jupyter/tensorflow-notebook:python-3.10
 COPY requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r ./requirements.txt

--- a/modules/jupyter/jupyter_image/notebook_image/README.md
+++ b/modules/jupyter/jupyter_image/notebook_image/README.md
@@ -1,0 +1,12 @@
+To build a new jupyter notebook image and use it for the RAG QSS:
+1. Update the cloudbuild.yaml with the new image tag.
+
+    The iamge tag should follow the pattern `sample-public-image-v<VERSION_NUMBER>-rag`.The prefix `sample-public-image-` is needed to so the images will internally be considered as vulnerability remediated and no more bugs will be filed for them.
+2. Then in this path, run:
+
+    `gcloud config set project ai-on-gke`
+
+    `gcloud builds submit --config cloudbuild.yaml .`
+
+    This will build and push the new image to the registry `us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke`
+3. Update the `notebook_image_tag` in `/applications/rag/main.tf` to the new image tag.

--- a/modules/jupyter/jupyter_image/notebook_image/cloudbuild.yaml
+++ b/modules/jupyter/jupyter_image/notebook_image/cloudbuild.yaml
@@ -15,8 +15,8 @@
 # to build, run `gcloud builds submit --config cloudbuild.yaml .` in directory
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'pull', 'docker.io/jupyter/tensorflow-notebook:python-3.10' ]
+  args: [ 'pull', 'docker.io/jupyter/tensorflow-notebook:python-3.11' ]
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', '<Artiact registry repo>/<image name>', '.' ]
+  args: [ 'build', '-t', 'us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:<NEW_IMAGE_TAG>', '.' ]
 images:
-- '<Artiact registry repo>/<image name>'
+- 'us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:<NEW_IMAGE_TAG>'

--- a/modules/jupyter/jupyter_image/notebook_image/cloudbuild.yaml
+++ b/modules/jupyter/jupyter_image/notebook_image/cloudbuild.yaml
@@ -17,6 +17,6 @@ steps:
 - name: 'gcr.io/cloud-builders/docker'
   args: [ 'pull', 'docker.io/jupyter/tensorflow-notebook:python-3.10' ]
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.2-rag', '.' ]
+  args: [ 'build', '-t', 'us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:<NEW_IMAGE_TAG>', '.' ]
 images:
-- 'us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.2-rag'
+- 'us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:<NEW_IMAGE_TAG>'

--- a/modules/jupyter/jupyter_image/notebook_image/cloudbuild.yaml
+++ b/modules/jupyter/jupyter_image/notebook_image/cloudbuild.yaml
@@ -15,8 +15,8 @@
 # to build, run `gcloud builds submit --config cloudbuild.yaml .` in directory
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'pull', 'docker.io/jupyter/tensorflow-notebook:python-3.11' ]
+  args: [ 'pull', 'docker.io/jupyter/tensorflow-notebook:python-3.10' ]
 - name: 'gcr.io/cloud-builders/docker'
-  args: [ 'build', '-t', 'us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:<NEW_IMAGE_TAG>', '.' ]
+  args: [ 'build', '-t', 'us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.2-rag', '.' ]
 images:
-- 'us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:<NEW_IMAGE_TAG>'
+- 'us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.2-rag'

--- a/modules/jupyter/jupyter_image/notebook_image/requirements.txt
+++ b/modules/jupyter/jupyter_image/notebook_image/requirements.txt
@@ -1,4 +1,6 @@
-langchain==0.3.7 
+langchain==0.3.7
+langchain-community==0.3.7
+cloud-sql-python-connector==1.14.0
 ray==2.9.3 
 datasets==2.18.0 
 sentence-transformers==2.5.1 

--- a/modules/jupyter/jupyter_image/notebook_image/requirements.txt
+++ b/modules/jupyter/jupyter_image/notebook_image/requirements.txt
@@ -1,6 +1,4 @@
 langchain==0.3.7
-langchain-community==0.3.7
-cloud-sql-python-connector==1.14.0
 ray==2.9.3 
 datasets==2.18.0 
 sentence-transformers==2.5.1 


### PR DESCRIPTION
Add prefix `sample-public-image-` to the image tag to mitigate the internal vulnerability check. New tag has been added https://pantheon.corp.google.com/artifacts/docker/ai-on-gke/us-central1/rag-on-gke/jupyter-notebook-image?e=13803378&mods=getting_started_solutions_mock_data&project=ai-on-gke