### PR TITLE
Split TPOT into two metrics, one with first token latency and one without

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
+++ b/benchmarks/benchmark/tools/profile-generator/container/benchmark_serving.py
@@ -34,7 +34,7 @@ PROMETHEUS_PORT = 9090
 # Prometheus Metrics
 prompt_length_metric = Histogram("LatencyProfileGenerator:prompt_length", "Input prompt length", buckets=[2**i for i in range(1, 16)])
 response_length_metric = Histogram("LatencyProfileGenerator:response_length", "Response length", buckets=[2**i for i in range(1, 16)])
-latency_per_output_token_metric = Histogram('LatencyProfileGenerator:latency_per_output_token', 'Time per output token per request (including first token)')
+request_latency_per_output_token_metric = Histogram('LatencyProfileGenerator:request_latency_per_output_token', 'Time per output token per request (including first token)')
 tpot_metric = Histogram('LatencyProfileGenerator:time_per_output_token', 'Time per output token per request (excluding first token)')
 ttft_metric = Histogram('LatencyProfileGenerator:time_to_first_token', 'Time to first token per request')
 active_requests_metric = Gauge('LatencyProfileGenerator:active_requests', 'How many requests actively being processed')
@@ -229,7 +229,7 @@ async def send_stream_request(
 
   # Exclude first token for tpot calculation
   tpot_metric.observe((request_end_time - ttft - request_start_time) / (output_len - 1))
-  latency_per_output_token_metric.observe((request_end_time - request_start_time) / output_len)
+  request_latency_per_output_token_metric.observe((request_end_time - request_start_time) / output_len)
   if ttft is not None:
     ttft_metric.observe(ttft)
   prompt_length_metric.observe(prompt_len)
@@ -384,7 +384,7 @@ async def send_request(
 
   # (prompt len, output len, latency, success)
   request_latency = (prompt_len, output_len, (request_end_time - request_start_time))
-  latency_per_output_token_metric.observe((request_end_time - request_start_time) / output_len)
+  request_latency_per_output_token_metric.observe((request_end_time - request_start_time) / output_len)
   prompt_length_metric.observe(prompt_len)
   response_length_metric.observe(output_len)
 


### PR DESCRIPTION
Extension of: https://github.com/GoogleCloudPlatform/ai-on-gke/pull/899

Before:
 - TPOT (includes first token latency)

After:
  - request_latency_per_output_token (includes first token latency)
 - TPOT (does not include first token latency)