### PR TITLE
Remove the acknowledge checkbox for solution_deployment_view

### DIFF
--- a/applications/jupyter/metadata.display.yaml
+++ b/applications/jupyter/metadata.display.yaml
@@ -41,16 +41,6 @@ spec:
           enumValueLabels:
             - label: Confirm that all prerequisites have been met.
               value: "true"
-        solution_deployment_view:
-          name: solution_deployment_view
-          title: Check to confirm that upon deployment completion, you need to go to the Solution deployment page, find your deployment, and follow suggested next steps on the deployment DETAILS tab.
-          section: acknowledge
-          subtext: <p>
-                    <a href="https://console.cloud.google.com/products/solutions/deployments"><i>Solution deployment page</i></a>
-                   </p>
-          enumValueLabels:
-            - label: Confirm that all prerequisites have been met.
-              value: "true"
         iap_consent_info:
           name: iap_consent_info
           title: Confirm your OAuth consent screen is configured correctly.

--- a/applications/jupyter/metadata.yaml
+++ b/applications/jupyter/metadata.yaml
@@ -36,9 +36,6 @@ spec:
       - name: acknowledge
         varType: bool
         required: true
-      - name: solution_deployment_view
-        varType: bool
-        required: true
       - name: iap_consent_info
         description: Configure the <a href="https://developers.google.com/workspace/guides/configure-oauth-consent#configure_oauth_consent"><i>OAuth Consent Screen</i></a> for your project. Ensure <b>User type</b> is set to <i>Internal</i>. Note that by default, only users within your organization can be allowlisted. To add external users, change the <b>User type</b> to <i>External</i> after the application is deployed.
         varType: bool

--- a/applications/rag/metadata.display.yaml
+++ b/applications/rag/metadata.display.yaml
@@ -25,16 +25,6 @@ spec:
           enumValueLabels:
             - label: Confirm that all prerequisites have been met.
               value: "true"
-        solution_deployment_view:
-          name: solution_deployment_view
-          title: Check to confirm that upon deployment completion, you need to go to the Solution deployment page, find your deployment, and follow suggested next steps on the deployment DETAILS tab.
-          section: acknowledge
-          subtext: <p>
-                    <a href="https://console.cloud.google.com/products/solutions/deployments"><i>Solution deployment page</i></a>
-                   </p>
-          enumValueLabels:
-            - label: Confirm that all prerequisites have been met.
-              value: "true"
         additional_labels:
           name: additional_labels
           title: Additional Labels

--- a/applications/rag/metadata.yaml
+++ b/applications/rag/metadata.yaml
@@ -20,9 +20,6 @@ spec:
       - name: acknowledge
         varType: bool
         required: true
-      - name: solution_deployment_view
-        varType: bool
-        required: true
       - name: additional_labels
         description: Additional labels to add to Kubernetes resources.
         varType: string

--- a/applications/ray/metadata.display.yaml
+++ b/applications/ray/metadata.display.yaml
@@ -25,16 +25,6 @@ spec:
           enumValueLabels:
             - label: Confirm that all prerequisites have been met.
               value: "true"
-        solution_deployment_view:
-          name: solution_deployment_view
-          title: Check to confirm that upon deployment completion, you need to go to the Solution deployment page, find your deployment, and follow suggested next steps on the deployment DETAILS tab.
-          section: acknowledge
-          subtext: <p>
-                    <a href="https://console.cloud.google.com/products/solutions/deployments"><i>Solution deployment page</i></a>
-                   </p>
-          enumValueLabels:
-            - label: Confirm that all prerequisites have been met.
-              value: "true"
         additional_labels:
           name: additional_labels
           title: Additional Labels

--- a/applications/ray/metadata.yaml
+++ b/applications/ray/metadata.yaml
@@ -24,9 +24,6 @@ spec:
       - name: acknowledge
         varType: bool
         required: true
-      - name: solution_deployment_view
-        varType: bool
-        required: true
       - name: iap_consent_info
         description: Configure the <a href="https://developers.google.com/workspace/guides/configure-oauth-consent#configure_oauth_consent"><i>OAuth Consent Screen</i></a> for your project. Ensure <b>User type</b> is set to <i>Internal</i>. Note that by default, only users within your organization can be allowlisted. To add external users, change the <b>User type</b> to <i>External</i> after the application is deployed.
         varType: bool


### PR DESCRIPTION
With the new GKE ML/AI UI, users of QSS don't need to go to the MP Solution deployment view page to view the deployment details. So remove the related acknowledge checkbox from the form.