### PR TITLE
Duplicates charts to rag folder so the Marketplace release can work

### DIFF
--- a/applications/rag/charts/gmp-engine/Chart.yaml
+++ b/applications/rag/charts/gmp-engine/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+name: gmp-engine
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"
+
+dependencies:
+- name: gmp-frontend
+  condition: gmp-frontend.enabled

--- a/applications/rag/charts/gmp-engine/charts/gmp-frontend/Chart.yaml
+++ b/applications/rag/charts/gmp-engine/charts/gmp-frontend/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: gmp-frontend
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0"

--- a/applications/rag/charts/gmp-engine/charts/gmp-frontend/templates/deployment.yaml
+++ b/applications/rag/charts/gmp-engine/charts/gmp-frontend/templates/deployment.yaml
@@ -1,0 +1,53 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+  labels:
+      app: {{ .Values.name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name }}
+    spec:
+      serviceAccountName: {{ required "serviceAccount is required!" .Values.serviceAccount }}
+      containers:
+        - name: {{ .Values.name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          - "--web.listen-address=:9090"
+          - "--query.project-id={{ required "projectID is required!" .Values.projectID }}"
+          ports:
+          - name: web
+            containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: web
+          livenessProbe:
+            httpGet:
+              path: /-/healthy
+              port: web
+          resources:
+            requests:
+              memory: {{ .Values.memory }}
+              cpu: {{ .Values.cpu }}

--- a/applications/rag/charts/gmp-engine/charts/gmp-frontend/templates/service.yaml
+++ b/applications/rag/charts/gmp-engine/charts/gmp-frontend/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    app: {{ .Values.name }}
+spec:
+  clusterIP: None
+  ports:
+  - name: web
+    port: 9090
+  selector:
+    app: {{ .Values.name }}

--- a/applications/rag/charts/gmp-engine/charts/gmp-frontend/values.yaml
+++ b/applications/rag/charts/gmp-engine/charts/gmp-frontend/values.yaml
@@ -1,0 +1,17 @@
+# Default values for gmp-frontend.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+name: "gmp-frontend"
+projectID: ""
+serviceAccount: ""
+
+image:
+  repository: gke.gcr.io/prometheus-engine/frontend
+  pullPolicy: IfNotPresent
+  tag: "v0.5.0-gke.0"
+
+replicaCount: 2
+
+cpu: "1m"
+memory: "5Mi"

--- a/applications/rag/charts/gmp-engine/templates/podmonitoring.yaml
+++ b/applications/rag/charts/gmp-engine/templates/podmonitoring.yaml
@@ -1,0 +1,30 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+{{- range $pm := .Values.podMonitoring }}
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: {{ $pm.name}}
+spec:
+  selector:
+    matchLabels:
+      {{- $pm.selector | toYaml | nindent 8 }}
+  endpoints:
+  - port: {{ $pm.port }}
+    interval: {{ $pm.interval }}
+---
+{{- end }}
+

--- a/applications/rag/charts/gmp-engine/values.yaml
+++ b/applications/rag/charts/gmp-engine/values.yaml
@@ -1,0 +1,10 @@
+# Default values for iap_jupyter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+podMonitoring: []
+
+gmp-frontend:
+  enabled: false
+  projectID: ""
+  serviceAccount: ""

--- a/applications/rag/main.tf
+++ b/applications/rag/main.tf
@@ -309,7 +309,7 @@ module "frontend" {
 resource "helm_release" "gmp-apps" {
   name      = "gmp-apps"
   provider  = helm.rag
-  chart     = "../../charts/gmp-engine/"
+  chart     = "./charts/gmp-engine"
   namespace = local.kubernetes_namespace
   # Timeout is increased to guarantee sufficient scale-up time for Autopilot nodes.
   timeout    = 1200


### PR DESCRIPTION
When we release RAG QSS on Marketplace, we zip the whole rag folder and upload it to a GCS bucket so Marketplace can use it to do terraform apply. With the current setup to install `gmp-engine` for rag, the Marketplace will not be able to find the charts since it's not in the GCS. It is also not possible to modify the chart path to point to the github patch like what we do for the other modules in RAG, because it is not supported with the current setup of the `gmp-engine` chart. As a workaround, duplicating the charts to the rag folder so it can be zipped together and uploaded to GCS.