### PR TITLE
Improve examples for DWS-Kueue usage

### DIFF
--- a/tutorials-and-examples/workflow-orchestration/dws-examples/dws-queues.yaml
+++ b/tutorials-and-examples/workflow-orchestration/dws-examples/dws-queues.yaml
@@ -28,20 +28,20 @@ kind: ClusterQueue
 metadata:
   name: "dws-cluster-queue"
 spec:
-  namespaceSelector: {} 
+  namespaceSelector: {}
   resourceGroups:
   - coveredResources: ["cpu", "memory", "nvidia.com/gpu", "ephemeral-storage"]
     flavors:
     - name: "default-flavor"
       resources:
       - name: "cpu"
-        nominalQuota: 10000  # Infinite quota.
+        nominalQuota: 1000000000    # "Infinite" quota
       - name: "memory"
-        nominalQuota: 10000Gi # Infinite quota.
+        nominalQuota: 1000000000Gi  # "Infinite" quota
       - name: "nvidia.com/gpu"
-        nominalQuota: 10000  # Infinite quota.
+        nominalQuota: 1000000000    # "Infinite" quota
       - name: "ephemeral-storage"
-        nominalQuota: 10000Ti # Infinite quota.
+        nominalQuota: 1000000000Ti  # "Infinite" quota
   admissionChecks:
   - dws-prov
 ---

--- a/tutorials-and-examples/workflow-orchestration/dws-examples/dws_and_reservation.yaml
+++ b/tutorials-and-examples/workflow-orchestration/dws-examples/dws_and_reservation.yaml
@@ -34,11 +34,11 @@ spec:
     - name: "dws"         # if reservation is saturated we try dws
       resources:
       - name: "cpu"
-        nominalQuota: 10000   # Infinite quota.
+        nominalQuota: 1000000000    # "Infinite" quota
       - name: "memory"
-        nominalQuota: 10000Gi # Infinite quota.
+        nominalQuota: 1000000000Gi  # "Infinite" quota
       - name: "nvidia.com/gpu"
-        nominalQuota: 10000   # Infinite quota.
+        nominalQuota: 1000000000    # "Infinite" quota
   admissionChecksStrategy:
     admissionChecks:
       - name: "dws-prov"


### PR DESCRIPTION
Bump Kueue quotas to 1 billion per resource to provide almost unlimited admission