### PR TITLE
Increase timeout to fix e2d flaky

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -100,7 +100,7 @@ steps:
     echo "pass" > /workspace/user_result.txt
 
     chmod +x /workspace/scripts/ci/wait_for_pods.sh
-    /workspace/scripts/ci/wait_for_pods.sh ml-$SHORT_SHA-$_BUILD_ID-ray 3000
+    /workspace/scripts/ci/wait_for_pods.sh ml-$SHORT_SHA-$_BUILD_ID-ray 3600
 
     kubectl wait --all pods -n ml-$SHORT_SHA-$_BUILD_ID-ray --for=condition=Ready --timeout=1200s
     # Ray head's readinessProbe is not probing the head service today. Therefore the wait for ready above is not reliable.


### PR DESCRIPTION
The E2E test [failed](https://pantheon.corp.google.com/cloud-build/builds;region=us-central1?query=trigger_id%3D%227f679323-a550-4c58-9c6d-5ed9f52b75d2%22&e=13803378&hl=en&mods=getting_started_solutions_mock_data&project=gke-ai-eco-dev) because of timeout waiting for the Ray pod sometimes: `error: timed out waiting for the condition on pods/ray-cluster-kuberay-head-d4sn5
Pod(s) found in the namespace 'ml-450d0fa-5920027c-ray'.
Waiting for any pod to exist in the namespace 'ml-450d0fa-5920027c-ray' (timeout: 3000s)...`. Increasing the timeout as a mitigation.

I have tested it by pointing the previously failed build to my branch, and saw the recent two build all succeeded: https://pantheon.corp.google.com/cloud-build/builds;region=us-central1?query=trigger_id%3D%227f679323-a550-4c58-9c6d-5ed9f52b75d2%22&e=13803378&hl=en&mods=getting_started_solutions_mock_data&project=gke-ai-eco-dev