### PR TITLE
Make GCS bucket optional

### DIFF
--- a/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
+++ b/benchmarks/benchmark/tools/profile-generator/container/latency_throughput_curve.sh
@@ -37,7 +37,10 @@ for request_rate in $(echo $REQUEST_RATES | tr ',' ' '); do
     num_prompts=$(awk "BEGIN {print int($request_rate * $BENCHMARK_TIME_SECONDS)}")
   fi
   echo "TOTAL prompts: $num_prompts"  # Output: 8
-  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --output-bucket=$OUTPUT_BUCKET --host=$IP  --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS"
+  PYTHON_OPTS="$PYTHON_OPTS --save-json-results --host=$IP  --port=$PORT --dataset=$PROMPT_DATASET_FILE --tokenizer=$TOKENIZER --request-rate=$request_rate --backend=$BACKEND --num-prompts=$num_prompts --max-input-length=$INPUT_LENGTH --max-output-length=$OUTPUT_LENGTH --file-prefix=$FILE_PREFIX --models=$MODELS"
+  if [[ "$OUTPUT_BUCKET" ]]; then
+    PYTHON_OPTS="$PYTHON_OPTS --output-bucket=$OUTPUT_BUCKET"
+  fi
   if [[ "$SCRAPE_SERVER_METRICS" = "true" ]]; then
     PYTHON_OPTS="$PYTHON_OPTS --scrape-server-metrics"
   fi


### PR DESCRIPTION
Tested the container e2e.

### With OUTPUT_BUCKET:

Yaml:
```
...
containers:
      - command:
        - bash
        - -c
        - ./latency_throughput_curve.sh
        env:
        - name: OUTPUT_LENGTH
          value: '512'
        - name: OUTPUT_BUCKET
          value: 'my-bucket'
...
```

Log: Notice the `output-bucket` flag

`python3 benchmark_serving.py --save-json-results --host=model-server-service.benchmark-catalog.svc.cluster.local --port=8081 --dataset=ShareGPT_V3_unfiltered_cleaned_split.json --tokenizer=meta-llama/Llama-2-7b-hf --request-rate=1 --backen │
│ d=vllm --num-prompts=10 --max-input-length=1024 --max-output-length=512 '--file-prefix=result/${ID}' --models=meta-llama/Llama-2-7b-hf --output-bucket=my-bucket --save-aggregated-result`

### Without :

Yaml:
```
...
containers:
      - command:
        - bash
        - -c
        - ./latency_throughput_curve.sh
        env:
        - name: OUTPUT_LENGTH
          value: '512'
...
```

Container log, notice there is no `output-bucket` flag.

`python3 benchmark_serving.py --save-json-results --host=model-server-service.benchmark-catalog.svc.cluster.local --port=8081 --dataset=ShareGPT_V3_unfiltered_cleaned_split.json --tokenizer=meta-llama/Llama-2-7b-hf --request-rate=1 --backen │
│ d=vllm --num-prompts=10 --max-input-length=1024 --max-output-length=512 '--file-prefix=result/${ID}' --models=meta-llama/Llama-2-7b-hf --save-aggregated-result`
