### PR TITLE
# Pull Request: Onboard Cluster Scan to AI-on-GKE

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 steps:
 - id: "validate platform"
   name: "gcr.io/$PROJECT_ID/terraform"
@@ -439,8 +440,9 @@ substitutions:
   _REGION: us-east4
   _USER_NAME: github
   _AUTOPILOT_CLUSTER: "false"
-  _BUILD_ID: "11122233"
+  _BUILD_ID: ${BUILD_ID:0:8}
   _SHIPSHAPE_IMAGE: us-docker.pkg.dev/k8ssecurityvalidation-agent/k8ssecurityvalidation-agent/k8ssecurityvalidation-agent@sha256:1f80ae746014330a3a83b5ee2fabeacf90fa488c4f0922072b628b95144f25c8
+logsBucket: gs://ai-on-gke-build-logs
 options:
   logging: CLOUD_LOGGING_ONLY
   substitutionOption: "ALLOW_LOOSE"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 steps:
 - id: "validate platform"
   name: "gcr.io/$PROJECT_ID/terraform"
@@ -278,6 +277,60 @@ steps:
   allowFailure: true
   waitFor: ['create gke cluster']
 
+- id: 'Generate Kubeconfig'
+  name: 'gcr.io/cloud-builders/gcloud'
+  env:
+  - 'KUBECONFIG=/workspace/kubeconfig'
+  - 'USE_GKE_GCLOUD_AUTH_PLUGIN=False'
+  args:
+  - 'container'
+  - 'clusters'
+  - 'get-credentials'
+  - 'ml-${SHORT_SHA}-${_PR_NUMBER}-${_BUILD_ID}-cluster'
+  - '--region=${_REGION}'
+  - '--project=$PROJECT_ID'
+  allowFailure: true
+  waitFor: ['test rag']
+
+- id: 'Copy metadata'
+  name: 'ubuntu'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    mkdir -p /workspace/security_test/allowlist
+    cp security_test/config.yaml /workspace/security_test/config.yaml
+    cp -r security_test/allowlist/* /workspace/security_test/allowlist/ || echo "Allowlist folder is empty or not found"
+  allowFailure: true
+  waitFor: ['Generate Kubeconfig']
+
+# gcr.io/cloud-builders/docker is a special image: This image provided by Google Cloud contains the docker command-line tool, which is essential for executing Docker commands like docker build and docker run within your Cloud Build steps.
+# gcr.io/${_PROJECT_ID}/check_violations:latest is your application image: This image contains your security check tool and its dependencies. It's designed to be run, not to build or run other Docker images.
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'run shipshape'
+  args:
+  - 'run'
+  - '--network=cloudbuild'
+  - '--rm'
+  - '-v'
+  - '/workspace/security_test/allowlist:/workspace/security_test/allowlist'
+  - '-v'
+  - '/workspace/security_test/config.yaml:/workspace/security_test/config.yaml'
+  - '-v'
+  - '/workspace/kubeconfig:/root/.kube/config'
+  - '${_SHIPSHAPE_IMAGE}'
+  - '--mode=cluster'
+  - '--allowlist_folder=/workspace/security_test/allowlist'
+  - '--cluster_name=ml-${SHORT_SHA}-${_PR_NUMBER}-${_BUILD_ID}-cluster'
+  - '--project_id=$PROJECT_ID'
+  - '--location=${_REGION}'
+  - '--kube_config_path=/root/.kube/config'
+  - '--max_wait_duration=3000'
+  - '--max_parallel=100'
+  - '--cluster_scan_config_path=/workspace/security_test/config.yaml'
+  allowFailure: true
+  waitFor: ['Copy metadata']
+
 - id: 'cleanup rag'
   name: 'gcr.io/$PROJECT_ID/terraform'
   entrypoint: 'bash'
@@ -304,7 +357,7 @@ steps:
     -var=cloudsql_instance=pgvector-instance-$SHORT_SHA-$_BUILD_ID \
     -auto-approve -no-color
   allowFailure: true
-  waitFor: ['test rag']
+  waitFor: ['run shipshape']
 
 - id: 'cleanup gke cluster'
   name: 'gcr.io/$PROJECT_ID/terraform'
@@ -386,9 +439,10 @@ substitutions:
   _REGION: us-east4
   _USER_NAME: github
   _AUTOPILOT_CLUSTER: "false"
-  _BUILD_ID: ${BUILD_ID:0:8}
-logsBucket: gs://ai-on-gke-build-logs
+  _BUILD_ID: "11122233"
+  _SHIPSHAPE_IMAGE: us-docker.pkg.dev/k8ssecurityvalidation-agent/k8ssecurityvalidation-agent/k8ssecurityvalidation-agent@sha256:1f80ae746014330a3a83b5ee2fabeacf90fa488c4f0922072b628b95144f25c8
 options:
+  logging: CLOUD_LOGGING_ONLY
   substitutionOption: "ALLOW_LOOSE"
   machineType: "E2_HIGHCPU_8"
 timeout: 5400s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -444,7 +444,6 @@ substitutions:
   _SHIPSHAPE_IMAGE: us-docker.pkg.dev/k8ssecurityvalidation-agent/k8ssecurityvalidation-agent/k8ssecurityvalidation-agent@sha256:1f80ae746014330a3a83b5ee2fabeacf90fa488c4f0922072b628b95144f25c8
 logsBucket: gs://ai-on-gke-build-logs
 options:
-  logging: CLOUD_LOGGING_ONLY
   substitutionOption: "ALLOW_LOOSE"
   machineType: "E2_HIGHCPU_8"
 timeout: 5400s

--- a/security_test/allowlist/category/cluster/continuous-image-puller/capabilities.json
+++ b/security_test/allowlist/category/cluster/continuous-image-puller/capabilities.json
@@ -1,0 +1,17 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "pause"
+    },
+    "message": "container \"pause\" in DaemonSet \"continuous-image-puller\" does not drop all capabilities in its securityContext. See go/gke-shipshape#capabilities for more details",
+    "policyName": "capabilities",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/continuous-image-puller/distroless.json
+++ b/security_test/allowlist/category/cluster/continuous-image-puller/distroless.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "image-pull-singleuser",
+      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.1-rag"
+    },
+    "message": "container \"image-pull-singleuser\" in DaemonSet \"continuous-image-puller\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.1-rag\" built from non-distroless base image \"Ubuntu 22.04.2 LTS\". See: go/gke-distroless for more details",
+    "policyName": "distroless",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "pause",
+      "image": "registry.k8s.io/pause:3.9"
+    },
+    "message": "image \"registry.k8s.io/pause:3.9\" could not be found on gcr.io",
+    "policyName": "distroless",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/continuous-image-puller/imagedigest.json
+++ b/security_test/allowlist/category/cluster/continuous-image-puller/imagedigest.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "image-pull-singleuser",
+      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.1-rag"
+    },
+    "message": "container \"image-pull-singleuser\" in DaemonSet \"continuous-image-puller\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.1-rag\" with no digest; valid image format: image[:tag]@sha256:\u003cdigest\u003e",
+    "policyName": "imagedigest",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "pause",
+      "image": "registry.k8s.io/pause:3.9"
+    },
+    "message": "container \"pause\" in DaemonSet \"continuous-image-puller\" has an image \"registry.k8s.io/pause:3.9\" with no digest; valid image format: image[:tag]@sha256:\u003cdigest\u003e",
+    "policyName": "imagedigest",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/continuous-image-puller/imagefreshness.json
+++ b/security_test/allowlist/category/cluster/continuous-image-puller/imagefreshness.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "image-pull-singleuser",
+      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.1-rag"
+    },
+    "message": "container \"image-pull-singleuser\" in DaemonSet \"continuous-image-puller\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.1-rag\" that does not have a valid digest.",
+    "policyName": "imagefreshness",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "pause",
+      "image": "registry.k8s.io/pause:3.9"
+    },
+    "message": "container \"pause\" in DaemonSet \"continuous-image-puller\" has an image \"registry.k8s.io/pause:3.9\" that does not have a valid digest.",
+    "policyName": "imagefreshness",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/continuous-image-puller/imagepath.json
+++ b/security_test/allowlist/category/cluster/continuous-image-puller/imagepath.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "image-pull-singleuser",
+      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.1-rag"
+    },
+    "message": "container \"image-pull-singleuser\" in DaemonSet \"continuous-image-puller\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.1-rag\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
+    "policyName": "imagepath",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "pause",
+      "image": "registry.k8s.io/pause:3.9"
+    },
+    "message": "container \"pause\" in DaemonSet \"continuous-image-puller\" has an image \"registry.k8s.io/pause:3.9\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
+    "policyName": "imagepath",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/continuous-image-puller/readonlyrootfs.json
+++ b/security_test/allowlist/category/cluster/continuous-image-puller/readonlyrootfs.json
@@ -1,0 +1,17 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "pause"
+    },
+    "message": "container \"pause\" in DaemonSet \"continuous-image-puller\" does not set readOnlyRootFilesystem: true in its securityContext. This setting is encouraged because it can prevent attackers from writing malicious binaries into runnable locations in the container filesystem.",
+    "policyName": "readonlyrootfs",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/continuous-image-puller/sbom.json
+++ b/security_test/allowlist/category/cluster/continuous-image-puller/sbom.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "image-pull-singleuser",
+      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.1-rag"
+    },
+    "message": "container \"image-pull-singleuser\" in DaemonSet \"continuous-image-puller\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/jupyter-notebook-image:sample-public-image-v1.1-rag\" without SBOM. See: go/gke-anthos-sbom-requirement for more details",
+    "policyName": "sbom",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "pause",
+      "image": "registry.k8s.io/pause:3.9"
+    },
+    "message": "container \"pause\" in DaemonSet \"continuous-image-puller\" has an image \"registry.k8s.io/pause:3.9\" without SBOM. See: go/gke-anthos-sbom-requirement for more details",
+    "policyName": "sbom",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/continuous-image-puller/seccompprofile.json
+++ b/security_test/allowlist/category/cluster/continuous-image-puller/seccompprofile.json
@@ -1,0 +1,13 @@
+[
+  {
+    "message": "pod in DaemonSet \"continuous-image-puller\" must set securityContext.seccompProfile.type to value RuntimeDefault",
+    "policyName": "seccompprofile",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "DaemonSet",
+      "name": "continuous-image-puller",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/hub/capabilities.json
+++ b/security_test/allowlist/category/cluster/hub/capabilities.json
@@ -1,0 +1,17 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "hub"
+    },
+    "message": "container \"hub\" in Deployment \"hub\" does not drop all capabilities in its securityContext. See go/gke-shipshape#capabilities for more details",
+    "policyName": "capabilities",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/hub/distroless.json
+++ b/security_test/allowlist/category/cluster/hub/distroless.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "hub",
+      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014"
+    },
+    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014\" built from non-distroless base image \"Debian GNU/Linux 11 (bullseye)\". See: go/gke-distroless for more details",
+    "policyName": "distroless",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/hub/imagedigest.json
+++ b/security_test/allowlist/category/cluster/hub/imagedigest.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "hub",
+      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014"
+    },
+    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014\" with no digest; valid image format: image[:tag]@sha256:\u003cdigest\u003e",
+    "policyName": "imagedigest",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/hub/imagefreshness.json
+++ b/security_test/allowlist/category/cluster/hub/imagefreshness.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "hub",
+      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014"
+    },
+    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014\" that does not have a valid digest.",
+    "policyName": "imagefreshness",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/hub/imagepath.json
+++ b/security_test/allowlist/category/cluster/hub/imagepath.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "hub",
+      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014"
+    },
+    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
+    "policyName": "imagepath",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/hub/rbac.json
+++ b/security_test/allowlist/category/cluster/hub/rbac.json
@@ -1,0 +1,200 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "Role \"hub\" has rbac rule for resource \"pods.\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "Role \"hub\" has rbac rule for resource \"pods.\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "persistentvolumeclaims",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "Role \"hub\" has rbac rule for resource \"persistentvolumeclaims.\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "persistentvolumeclaims",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "Role \"hub\" has rbac rule for resource \"persistentvolumeclaims.\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "secrets",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "Role \"hub\" has rbac rule for resource \"secrets.\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "secrets",
+      "verbs": [
+        "watch"
+      ]
+    },
+    "message": "Role \"hub\" has rbac rule for resource \"secrets.\" with verb \"watch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "secrets",
+      "verbs": [
+        "list"
+      ]
+    },
+    "message": "Role \"hub\" has rbac rule for resource \"secrets.\" with verb \"list\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "secrets",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "Role \"hub\" has rbac rule for resource \"secrets.\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "secrets",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "Role \"hub\" has rbac rule for resource \"secrets.\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "Role \"hub\" has rbac rule for resource \"services.\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "Role \"hub\" has rbac rule for resource \"services.\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/hub/readonlyrootfs.json
+++ b/security_test/allowlist/category/cluster/hub/readonlyrootfs.json
@@ -1,0 +1,17 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "hub"
+    },
+    "message": "container \"hub\" in Deployment \"hub\" does not set readOnlyRootFilesystem: true in its securityContext. This setting is encouraged because it can prevent attackers from writing malicious binaries into runnable locations in the container filesystem.",
+    "policyName": "readonlyrootfs",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/hub/seccompprofile.json
+++ b/security_test/allowlist/category/cluster/hub/seccompprofile.json
@@ -1,0 +1,13 @@
+[
+  {
+    "message": "pod in Deployment \"hub\" must set securityContext.seccompProfile.type to value RuntimeDefault",
+    "policyName": "seccompprofile",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "hub",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/kuberay-operator-leader-election/rbac.json
+++ b/security_test/allowlist/category/cluster/kuberay-operator-leader-election/rbac.json
@@ -1,0 +1,129 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "configmaps",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "Role \"kuberay-operator-leader-election\" has rbac rule for resource: \"configmaps.\" with verb \"update\" that must specify a resourceName.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "kuberay-operator-leader-election",
+      "namespace": "gke-ray-system",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "configmaps",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "Role \"kuberay-operator-leader-election\" has rbac rule for resource: \"configmaps.\" with verb \"patch\" that must specify a resourceName.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "kuberay-operator-leader-election",
+      "namespace": "gke-ray-system",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "configmaps",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "Role \"kuberay-operator-leader-election\" has rbac rule for resource: \"configmaps.\" with verb \"delete\" that must specify a resourceName.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "kuberay-operator-leader-election",
+      "namespace": "gke-ray-system",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "configmaps/status",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "Role \"kuberay-operator-leader-election\" has rbac rule for resource \"configmaps/status.\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "kuberay-operator-leader-election",
+      "namespace": "gke-ray-system",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "configmaps/status",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "Role \"kuberay-operator-leader-election\" has rbac rule for resource \"configmaps/status.\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "kuberay-operator-leader-election",
+      "namespace": "gke-ray-system",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "configmaps/status",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "Role \"kuberay-operator-leader-election\" has rbac rule for resource \"configmaps/status.\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "kuberay-operator-leader-election",
+      "namespace": "gke-ray-system",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "coordination.k8s.io",
+      "resource": "leases",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "Role \"kuberay-operator-leader-election\" has rbac rule for resource: \"leases.coordination.k8s.io\" with verb \"update\" that must specify a resourceName.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "kuberay-operator-leader-election",
+      "namespace": "gke-ray-system",
+      "version": "v1"
+    }
+  }
+]

--- a/security_test/allowlist/category/cluster/kuberay-operator/rbac.json
+++ b/security_test/allowlist/category/cluster/kuberay-operator/rbac.json
@@ -1,0 +1,1454 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "batch",
+      "resource": "jobs",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"jobs.batch\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "batch",
+      "resource": "jobs",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"jobs.batch\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "batch",
+      "resource": "jobs",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"jobs.batch\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "batch",
+      "resource": "jobs",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"jobs.batch\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "coordination.k8s.io",
+      "resource": "leases",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource: \"leases.coordination.k8s.io\" with verb \"update\" that must specify a resourceName.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods.\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods.\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods",
+      "verbs": [
+        "deletecollection"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods.\" with verb \"deletecollection\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods.\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods.\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods/proxy",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods/proxy.\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods/proxy",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods/proxy.\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods/proxy",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods/proxy.\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods/status",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods/status.\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods/status",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods/status.\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods/status",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods/status.\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods/status",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"pods/status.\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "serviceaccounts",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"serviceaccounts.\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "serviceaccounts",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"serviceaccounts.\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"services.\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"services.\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"services.\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"services.\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services/proxy",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"services/proxy.\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services/proxy",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"services/proxy.\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services/proxy",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"services/proxy.\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services/proxy",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"services/proxy.\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services/status",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"services/status.\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "services/status",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"services/status.\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "extensions",
+      "resource": "ingresses",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"ingresses.extensions\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "extensions",
+      "resource": "ingresses",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"ingresses.extensions\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "extensions",
+      "resource": "ingresses",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"ingresses.extensions\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "extensions",
+      "resource": "ingresses",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"ingresses.extensions\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "networking.k8s.io",
+      "resource": "ingresses",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"ingresses.networking.k8s.io\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "networking.k8s.io",
+      "resource": "ingresses",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"ingresses.networking.k8s.io\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "networking.k8s.io",
+      "resource": "ingresses",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"ingresses.networking.k8s.io\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "networking.k8s.io",
+      "resource": "ingresses",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"ingresses.networking.k8s.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayclusters.ray.io\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayclusters.ray.io\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayclusters.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters",
+      "verbs": [
+        "list"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayclusters.ray.io\" with verb \"list\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayclusters.ray.io\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayclusters.ray.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters",
+      "verbs": [
+        "watch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayclusters.ray.io\" with verb \"watch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters/finalizers",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayclusters/finalizers.ray.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters/status",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayclusters/status.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters/status",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayclusters/status.ray.io\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters/status",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayclusters/status.ray.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "list"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"list\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "watch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"watch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs/finalizers",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayjobs/finalizers.ray.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs/status",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayjobs/status.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs/status",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayjobs/status.ray.io\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs/status",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayjobs/status.ray.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayservices.ray.io\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayservices.ray.io\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayservices.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "list"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayservices.ray.io\" with verb \"list\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayservices.ray.io\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayservices.ray.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "watch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayservices.ray.io\" with verb \"watch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices/finalizers",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayservices/finalizers.ray.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices/status",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayservices/status.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices/status",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayservices/status.ray.io\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices/status",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rayservices/status.ray.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "rbac.authorization.k8s.io",
+      "resource": "rolebindings",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rolebindings.rbac.authorization.k8s.io\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "rbac.authorization.k8s.io",
+      "resource": "rolebindings",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"rolebindings.rbac.authorization.k8s.io\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "rbac.authorization.k8s.io",
+      "resource": "roles",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"roles.rbac.authorization.k8s.io\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "rbac.authorization.k8s.io",
+      "resource": "roles",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"roles.rbac.authorization.k8s.io\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "rbac.authorization.k8s.io",
+      "resource": "roles",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"roles.rbac.authorization.k8s.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "route.openshift.io",
+      "resource": "routes",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"routes.route.openshift.io\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "route.openshift.io",
+      "resource": "routes",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"routes.route.openshift.io\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "route.openshift.io",
+      "resource": "routes",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"routes.route.openshift.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "route.openshift.io",
+      "resource": "routes",
+      "verbs": [
+        "list"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"routes.route.openshift.io\" with verb \"list\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "route.openshift.io",
+      "resource": "routes",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"routes.route.openshift.io\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "route.openshift.io",
+      "resource": "routes",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"routes.route.openshift.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "route.openshift.io",
+      "resource": "routes",
+      "verbs": [
+        "watch"
+      ]
+    },
+    "message": "ClusterRole \"kuberay-operator\" has rbac rule for resource \"routes.route.openshift.io\" with verb \"watch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "kuberay-operator",
+      "version": "v1"
+    }
+  }
+]

--- a/security_test/allowlist/category/cluster/mistral-7b-instruct/allowprivilegeescalation.json
+++ b/security_test/allowlist/category/cluster/mistral-7b-instruct/allowprivilegeescalation.json
@@ -1,0 +1,17 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "mistral-7b-instruct"
+    },
+    "message": "container \"mistral-7b-instruct\" in Deployment \"mistral-7b-instruct\" does not set allowPrivilegeEscalation: false in its securityContext. See go/gke-shipshape#allowprivilegeescalation for more details",
+    "policyName": "allowprivilegeescalation",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/mistral-7b-instruct/capabilities.json
+++ b/security_test/allowlist/category/cluster/mistral-7b-instruct/capabilities.json
@@ -1,0 +1,17 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "mistral-7b-instruct"
+    },
+    "message": "container \"mistral-7b-instruct\" in Deployment \"mistral-7b-instruct\" does not drop all capabilities in its securityContext. See go/gke-shipshape#capabilities for more details",
+    "policyName": "capabilities",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/mistral-7b-instruct/distroless.json
+++ b/security_test/allowlist/category/cluster/mistral-7b-instruct/distroless.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "download-model",
+      "image": "google/cloud-sdk:473.0.0-alpine"
+    },
+    "message": "image \"google/cloud-sdk:473.0.0-alpine\" could not be found on gcr.io",
+    "policyName": "distroless",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "mistral-7b-instruct",
+      "image": "ghcr.io/huggingface/text-generation-inference:1.4.3"
+    },
+    "message": "image \"ghcr.io/huggingface/text-generation-inference:1.4.3\" could not be found on gcr.io",
+    "policyName": "distroless",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/mistral-7b-instruct/imagedigest.json
+++ b/security_test/allowlist/category/cluster/mistral-7b-instruct/imagedigest.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "download-model",
+      "image": "google/cloud-sdk:473.0.0-alpine"
+    },
+    "message": "container \"download-model\" in Deployment \"mistral-7b-instruct\" has an image \"google/cloud-sdk:473.0.0-alpine\" with no digest; valid image format: image[:tag]@sha256:\u003cdigest\u003e",
+    "policyName": "imagedigest",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "mistral-7b-instruct",
+      "image": "ghcr.io/huggingface/text-generation-inference:1.4.3"
+    },
+    "message": "container \"mistral-7b-instruct\" in Deployment \"mistral-7b-instruct\" has an image \"ghcr.io/huggingface/text-generation-inference:1.4.3\" with no digest; valid image format: image[:tag]@sha256:\u003cdigest\u003e",
+    "policyName": "imagedigest",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/mistral-7b-instruct/imagefreshness.json
+++ b/security_test/allowlist/category/cluster/mistral-7b-instruct/imagefreshness.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "download-model",
+      "image": "google/cloud-sdk:473.0.0-alpine"
+    },
+    "message": "container \"download-model\" in Deployment \"mistral-7b-instruct\" has an image \"google/cloud-sdk:473.0.0-alpine\" that does not have a valid digest.",
+    "policyName": "imagefreshness",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "mistral-7b-instruct",
+      "image": "ghcr.io/huggingface/text-generation-inference:1.4.3"
+    },
+    "message": "container \"mistral-7b-instruct\" in Deployment \"mistral-7b-instruct\" has an image \"ghcr.io/huggingface/text-generation-inference:1.4.3\" that does not have a valid digest.",
+    "policyName": "imagefreshness",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/mistral-7b-instruct/imagepath.json
+++ b/security_test/allowlist/category/cluster/mistral-7b-instruct/imagepath.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "download-model",
+      "image": "google/cloud-sdk:473.0.0-alpine"
+    },
+    "message": "container \"download-model\" in Deployment \"mistral-7b-instruct\" has an image \"google/cloud-sdk:473.0.0-alpine\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
+    "policyName": "imagepath",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "mistral-7b-instruct",
+      "image": "ghcr.io/huggingface/text-generation-inference:1.4.3"
+    },
+    "message": "container \"mistral-7b-instruct\" in Deployment \"mistral-7b-instruct\" has an image \"ghcr.io/huggingface/text-generation-inference:1.4.3\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
+    "policyName": "imagepath",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/mistral-7b-instruct/readonlyrootfs.json
+++ b/security_test/allowlist/category/cluster/mistral-7b-instruct/readonlyrootfs.json
@@ -1,0 +1,17 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "mistral-7b-instruct"
+    },
+    "message": "container \"mistral-7b-instruct\" in Deployment \"mistral-7b-instruct\" does not set readOnlyRootFilesystem: true in its securityContext. This setting is encouraged because it can prevent attackers from writing malicious binaries into runnable locations in the container filesystem.",
+    "policyName": "readonlyrootfs",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/mistral-7b-instruct/rootless.json
+++ b/security_test/allowlist/category/cluster/mistral-7b-instruct/rootless.json
@@ -1,0 +1,17 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "mistral-7b-instruct"
+    },
+    "message": "container \"mistral-7b-instruct\" in Deployment \"mistral-7b-instruct\" is running as root. Update the container to run as non-root. See go/gke-shipshape#rootless for more details",
+    "policyName": "rootless",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/mistral-7b-instruct/sbom.json
+++ b/security_test/allowlist/category/cluster/mistral-7b-instruct/sbom.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "download-model",
+      "image": "google/cloud-sdk:473.0.0-alpine"
+    },
+    "message": "container \"download-model\" in Deployment \"mistral-7b-instruct\" has an image \"google/cloud-sdk:473.0.0-alpine\" with no digest specified. Unable to find digest from registry.",
+    "policyName": "sbom",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "mistral-7b-instruct",
+      "image": "ghcr.io/huggingface/text-generation-inference:1.4.3"
+    },
+    "message": "container \"mistral-7b-instruct\" in Deployment \"mistral-7b-instruct\" has an image \"ghcr.io/huggingface/text-generation-inference:1.4.3\" with no digest specified. Unable to find digest from registry.",
+    "policyName": "sbom",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/mistral-7b-instruct/seccompprofile.json
+++ b/security_test/allowlist/category/cluster/mistral-7b-instruct/seccompprofile.json
@@ -1,0 +1,13 @@
+[
+  {
+    "message": "pod in Deployment \"mistral-7b-instruct\" must set securityContext.seccompProfile.type to value RuntimeDefault",
+    "policyName": "seccompprofile",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "mistral-7b-instruct",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/proxy/capabilities.json
+++ b/security_test/allowlist/category/cluster/proxy/capabilities.json
@@ -1,0 +1,17 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "chp"
+    },
+    "message": "container \"chp\" in Deployment \"proxy\" does not drop all capabilities in its securityContext. See go/gke-shipshape#capabilities for more details",
+    "policyName": "capabilities",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "proxy",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+]

--- a/security_test/allowlist/category/cluster/proxy/distroless.json
+++ b/security_test/allowlist/category/cluster/proxy/distroless.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "chp",
+      "image": "quay.io/jupyterhub/configurable-http-proxy:4.6.1"
+    },
+    "message": "image \"quay.io/jupyterhub/configurable-http-proxy:4.6.1\" could not be found on gcr.io",
+    "policyName": "distroless",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "proxy",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/proxy/imagedigest.json
+++ b/security_test/allowlist/category/cluster/proxy/imagedigest.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "chp",
+      "image": "quay.io/jupyterhub/configurable-http-proxy:4.6.1"
+    },
+    "message": "container \"chp\" in Deployment \"proxy\" has an image \"quay.io/jupyterhub/configurable-http-proxy:4.6.1\" with no digest; valid image format: image[:tag]@sha256:\u003cdigest\u003e",
+    "policyName": "imagedigest",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "proxy",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/proxy/imagefreshness.json
+++ b/security_test/allowlist/category/cluster/proxy/imagefreshness.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "chp",
+      "image": "quay.io/jupyterhub/configurable-http-proxy:4.6.1"
+    },
+    "message": "container \"chp\" in Deployment \"proxy\" has an image \"quay.io/jupyterhub/configurable-http-proxy:4.6.1\" that does not have a valid digest.",
+    "policyName": "imagefreshness",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "proxy",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/proxy/imagepath.json
+++ b/security_test/allowlist/category/cluster/proxy/imagepath.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "image": "quay.io/jupyterhub/configurable-http-proxy:4.6.1",
+      "containerName": "chp"
+    },
+    "message": "container \"chp\" in Deployment \"proxy\" has an image \"quay.io/jupyterhub/configurable-http-proxy:4.6.1\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
+    "policyName": "imagepath",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "proxy",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/proxy/readonlyrootfs.json
+++ b/security_test/allowlist/category/cluster/proxy/readonlyrootfs.json
@@ -1,0 +1,17 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "chp"
+    },
+    "message": "container \"chp\" in Deployment \"proxy\" does not set readOnlyRootFilesystem: true in its securityContext. This setting is encouraged because it can prevent attackers from writing malicious binaries into runnable locations in the container filesystem.",
+    "policyName": "readonlyrootfs",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "proxy",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/proxy/sbom.json
+++ b/security_test/allowlist/category/cluster/proxy/sbom.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "chp",
+      "image": "quay.io/jupyterhub/configurable-http-proxy:4.6.1"
+    },
+    "message": "container \"chp\" in Deployment \"proxy\" has an image \"quay.io/jupyterhub/configurable-http-proxy:4.6.1\" with no digest specified. Unable to find digest from registry.",
+    "policyName": "sbom",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "proxy",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/proxy/seccompprofile.json
+++ b/security_test/allowlist/category/cluster/proxy/seccompprofile.json
@@ -1,0 +1,13 @@
+[
+  {
+    "message": "pod in Deployment \"proxy\" must set securityContext.seccompProfile.type to value RuntimeDefault",
+    "policyName": "seccompprofile",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "proxy",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/rag-frontend/allowprivilegeescalation.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/allowprivilegeescalation.json
@@ -1,0 +1,32 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "rag-frontend"
+    },
+    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" does not set allowPrivilegeEscalation: false in its securityContext. See go/gke-shipshape#allowprivilegeescalation for more details",
+    "policyName": "allowprivilegeescalation",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "cloud-sql-proxy"
+    },
+    "message": "container \"cloud-sql-proxy\" in Deployment \"rag-frontend\" does not set allowPrivilegeEscalation: false in its securityContext. See go/gke-shipshape#allowprivilegeescalation for more details",
+    "policyName": "allowprivilegeescalation",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/rag-frontend/capabilities.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/capabilities.json
@@ -1,0 +1,32 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "rag-frontend"
+    },
+    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" does not drop all capabilities in its securityContext. See go/gke-shipshape#capabilities for more details",
+    "policyName": "capabilities",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "cloud-sql-proxy"
+    },
+    "message": "container \"cloud-sql-proxy\" in Deployment \"rag-frontend\" does not drop all capabilities in its securityContext. See go/gke-shipshape#capabilities for more details",
+    "policyName": "capabilities",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/rag-frontend/distroless.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/distroless.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "rag-frontend",
+      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59"
+    },
+    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59\" built from non-distroless base image \"Debian GNU/Linux 12 (bookworm)\". See: go/gke-distroless for more details",
+    "policyName": "distroless",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/rag-frontend/imagedigest.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/imagedigest.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "image": "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0",
+      "containerName": "cloud-sql-proxy"
+    },
+    "message": "container \"cloud-sql-proxy\" in Deployment \"rag-frontend\" has an image \"gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0\" with no digest; valid image format: image[:tag]@sha256:\u003cdigest\u003e",
+    "policyName": "imagedigest",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/rag-frontend/imagefreshness.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/imagefreshness.json
@@ -1,0 +1,18 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "cloud-sql-proxy",
+      "image": "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0"
+    },
+    "message": "container \"cloud-sql-proxy\" in Deployment \"rag-frontend\" has an image \"gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0\" that does not have a valid digest.",
+    "policyName": "imagefreshness",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/rag-frontend/imagepath.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/imagepath.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59",
+      "containerName": "rag-frontend"
+    },
+    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
+    "policyName": "imagepath",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "cloud-sql-proxy",
+      "image": "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0"
+    },
+    "message": "container \"cloud-sql-proxy\" in Deployment \"rag-frontend\" has an image \"gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
+    "policyName": "imagepath",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/rag-frontend/readonlyrootfs.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/readonlyrootfs.json
@@ -1,0 +1,32 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "rag-frontend"
+    },
+    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" does not set readOnlyRootFilesystem: true in its securityContext. This setting is encouraged because it can prevent attackers from writing malicious binaries into runnable locations in the container filesystem.",
+    "policyName": "readonlyrootfs",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "cloud-sql-proxy"
+    },
+    "message": "container \"cloud-sql-proxy\" in Deployment \"rag-frontend\" does not set readOnlyRootFilesystem: true in its securityContext. This setting is encouraged because it can prevent attackers from writing malicious binaries into runnable locations in the container filesystem.",
+    "policyName": "readonlyrootfs",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/rag-frontend/rootless.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/rootless.json
@@ -1,0 +1,32 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "rag-frontend"
+    },
+    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" is running as root. Update the container to run as non-root. See go/gke-shipshape#rootless for more details",
+    "policyName": "rootless",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "cloud-sql-proxy"
+    },
+    "message": "container \"cloud-sql-proxy\" in Deployment \"rag-frontend\" is running as root. Update the container to run as non-root. See go/gke-shipshape#rootless for more details",
+    "policyName": "rootless",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/rag-frontend/sbom.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/sbom.json
@@ -1,0 +1,34 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "rag-frontend",
+      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59"
+    },
+    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59\" without SBOM. See: go/gke-anthos-sbom-requirement for more details",
+    "policyName": "sbom",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
+      "containerName": "cloud-sql-proxy",
+      "image": "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0"
+    },
+    "message": "container \"cloud-sql-proxy\" in Deployment \"rag-frontend\" has an image \"gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.8.0\" without SBOM. See: go/gke-anthos-sbom-requirement for more details",
+    "policyName": "sbom",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/rag-frontend/seccompprofile.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/seccompprofile.json
@@ -1,0 +1,13 @@
+[
+  {
+    "message": "pod in Deployment \"rag-frontend\" must set securityContext.seccompProfile.type to value RuntimeDefault",
+    "policyName": "seccompprofile",
+    "resourceKey": {
+      "group": "apps",
+      "kind": "Deployment",
+      "name": "rag-frontend",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/ray-cluster-kuberay/rbac.json
+++ b/security_test/allowlist/category/cluster/ray-cluster-kuberay/rbac.json
@@ -1,0 +1,58 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "resource": "pods",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "Role \"ray-cluster-kuberay\" has rbac rule for resource \"pods.\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "ray-cluster-kuberay",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "Role \"ray-cluster-kuberay\" has rbac rule for resource \"rayclusters.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "ray-cluster-kuberay",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayclusters",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "Role \"ray-cluster-kuberay\" has rbac rule for resource \"rayclusters.ray.io\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "Role",
+      "name": "ray-cluster-kuberay",
+      "namespace": ".*",
+      "version": "v1"
+    }
+  }
+] 

--- a/security_test/allowlist/category/cluster/rayjob-editor-role/rbac.json
+++ b/security_test/allowlist/category/cluster/rayjob-editor-role/rbac.json
@@ -1,0 +1,146 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-editor-role\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-editor-role\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-editor-role\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "list"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-editor-role\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"list\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-editor-role\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-editor-role\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "watch"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-editor-role\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"watch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs/status",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-editor-role\" has rbac rule for resource \"rayjobs/status.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-editor-role",
+      "version": "v1"
+    }
+  }
+]

--- a/security_test/allowlist/category/cluster/rayjob-viewer-role/rbac.json
+++ b/security_test/allowlist/category/cluster/rayjob-viewer-role/rbac.json
@@ -1,0 +1,74 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-viewer-role\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-viewer-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "list"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-viewer-role\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"list\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-viewer-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs",
+      "verbs": [
+        "watch"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-viewer-role\" has rbac rule for resource \"rayjobs.ray.io\" with verb \"watch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-viewer-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayjobs/status",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"rayjob-viewer-role\" has rbac rule for resource \"rayjobs/status.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayjob-viewer-role",
+      "version": "v1"
+    }
+  }
+]

--- a/security_test/allowlist/category/cluster/rayservice-editor-role/rbac.json
+++ b/security_test/allowlist/category/cluster/rayservice-editor-role/rbac.json
@@ -1,0 +1,146 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "create"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-editor-role\" has rbac rule for resource \"rayservices.ray.io\" with verb \"create\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "delete"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-editor-role\" has rbac rule for resource \"rayservices.ray.io\" with verb \"delete\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-editor-role\" has rbac rule for resource \"rayservices.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "list"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-editor-role\" has rbac rule for resource \"rayservices.ray.io\" with verb \"list\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "patch"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-editor-role\" has rbac rule for resource \"rayservices.ray.io\" with verb \"patch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "update"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-editor-role\" has rbac rule for resource \"rayservices.ray.io\" with verb \"update\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "watch"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-editor-role\" has rbac rule for resource \"rayservices.ray.io\" with verb \"watch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-editor-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices/status",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-editor-role\" has rbac rule for resource \"rayservices/status.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-editor-role",
+      "version": "v1"
+    }
+  }
+]

--- a/security_test/allowlist/category/cluster/rayservice-viewer-role/rbac.json
+++ b/security_test/allowlist/category/cluster/rayservice-viewer-role/rbac.json
@@ -1,0 +1,74 @@
+[
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-viewer-role\" has rbac rule for resource \"rayservices.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-viewer-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "list"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-viewer-role\" has rbac rule for resource \"rayservices.ray.io\" with verb \"list\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-viewer-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices",
+      "verbs": [
+        "watch"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-viewer-role\" has rbac rule for resource \"rayservices.ray.io\" with verb \"watch\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-viewer-role",
+      "version": "v1"
+    }
+  },
+  {
+    "details": {
+      "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.RBACDetails",
+      "apiGroup": "ray.io",
+      "resource": "rayservices/status",
+      "verbs": [
+        "get"
+      ]
+    },
+    "message": "ClusterRole \"rayservice-viewer-role\" has rbac rule for resource \"rayservices/status.ray.io\" with verb \"get\" that is not allowed.",
+    "policyName": "rbac",
+    "resourceKey": {
+      "group": "rbac.authorization.k8s.io",
+      "kind": "ClusterRole",
+      "name": "rayservice-viewer-role",
+      "version": "v1"
+    }
+  }
+]

--- a/security_test/config.yaml
+++ b/security_test/config.yaml
@@ -1,0 +1,69 @@
+wantedResources:
+- Group: "^apps$"
+  Version: "^v1$"
+  Kind: "^Deployment$"
+- Group: "^apps$"
+  Version: "^v1$"
+  Kind: "^Job$"
+- Group: "^apps$"
+  Version: "^v1$"
+  Kind: "^DaemonSet$"
+- Group: ".*"
+  Version: "^v1$"
+  Kind: "^ServiceAccount$"
+- Group: "rbac.authorization.k8s.io$"
+  Version: "^v1$"
+  Kind: "^Role$"
+- Group: "rbac.authorization.k8s.io$"
+  Version: "^v1$"
+  Kind: "^RoleBinding$"
+- Group: "rbac.authorization.k8s.io$"
+  Version: "^v1$"
+  Kind: "^ClusterRole$"
+- Group: "rbac.authorization.k8s.io$"
+  Version: "^v1$"
+  Kind: "^ClusterRoleBinding$"
+# Ignored objects configuration
+ignoredObjects:
+
+# General system-related objects
+- Group: ".*"
+  Kind: ".*"
+  Version: ".*"
+  Namespace: ".*"
+  Name: "^system:.*"
+
+# Objects from system-related namespaces
+- Group: ".*"
+  Kind: ".*"
+  Version: ".*"
+  Namespace: "^(kube-system|kube-public|kube-node-lease|gke-(gmp-system.*|managed-.*|gmp-public))$"
+  Name: ".*"
+
+# ClusterRoles (system-related or not security-relevant)
+- Group: "rbac.authorization.k8s.io"
+  Kind: "ClusterRole"
+  Version: "v1"
+  Namespace: ".*"
+  Name: "^(cluster-admin|cilium.*|external-metrics-reader|anet-operator-cluster-role|cluster-autoscaler|filestorecsi-resizer-role|pdcsi-snapshotter-role|ca-cr-actor|antrea-agent|egress-nat-controller|pdcsi-resizer-role|snapshot-controller-runner|gce:cloud-provider|gce:beta:kubelet-certificate-rotation|pdcsi-attacher-role|pdcsi-provisioner-role|edit|gke-gmp-system:operator|filestorecsi-provisioner-role|admin|gke-spiffe-issuer|gke-spiffe-user|ca-pr-beta-actor|kubelet-api-admin|gmp-system:operator|gce:beta:kubelet-certificate-bootstrap)$"
+
+# ClusterRoleBindings (system-related or not security-relevant)
+- Group: "rbac.authorization.k8s.io"
+  Kind: "ClusterRoleBinding"
+  Version: "v1"
+  Namespace: ".*"
+  Name: "^(gce:beta:kubelet-certificate-rotation|gce:gke-metadata-server-reader|antrea-agent|nodes-are-gke-spiffe-users)$"
+
+# Role-related objects in specific namespaces
+- Group: "rbac.authorization.k8s.io"
+  Kind: "Role"
+  Version: "v1"
+  Namespace: "^(gmp-public|gmp-system)$"
+  Name: "^operator$"
+
+# Specific ServiceAccounts
+- Group: ".*"
+  Kind: "ServiceAccount"
+  Version: "v1"
+  Namespace: "default"
+  Name: "^default$"


### PR DESCRIPTION
## Overview

This pull request introduces the integration of the Kubernetes Security Validation Service (Shipshape) cluster scan into the AI-on-GKE project. The cluster scan ensures enhanced security validation and compliance for Kubernetes YAML configurations. By onboarding the cluster scan, the project aligns with the broader objective of securing Kubernetes workloads across all GitHub repositories.

## Key Changes

### 1. **Cluster Scan Workflow**
- Added a step to scan the GKE cluster dynamically during the presubmit process.

### 2. **Security Validation Integration**
- Integrated Shipshape cluster scan in the Cloud Build pipeline.
- Configured Shipshape to utilize the cluster scan mode with the following features:
  - **Allowlist Support:** Allowlisted known violations to prevent build failures due to existing, non-critical issues.
  - **Regex-Based Matching:** Enhanced allowlist capabilities with regex support for namespace and object name patterns.
  - **Configuration File:** Introduced a configuration file specifying wanted resources and ignored objects, enabling fine-grained control over validation.

### 3. **Test and Validation**
- Added Terraform steps to deploy and test the following applications in the GKE cluster:
  - **RAG (Retriever-Augmented Generation):** Verified RAG violations, including Ray dashboard readiness and frontend prompt testing. Details in security_test folder.

## How to Test

### 1. Presubmit Testing
- Triggered automatically during PR submission.
- Validates cluster creation, application deployments, and Shipshape cluster scans.

### 2. Manual Testing
- To run locally: ```bash gcloud builds submit --config cloudbuild.yaml . --project=gke-ai-eco-dev ```