### PR TITLE
[TPU Webhook] Fix KubeRay headless worker svc truncation bug

### DIFF
--- a/ray-on-gke/tpu/kuberay-tpu-webhook/main.go
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/main.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	ray "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
+	utils "github.com/ray-project/kuberay/ray-operator/controllers/ray/utils"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -250,12 +251,7 @@ func generateHeadlessServiceName(clusterName string) string {
 
 	// Apply the same truncation as in the RayCluster controller when generating the headless service
 	// name. This is to maintain the up-to 63 char compatibility guarantee for hostnames (RFC 1123).
-	maxLength := 50
-	if len(serviceName) > maxLength {
-		// shorten the name
-		offset := int(math.Abs(float64(maxLength) - float64(len(serviceName))))
-		serviceName = serviceName[offset:]
-	}
+	serviceName = utils.CheckName(serviceName)
 	return serviceName
 }
 

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/main.go
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/main.go
@@ -251,8 +251,7 @@ func generateHeadlessServiceName(clusterName string) string {
 
 	// Apply the same truncation as in the RayCluster controller when generating the headless service
 	// name. This is to maintain the up-to 63 char compatibility guarantee for hostnames (RFC 1123).
-	serviceName = utils.CheckName(serviceName)
-	return serviceName
+	return utils.CheckName(serviceName)
 }
 
 // genDNSHostnames returns list of DNS hostnames for TPU VM hosts as a string

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/main.go
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/main.go
@@ -244,16 +244,32 @@ func extractRayCluster(admissionReview *admissionv1.AdmissionReview) (*ray.RayCl
 	return &rayCluster, nil
 }
 
+// generateHeadlessServiceName returns the expected TPU headless service name for a RayCluster
+func generateHeadlessServiceName(clusterName string) string {
+	serviceName := fmt.Sprintf("%s-%s", clusterName, headlessServiceSuffix)
+
+	// Apply the same truncation as in the RayCluster controller when generating the headless service
+	// name. This is to maintain the up-to 63 char compatibility guarantee for hostnames (RFC 1123).
+	maxLength := 50
+	if len(serviceName) > maxLength {
+		// shorten the name
+		offset := int(math.Abs(float64(maxLength) - float64(len(serviceName))))
+		serviceName = serviceName[offset:]
+	}
+	return serviceName
+}
+
 // genDNSHostnames returns list of DNS hostnames for TPU VM hosts as a string
 func genDNSHostnames(numOfHosts int32, groupName string, clusterName string, namespace string, replicaIndex int) (string, error) {
 	if numOfHosts == 0 {
 		err := errors.New("workerGroupSpec NumOfHosts not set")
 		return "", err
 	}
+	headlessServiceName := generateHeadlessServiceName(clusterName)
 	hostNames := make([]string, numOfHosts)
-	// Host names will be of the form {WORKER_GROUP_NAME}-{REPLICA_INDEX}-{HOST_INDEX}.headless-worker-svc
+	// Host names will be of the form {WORKER_GROUP_NAME}-{REPLICA_INDEX}-{HOST_INDEX}.{CLUSTER_NAME}-headless-worker-svc
 	for j := 0; j < int(numOfHosts); j++ {
-		hostNames[j] = fmt.Sprintf("%s-%d-%d.%s-%s", groupName, replicaIndex, j, clusterName, headlessServiceSuffix)
+		hostNames[j] = fmt.Sprintf("%s-%d-%d.%s", groupName, replicaIndex, j, headlessServiceName)
 	}
 	klog.V(1).InfoS("genDNSHostnames", "RayCluster", namespace+"/"+clusterName, "NumOfHosts", numOfHosts, "Replica Index", replicaIndex)
 	return strings.Join(hostNames, ","), nil
@@ -268,7 +284,7 @@ func injectHostnames(clusterName string, hostNames string, envPath string, conta
 		Value: hostNames,
 	}
 	subdomainPatch["path"] = subdomainPath
-	subdomainPatch["value"] = fmt.Sprintf("%s-%s", clusterName, headlessServiceSuffix)
+	subdomainPatch["value"] = generateHeadlessServiceName(clusterName)
 	// create new EnvVar array if container.Env is empty, and append hostnames if not
 	if len(container.Env) == 0 {
 		hostNamesPatch["path"] = envPath
@@ -678,7 +694,7 @@ func (t *TPUWebhookServer) mutatePod(admissionReview *admissionv1.AdmissionRevie
 					return nil, err
 				}
 				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "TPU_WORKER_HOSTNAMES", hostnames)
-				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "subdomain", clusterName+"-"+headlessServiceSuffix)
+				klog.V(1).InfoS("mutatePod", "RayCluster", namespace+"/"+clusterName, "subdomain", generateHeadlessServiceName(clusterName))
 				injectHostnames(clusterName, hostnames, path, container, &patches)
 			}
 			// inject TPU_WORKER_ID


### PR DESCRIPTION
This PR fixes a bug where the KubeRay RayCluster controller's truncation of generated service names ([here](https://github.com/ray-project/kuberay/blob/b753f1ad8b85e94003ed95dbbd75ff1a41d30570/ray-operator/controllers/ray/utils/util.go#L184)) resulted in incorrectly generated `TPU_WORKER_HOSTNAMES`. This bug was discovered because RayJobs and RayServices with names > 13 chars result in long generated RayCluster names and a truncated TPU headless worker service name. This PR applies the same truncation when generating the name within the webhook so that the names remain consistent.

Related Issues:
https://github.com/ray-project/kuberay/issues/2923

Testing Process:
- [x] Unit tests - added unit test coverage
- [x] Manual tests