### PR TITLE
Update default TPU webhook image to v1.2.2

### DIFF
--- a/ray-on-gke/tpu/kuberay-tpu-webhook/Makefile
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/Makefile
@@ -1,7 +1,7 @@
 # Image URL to use all building/pushing image targets  
-IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.1-gke.0
+IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.2-gke.1
 
-# For europe, use europe-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.0-gke.1
+# For europe, use europe-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook
   
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)  
 ifeq (,$(shell go env GOBIN))  

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/deployments/deployment.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/deployments/deployment.yaml
@@ -64,7 +64,7 @@ spec:
     spec:
       serviceAccountName: kuberay-tpu-webhook
       containers:
-        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.1-gke.0
+        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.2-gke.1
           imagePullPolicy: Always
           name: kuberay-tpu-webhook
           args:

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/Chart.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.1
+version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.1"
+appVersion: "1.2.2"

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/values.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/values.yaml
@@ -7,7 +7,7 @@ tpuWebhook:
   
   image:
     repository: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook
-    tag: v1.2.1-gke.0
+    tag: v1.2.2-gke.1
     pullPolicy: Always
 
   deployment:


### PR DESCRIPTION
The `us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.2-gke.1` image contains a bug fix for incorrect `TPU_WORKER_HOSTNAMES` caused by the KubeRay controller truncating the headless service name. This PR updates the default image used by the helm chart and deployments to the lastest correct version.