### PR TITLE
Move automountServiceAccountToken flag to pod level

### DIFF
--- a/benchmarks/benchmark/tools/CL2-benchmark/statefulset.yaml
+++ b/benchmarks/benchmark/tools/CL2-benchmark/statefulset.yaml
@@ -21,7 +21,6 @@ spec:
   # needs to be set for the DNS label to be based on pod name rather than its IP address
   # https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#stable-network-id
   serviceName: headless-service-0
-  automountServiceAccountToken: false
   template:
     metadata:
       labels:
@@ -33,6 +32,7 @@ spec:
       priorityClassName: {{$PriorityClass}}
       nodeSelector:
         worker-node-pool: "true"
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: ENV_VAR


### PR DESCRIPTION
Current it's a noop on the statefulset as the flag is defined on the pod spec, not the statefulset spec

https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#service-account