### PR TITLE
fix(dws): Adding a job that's compatible with GKE autopilot

### DIFF
--- a/tutorials-and-examples/workflow-orchestration/dws-examples/README.md
+++ b/tutorials-and-examples/workflow-orchestration/dws-examples/README.md
@@ -19,4 +19,5 @@ For more configuration options visit [Kueue's installation guide.](https://kueue
 
 * `dws-queue.yaml` - Kueue's Cluster and Local queues with ProvisioningRequest and DWS support enabled.
 * `job.yaml` - Sample job that requires GPU and uses DWS-enabled queue. Contains optional annotation ` provreq.kueue.x-k8s.io/maxRunDurationSeconds` which sets `maxRunDurationSeconds` for the created ProvisioningRequest
+* `job-autopilot.yaml` - Sample job that requires GPU and uses DWS-enabled queue, compatible with Autopilot GKE clusters. Compared to `job.yaml`, replaces the nodepool selector with accelerator selector, which allows autopilot to manage the nodes.
 

--- a/tutorials-and-examples/workflow-orchestration/dws-examples/job-autopilot.yaml
+++ b/tutorials-and-examples/workflow-orchestration/dws-examples/job-autopilot.yaml
@@ -1,0 +1,35 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: sample-job
+  namespace: default
+  labels:
+    kueue.x-k8s.io/queue-name: dws-local-queue
+  annotations:
+    provreq.kueue.x-k8s.io/maxRunDurationSeconds: "600"
+spec:
+  parallelism: 1
+  completions: 1
+  suspend: true
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-accelerator: "nvidia-tesla-t4"
+      tolerations:
+      - key: "nvidia.com/gpu"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: dummy-job
+        image: gcr.io/k8s-staging-perf-tests/sleep:v0.0.3
+        args: ["120s"]
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "100Mi"
+            nvidia.com/gpu: 1
+          limits:
+            cpu: "100m"
+            memory: "100Mi"
+            nvidia.com/gpu: 1
+      restartPolicy: Never


### PR DESCRIPTION
When running the example from the [documentation page](https://cloud.google.com/kubernetes-engine/docs/how-to/provisioningrequest) on GKE Autopilot cluster, when we reach the step to run `kubectl create -f ./job.yaml` I ended up with an error:

```
Error from server (GKE Warden constraints violations): error when creating "./job.yaml": admission webhook "warden-validating.common-webhooks.networking.gke.io" denied the request: GKE Warden rejected the request because it violates one or more constraints.
Violations details: 
{
   "[denied by autogke-gpu-limitation]":[
      "When requesting 'nvidia.com/gpu' resources, you must specify either node selector 'cloud.google.com/gke-accelerator' with accelerator type or node selector 'cloud.google.com/compute-class' with existing custom compute class which has at least one GPU priority rule."
   ],
   "[denied by autogke-node-affinity-selector-limitation]":[
      "Key 'cloud.google.com/gke-nodepool' is not allowed with node selector; Autopilot only allows labels with keys: cloud.google.com/compute-class,cloud.google.com/machine-family,cloud.google.com/gke-ephemeral-storage-local-ssd,cloud.google.com/gke-spot,cloud.google.com/gke-placement-group,topology.kubernetes.io/region,topology.kubernetes.io/zone,failure-domain.beta.kubernetes.io/region,failure-domain.beta.kubernetes.io/zone,cloud.google.com/gke-os-distribution,kubernetes.io/os,kubernetes.io/arch,cloud.google.com/private-node,sandbox.gke.io/runtime,cloud.google.com/gke-accelerator,cloud.google.com/gke-accelerator-count,iam.gke.io/gke-metadata-server-enabled,cloud.google.com/reservation-name,cloud.google.com/gke-tpu-accelerator,cloud.google.com/gke-tpu-topology,cloud.google.com/reservation-project,cloud.google.com/reservation-affinity,cloud.google.com/gke-gpu-sharing-strategy,cloud.google.com/gke-max-shared-clients-per-gpu,cloud.google.com/gke-gpu-partition-size,cloud.google.com/pods-per-node,cloud.google.com/gke-boot-disk,cloud.google.com/gke-boot-disk-size,cloud.google.com/gke-gpu-driver-version,cloud.google.com/gke-nccl-fastsocket,cloud.google.com/pods-per-node,autoscaling.gke.io/provisioning-request."
   ]
}
```

It seems that this job definition is not friendly towards Autopilot clusters. That's why I'm adding `job-autopilot.yaml`, that works with autopilot clusters and allows for completion of this example. It's exactly the same as `job.yaml`, except it replaces `cloud.google.com/gke-nodepool: NODEPOOL_NAME` with `cloud.google.com/gke-accelerator: "nvidia-tesla-t4"`