### PR TITLE
bump Werkzeug version to fix vulnerability

### DIFF
--- a/applications/rag/frontend/container/requirements.txt
+++ b/applications/rag/frontend/container/requirements.txt
@@ -14,7 +14,7 @@
 
 Flask==3.0.0
 gunicorn==22.0.0
-Werkzeug==3.0.3
+Werkzeug==3.0.6
 langchain==0.3.14
 langchain-community==0.3.14
 sentence-transformers==2.5.1


### PR DESCRIPTION
Tested by generating the image without vulnerabilities mentioned in the report.