### PR TITLE
Update rag frontend image version

### DIFF
--- a/applications/rag/frontend/main.tf
+++ b/applications/rag/frontend/main.tf
@@ -109,7 +109,7 @@ resource "kubernetes_deployment" "rag_frontend_deployment" {
       spec {
         service_account_name = var.google_service_account
         container {
-          image = "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59"
+          image = "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:2b14a3a95f433cc394087ba0d6376d160d8080b62f485f1a119c52b8a6119368"
           name  = "rag-frontend"
 
           port {

--- a/security_test/allowlist/category/cluster/rag-frontend/distroless.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/distroless.json
@@ -3,9 +3,9 @@
     "details": {
       "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
       "containerName": "rag-frontend",
-      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59"
+      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:2b14a3a95f433cc394087ba0d6376d160d8080b62f485f1a119c52b8a6119368"
     },
-    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59\" built from non-distroless base image \"Debian GNU/Linux 12 (bookworm)\". See: go/gke-distroless for more details",
+    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:2b14a3a95f433cc394087ba0d6376d160d8080b62f485f1a119c52b8a6119368\" built from non-distroless base image \"Debian GNU/Linux 12 (bookworm)\". See: go/gke-distroless for more details",
     "policyName": "distroless",
     "resourceKey": {
       "group": "apps",

--- a/security_test/allowlist/category/cluster/rag-frontend/imagepath.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/imagepath.json
@@ -2,10 +2,10 @@
   {
     "details": {
       "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
-      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59",
+      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:2b14a3a95f433cc394087ba0d6376d160d8080b62f485f1a119c52b8a6119368",
       "containerName": "rag-frontend"
     },
-    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
+    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:2b14a3a95f433cc394087ba0d6376d160d8080b62f485f1a119c52b8a6119368\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
     "policyName": "imagepath",
     "resourceKey": {
       "group": "apps",

--- a/security_test/allowlist/category/cluster/rag-frontend/sbom.json
+++ b/security_test/allowlist/category/cluster/rag-frontend/sbom.json
@@ -3,9 +3,9 @@
     "details": {
       "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
       "containerName": "rag-frontend",
-      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59"
+      "image": "us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:2b14a3a95f433cc394087ba0d6376d160d8080b62f485f1a119c52b8a6119368"
     },
-    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:ec0e7b1ce6d0f9570957dd7fb3dcf0a16259cba915570846b356a17d6e377c59\" without SBOM. See: go/gke-anthos-sbom-requirement for more details",
+    "message": "container \"rag-frontend\" in Deployment \"rag-frontend\" has an image \"us-central1-docker.pkg.dev/ai-on-gke/rag-on-gke/frontend@sha256:2b14a3a95f433cc394087ba0d6376d160d8080b62f485f1a119c52b8a6119368\" without SBOM. See: go/gke-anthos-sbom-requirement for more details",
     "policyName": "sbom",
     "resourceKey": {
       "group": "apps",


### PR DESCRIPTION
Update the usage of rag frontend image to the version without complained vulnerabilities. The new image: https://pantheon.corp.google.com/artifacts/docker/ai-on-gke/us-central1/rag-on-gke/frontend/sha256:2b14a3a95f433cc394087ba0d6376d160d8080b62f485f1a119c52b8a6119368?e=13803378&mods=getting_started_solutions_mock_data&project=ai-on-gke

@blackzlq please verify my change to the allowlist makes sense