### PR TITLE
Create github workflow to mark old issues as stale and close

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,45 @@
+---
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This workflow applies stale label to issues that have had no activity for atleast 30 days.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 10 1,15 * *
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    name: stale issues
+    steps:
+      - name: Stale issues
+        uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 30
+          days-before-issue-close: 60
+          stale-issue-message: >
+            'This issue is marked as Stale due to inactivity for more than 30 days.  To
+            avoid being marked as 'stale' please add 'awaiting-maintainer' label or
+            add a comment. Thank you for your contributions '
+          stale-issue-label: stale
+          exempt-issue-labels: awaiting-maintainer, obsolete
+          ascending: true
+          enable-statistics: true
+          labels-to-remove-when-unstale: stale,obsolete


### PR DESCRIPTION
This workflow is to mark all issues as stale after 30 days, and mark for closure after 60. Issues labeled "awaiting-maintainer" will not be marked stale.