### PR TITLE
Marks issues as obsolete after 30 days of stale

### DIFF
--- a/.github/workflows/obsolete.yaml
+++ b/.github/workflows/obsolete.yaml
@@ -1,0 +1,46 @@
+---
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This workflow applies 'obsolete' label to issues that have had no activity for 60 days.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues obsolete
+on:
+  schedule:
+    - cron: 0 2 1,15 * *
+  workflow_dispatch:
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    name: Track Obsolete Issues
+    steps:
+      - name: Track stale issues and check if obsolete
+        uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 30
+          stale-issue-message: >
+            This issue is marked as obsolete due to inactivity for last 60 days.  To
+            avoid issue getting closed in next 30 days, please add a comment or add
+            'awaiting-maintainer' label. Thank you for your contributions
+          stale-issue-label: obsolete
+          only-labels: stale
+          labels-to-remove-when-unstale: stale,obsolete
+          exempt-issue-labels: awaiting-maintainer
+          remove-stale-when-updated: true
+          ascending: true
+          enable-statistics: true


### PR DESCRIPTION
This GitHub workflow marks an issue as obsolete after 30 days of the "stale" label applied to the issue.