### PR TITLE
Close obsolete issues after 30 days

### DIFF
--- a/.github/workflows/close.yaml
+++ b/.github/workflows/close.yaml
@@ -1,0 +1,46 @@
+---
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This workflow closes issues that have had no activity for 90 days.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Close Old
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: 0 1 1,15 * *
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v8
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 30
+          close-issue-message: >
+            We are closing this as there was no activity in this issue for last 90
+            days. Please reopen if you’d like to discuss anything further.
+          only-labels: obsolete
+          exempt-issue-labels: awaiting-maintainer
+          ascending: true
+          days-before-close: 0
+          close-issue-reason: not_planned
+          stale-issue-label: wontfix
+          enable-statistics: true
+          labels-to-remove-when-unstale: stale,obsolete


### PR DESCRIPTION
This GitHub workflow closes issues that have been labeled "obsolete" for 30 days. This means an issue is automatically closed after 90 days if it does not have the label "awaiting-maintainer".