### PR TITLE
Adds sample-public-image- prefix to jupyterhub-authentication-class/jupyter-auth-class image tag

### DIFF
--- a/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
@@ -25,7 +25,7 @@ hub:
   image:
     name: us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class
     # This is the timestamp of the image, we should avoid using 'latest'
-    tag: '1710974014'
+    tag: 'sample-public-image-1710974014'
   labels:
     ${indent(4, chomp(jsonencode(additional_labels)))}
   config:

--- a/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth-autopilot.yaml
@@ -25,7 +25,7 @@ hub:
   image:
     name: us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class
     # This is the timestamp of the image, we should avoid using 'latest'
-    tag: 'sample-public-image-1710974014'
+    tag: 'sample-public-image-1741648202'
   labels:
     ${indent(4, chomp(jsonencode(additional_labels)))}
   config:

--- a/modules/jupyter/jupyter_config/config-selfauth.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth.yaml
@@ -25,7 +25,7 @@ hub:
   image:
     name: us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class
     # This is the timestamp of the image, we should avoid using 'latest'
-    tag: '1710974014'
+    tag: 'sample-public-image-1710974014'
   labels:
     ${indent(4, chomp(jsonencode(additional_labels)))}
   config:

--- a/modules/jupyter/jupyter_config/config-selfauth.yaml
+++ b/modules/jupyter/jupyter_config/config-selfauth.yaml
@@ -25,7 +25,7 @@ hub:
   image:
     name: us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class
     # This is the timestamp of the image, we should avoid using 'latest'
-    tag: 'sample-public-image-1710974014'
+    tag: 'sample-public-image-1741648202'
   labels:
     ${indent(4, chomp(jsonencode(additional_labels)))}
   config:

--- a/security_test/allowlist/category/cluster/hub/distroless.json
+++ b/security_test/allowlist/category/cluster/hub/distroless.json
@@ -3,9 +3,9 @@
     "details": {
       "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
       "containerName": "hub",
-      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014"
+      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:sample-public-image-1741648202"
     },
-    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014\" built from non-distroless base image \"Debian GNU/Linux 11 (bullseye)\". See: go/gke-distroless for more details",
+    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:sample-public-image-1741648202\" built from non-distroless base image \"Debian GNU/Linux 11 (bullseye)\". See: go/gke-distroless for more details",
     "policyName": "distroless",
     "resourceKey": {
       "group": "apps",
@@ -15,4 +15,4 @@
       "version": "v1"
     }
   }
-] 
+]

--- a/security_test/allowlist/category/cluster/hub/imagedigest.json
+++ b/security_test/allowlist/category/cluster/hub/imagedigest.json
@@ -3,9 +3,9 @@
     "details": {
       "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
       "containerName": "hub",
-      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014"
+      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:sample-public-image-1741648202"
     },
-    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014\" with no digest; valid image format: image[:tag]@sha256:\u003cdigest\u003e",
+    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:sample-public-image-1741648202\" with no digest; valid image format: image[:tag]@sha256:\u003cdigest\u003e",
     "policyName": "imagedigest",
     "resourceKey": {
       "group": "apps",
@@ -15,4 +15,4 @@
       "version": "v1"
     }
   }
-] 
+]

--- a/security_test/allowlist/category/cluster/hub/imagefreshness.json
+++ b/security_test/allowlist/category/cluster/hub/imagefreshness.json
@@ -3,9 +3,9 @@
     "details": {
       "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
       "containerName": "hub",
-      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014"
+      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:sample-public-image-1741648202"
     },
-    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014\" that does not have a valid digest.",
+    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:sample-public-image-1741648202\" that does not have a valid digest.",
     "policyName": "imagefreshness",
     "resourceKey": {
       "group": "apps",
@@ -15,4 +15,4 @@
       "version": "v1"
     }
   }
-] 
+]

--- a/security_test/allowlist/category/cluster/hub/imagepath.json
+++ b/security_test/allowlist/category/cluster/hub/imagepath.json
@@ -3,9 +3,9 @@
     "details": {
       "@type": "type.googleapis.com/google.internal.kubernetes.security.validation.v1.ContainerDetails",
       "containerName": "hub",
-      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014"
+      "image": "us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:sample-public-image-1741648202"
     },
-    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:1710974014\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
+    "message": "container \"hub\" in Deployment \"hub\" has an image \"us-docker.pkg.dev/ai-on-gke/jupyterhub-authentication-class/jupyter-auth-class:sample-public-image-1741648202\" with an invalid path. See go/gke-shipshape#imagepath for valid image paths.",
     "policyName": "imagepath",
     "resourceKey": {
       "group": "apps",
@@ -15,4 +15,4 @@
       "version": "v1"
     }
   }
-] 
+]


### PR DESCRIPTION
Add prefix `sample-public-image-` to the image tag to indicate image is not production ready.