### PR TITLE
Bump TPU Webhook to v1.2.3

### DIFF
--- a/ray-on-gke/tpu/kuberay-tpu-webhook/Makefile
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets  
-IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.2-gke.1
+IMG ?= us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.3-gke.0
 
 # For europe, use europe-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook
   

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/deployments/deployment.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/deployments/deployment.yaml
@@ -64,7 +64,7 @@ spec:
     spec:
       serviceAccountName: kuberay-tpu-webhook
       containers:
-        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.2-gke.1
+        - image: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook:v1.2.3-gke.0
           imagePullPolicy: Always
           name: kuberay-tpu-webhook
           args:

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/Chart.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.2"
+appVersion: "1.2.3"

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/values.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/values.yaml
@@ -7,7 +7,7 @@ tpuWebhook:
   
   image:
     repository: us-docker.pkg.dev/ai-on-gke/kuberay-tpu-webhook/tpu-webhook
-    tag: v1.2.2-gke.1
+    tag: v1.2.3-gke.0
     pullPolicy: Always
 
   deployment:


### PR DESCRIPTION
This PR bumps the webhook image used in the deployment and helm-chart to the latest recommended version. The v1.2.3 webhook version contains fixes to the name of the TPU headless service generated by KubeRay.