### PR TITLE
Add resource label and rename cluster tracking string

### DIFF
--- a/applications/hcc/main.tf
+++ b/applications/hcc/main.tf
@@ -218,7 +218,7 @@ module "a3-ultragpu-cluster" {
   maintenance_exclusions = [{
     end_time        = "2025-12-22T00:00:00Z"
     exclusion_scope = "NO_MINOR_OR_NODE_UPGRADES"
-    name            = "no-minor-or-node-upgrades-indefinite"
+    name            = "no-minor-or-node-upgrades-indefinite-cluster-director"
     start_time      = "2024-12-01T00:00:00Z"
   }]
   master_authorized_networks = [{

--- a/applications/hcc/modules/embedded/modules/scheduler/gke-cluster/main.tf
+++ b/applications/hcc/modules/embedded/modules/scheduler/gke-cluster/main.tf
@@ -16,7 +16,14 @@
 
 locals {
   # This label allows for billing report tracking based on module.
-  labels = merge(var.labels, { ghpc_module = "gke-cluster", ghpc_role = "scheduler" })
+  labels = merge(
+    var.labels, 
+    { 
+      ghpc_module = "gke-cluster", 
+      ghpc_role = "scheduler" 
+      "gke_product_type" = "cluster-director"
+    }
+  )
 }
 
 locals {

--- a/applications/hcc/modules/embedded/modules/scheduler/gke-cluster/main.tf
+++ b/applications/hcc/modules/embedded/modules/scheduler/gke-cluster/main.tf
@@ -21,7 +21,7 @@ locals {
     { 
       ghpc_module = "gke-cluster", 
       ghpc_role = "scheduler" 
-      "gke_product_type" = "cluster-director"
+      "gke_product_type" = "cluster-director-qss"
     }
   )
 }


### PR DESCRIPTION
- Add a new resource label: gke_product_type:  cluster-director-qss to track the cluster 
- rename _name_ string in maintenance_exclusions to track the cluster 
