### PR TITLE
Configure maintenance exclusion and add cluster-director label 

### DIFF
--- a/applications/hcc/main.tf
+++ b/applications/hcc/main.tf
@@ -72,6 +72,13 @@ module "a3-megagpu-cluster" {
     cidr_block   = var.authorized_cidr
     display_name = "kubectl-access-network"
   }]
+  release_channel               = "RAPID"
+  maintenance_exclusions = [{
+    end_time        = "2025-12-22T00:00:00Z"
+    exclusion_scope = "NO_MINOR_OR_NODE_UPGRADES"
+    name            = "no-minor-or-node-upgrades-indefinite-cluster-director-mega"
+    start_time      = "2024-12-01T00:00:00Z"
+  }]
   network_id           = module.gke-a3-mega-net[0].network_id
   project_id           = var.project_id
   region          = local.region != null ? local.region : error("Cannot find region for zone")
@@ -93,6 +100,7 @@ module "a3_megagpu_pool" {
   internal_ghpc_module_id   = "a3_megagpu_pool"
   labels                    = var.labels
   machine_type              = "a3-megagpu-8g"
+  auto_upgrade        = true
   placement_policy = var.placement_policy_name == "" ? {
     policy_type = ""
   } : {
@@ -218,7 +226,7 @@ module "a3-ultragpu-cluster" {
   maintenance_exclusions = [{
     end_time        = "2025-12-22T00:00:00Z"
     exclusion_scope = "NO_MINOR_OR_NODE_UPGRADES"
-    name            = "no-minor-or-node-upgrades-indefinite"
+    name            = "no-minor-or-node-upgrades-indefinite-cluster-director-ultra"
     start_time      = "2024-12-01T00:00:00Z"
   }]
   master_authorized_networks = [{

--- a/applications/hcc/modules/embedded/modules/scheduler/gke-cluster/main.tf
+++ b/applications/hcc/modules/embedded/modules/scheduler/gke-cluster/main.tf
@@ -16,7 +16,12 @@
 
 locals {
   # This label allows for billing report tracking based on module.
-  labels = merge(var.labels, { ghpc_module = "gke-cluster", ghpc_role = "scheduler" })
+  labels = merge(var.labels, { 
+    ghpc_module = "gke-cluster", 
+    ghpc_role = "scheduler",
+    "gke_product_type" = "cluster-director-qss"
+    }
+  )
 }
 
 locals {

--- a/applications/hcc/modules/embedded/modules/scheduler/gke-cluster/main.tf
+++ b/applications/hcc/modules/embedded/modules/scheduler/gke-cluster/main.tf
@@ -19,7 +19,7 @@ locals {
   labels = merge(var.labels, { 
     ghpc_module = "gke-cluster", 
     ghpc_role = "scheduler",
-    "gke_product_type" = "cluster-director-qss"
+    gke_product_type = "cluster-director-qss"
     }
   )
 }


### PR DESCRIPTION
- Added `maintenance_exclusions` to the `a3-megagpu-cluster` 
- Added the resource label `gke_product_type: cluster-director-qss` to identify the clusters provisioned by Cluster Director QSS