### PR TITLE
Add identifying labels to workload pods

### DIFF
--- a/applications/hcc/modules/nemo/helm-charts/nccl-tests/templates/mega-test.yaml
+++ b/applications/hcc/modules/nemo/helm-charts/nccl-tests/templates/mega-test.yaml
@@ -52,6 +52,10 @@ spec:
                     {"interfaceName":"eth7","network":"vpc7"},
                     {"interfaceName":"eth8","network":"vpc8"}
                   ]
+              labels:
+                {{- with $root.Values.workloadLabels }} 
+                {{- toYaml . | nindent 16 }}   
+                {{- end }}
             spec:
               restartPolicy: Never
               nodeSelector:

--- a/applications/hcc/modules/nemo/helm-charts/nccl-tests/templates/ultra-test.yaml
+++ b/applications/hcc/modules/nemo/helm-charts/nccl-tests/templates/ultra-test.yaml
@@ -40,6 +40,10 @@ spec:
                     {"interfaceName":"eth7","network":"vpc7"},
                     {"interfaceName":"eth8","network":"vpc8"}
                   ]
+              labels: 
+                {{- with $root.Values.workloadLabels }} 
+                {{- toYaml . | nindent 16 }}  
+                {{- end }}
             spec:
               activeDeadlineSeconds: 3600
               restartPolicy: Never

--- a/applications/hcc/modules/nemo/helm-charts/training/a3mega/nemo-training/templates/nemo-launcher-job.yaml
+++ b/applications/hcc/modules/nemo/helm-charts/training/a3mega/nemo-training/templates/nemo-launcher-job.yaml
@@ -41,6 +41,10 @@ spec:
       {{- if $root.Values.volumes.gcsMounts }}
       gke-gcsfuse/volumes: "true"
       {{- end}}
+    labels:
+      {{- with $root.Values.workloadLabels }} 
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
 
    spec:
      #schedulingGates:

--- a/applications/hcc/modules/nemo/helm-charts/training/a3ultra/maxtext-training/templates/maxtext-launcher-job.yaml
+++ b/applications/hcc/modules/nemo/helm-charts/training/a3ultra/maxtext-training/templates/maxtext-launcher-job.yaml
@@ -70,6 +70,10 @@ spec:
           ]
         {{- end }}
         {{- end }}
+      labels:
+        {{- with $root.Values.workloadLabels }} 
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if $root.Values.network.hostNetwork }}
       hostNetwork: true

--- a/applications/hcc/modules/nemo/helm-charts/training/a3ultra/nemo-training/templates/nemo-launcher-job.yaml
+++ b/applications/hcc/modules/nemo/helm-charts/training/a3ultra/nemo-training/templates/nemo-launcher-job.yaml
@@ -70,6 +70,10 @@ spec:
           ]
         {{- end }}
         {{- end }}
+      labels:
+        {{- with $root.Values.workloadLabels }} 
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- if $root.Values.network.hostNetwork }}
       hostNetwork: true

--- a/applications/hcc/modules/nemo/main.tf
+++ b/applications/hcc/modules/nemo/main.tf
@@ -55,9 +55,22 @@ resource "helm_release" "benchmark" {
     value = var.queue
   }
 
-  set_json {
-    name  = "workloadLabels"
-    value = jsonencode(local.workload_labels)
+  set {
+    name  = "workloadLabels.ai-on-gke-solution" # Note the dot notation for the key path
+    value = local.workload_labels["ai-on-gke-solution"]
+  }
+  set {
+    name  = "workloadLabels.ai-on-gke-machine-type"
+    value = local.workload_labels["ai-on-gke-machine-type"]
+  }
+  set {
+    name  = "workloadLabels.ai-on-gke-framework"
+    value = local.workload_labels["ai-on-gke-framework"]
+  }
+
+  set {
+    name  = "workloadLabels.ai-on-gke-model"
+    value = local.workload_labels["ai-on-gke-model"]
   }
 
   set {
@@ -89,9 +102,17 @@ resource "helm_release" "nccl_tests" {
     value = var.node_count
   }
 
-  set_json {
-    name  = "workloadLabels"
-    value = jsonencode(local.workload_labels) 
+  set {
+    name  = "workloadLabels.ai-on-gke-solution"
+    value = local.workload_labels["ai-on-gke-solution"]
+  }
+  set {
+    name  = "workloadLabels.ai-on-gke-machine-type"
+    value = local.workload_labels["ai-on-gke-machine-type"]
+  }
+  set {
+    name  = "workloadLabels.ai-on-gke-framework"
+    value = local.workload_labels["ai-on-gke-framework"]
   }
 
   set {

--- a/applications/hcc/modules/nemo/main.tf
+++ b/applications/hcc/modules/nemo/main.tf
@@ -55,6 +55,11 @@ resource "helm_release" "benchmark" {
     value = var.queue
   }
 
+  set_json {
+    name  = "workloadLabels"
+    value = jsonencode(local.workload_labels)
+  }
+
   set {
     name = "workload.gpus"
     value = var.node_count * 8
@@ -82,6 +87,11 @@ resource "helm_release" "nccl_tests" {
   set {
     name = "workload.node_count"
     value = var.node_count
+  }
+
+  set_json {
+    name  = "workloadLabels"
+    value = jsonencode(local.workload_labels) 
   }
 
   set {

--- a/applications/hcc/modules/nemo/recipe.tf
+++ b/applications/hcc/modules/nemo/recipe.tf
@@ -26,4 +26,34 @@ locals {
     "gke-nccl"                         = ""
   }[var.recipe]
 
+  machine_type_label = var.gpu_type == "A3 Mega" ? "a3mega" : (var.gpu_type == "A3 Ultra" ? "a3ultra" : "unknown")
+
+  framework_label = {
+    "llama3.1_7b_nemo_pretraining"     = "nemo"
+    "llama3.1_70b_nemo_pretraining"    = "nemo"
+    "llama3.1_70b_maxtext_pretraining" = "maxtext"
+    "mixtral8_7b_nemo_pretraining"     = "nemo"
+    "mixtral8_7b_maxtext_pretraining"  = "maxtext"
+    "gke-nccl"                         = "nccltest"
+  }[var.recipe]
+
+  model_label = {
+    "llama3.1_7b_nemo_pretraining"     = "llama-3.1-7b"
+    "llama3.1_70b_nemo_pretraining"    = "llama-3.1-70b"
+    "llama3.1_70b_maxtext_pretraining" = "llama-3.1-70b"
+    "mixtral8_7b_nemo_pretraining"     = "mixtral-8-7b" 
+    "mixtral8_7b_maxtext_pretraining"  = "mixtral-8-7b" 
+    "gke-nccl"                         = null
+  }[var.recipe]
+ 
+  workload_labels = merge(
+    {
+      "ai-on-gke-solution"     = "cluster-director-quick-start-solution"
+      "ai-on-gke-machine-type" = local.machine_type_label
+      "ai-on-gke-framework"    = local.framework_label
+    },
+    
+    local.model_label != null ? { "ai-on-gke-model" = local.model_label } : {}
+  )
+
 }


### PR DESCRIPTION
Adds identifying labels to the Pods created by the AI/ML workloads (Nemo, MaxText, NCCL tests) deployed via the Cluster Director Quick Start Solution.

The following labels are added to each workload pod's metadata:
* `ai-on-gke-solution`: Static value "cluster-director-qss"
* `ai-on-gke-machine-type`: Derived from GPU type (`a3mega` or `a3ultra`)
* `ai-on-gke-framework`: Derived from the selected recipe (`nemo`, `maxtext`, or `nccltest`)
* `ai-on-gke-model`: Derived from the selected recipe (e.g., `llama-3.1-7b`, `mixtral-8-7b`), omitted for NCCL tests.

