### PR TITLE
region update for a3ultra

### DIFF
--- a/applications/hcc/metadata.display.yaml
+++ b/applications/hcc/metadata.display.yaml
@@ -87,6 +87,7 @@ spec:
               - us-east4-b
               - us-east5-a
               - us-east7-c
+              - us-south1-b
               - us-west1-c
           toggleUsingVariables:
           - variableName: gpu_type


### PR DESCRIPTION
updated a3ultra zones:
- europe-west1-b
- us-central1-b
- us-east4-b
- us-east5-a
- us-east7-c
- us-south1-b (new)
- us-west1-c