### PR TITLE
rename identifying labels to workload pods 

### DIFF
--- a/applications/hcc/modules/nemo/main.tf
+++ b/applications/hcc/modules/nemo/main.tf
@@ -59,10 +59,7 @@ resource "helm_release" "benchmark" {
     name  = "workloadLabels.ai-on-gke-solution" # Note the dot notation for the key path
     value = local.workload_labels["ai-on-gke-solution"]
   }
-  set {
-    name  = "workloadLabels.ai-on-gke-machine-type"
-    value = local.workload_labels["ai-on-gke-machine-type"]
-  }
+
   set {
     name  = "workloadLabels.ai-on-gke-framework"
     value = local.workload_labels["ai-on-gke-framework"]
@@ -106,10 +103,7 @@ resource "helm_release" "nccl_tests" {
     name  = "workloadLabels.ai-on-gke-solution"
     value = local.workload_labels["ai-on-gke-solution"]
   }
-  set {
-    name  = "workloadLabels.ai-on-gke-machine-type"
-    value = local.workload_labels["ai-on-gke-machine-type"]
-  }
+
   set {
     name  = "workloadLabels.ai-on-gke-framework"
     value = local.workload_labels["ai-on-gke-framework"]

--- a/applications/hcc/modules/nemo/recipe.tf
+++ b/applications/hcc/modules/nemo/recipe.tf
@@ -26,8 +26,6 @@ locals {
     "gke-nccl"                         = ""
   }[var.recipe]
 
-  machine_type_label = var.gpu_type == "A3 Mega" ? "a3mega" : (var.gpu_type == "A3 Ultra" ? "a3ultra" : "unknown")
-
   framework_label = {
     "llama3.1_7b_nemo_pretraining"     = "nemo"
     "llama3.1_70b_nemo_pretraining"    = "nemo"
@@ -49,7 +47,6 @@ locals {
   workload_labels = merge(
     {
       "ai-on-gke-solution"     = "cluster-director-quick-start-solution"
-      "ai-on-gke-machine-type" = local.machine_type_label
       "ai-on-gke-framework"    = local.framework_label
     },
     

--- a/applications/hcc/modules/nemo/recipe.tf
+++ b/applications/hcc/modules/nemo/recipe.tf
@@ -36,11 +36,11 @@ locals {
   }[var.recipe]
 
   model_label = {
-    "llama3.1_7b_nemo_pretraining"     = "llama-3.1-7b"
-    "llama3.1_70b_nemo_pretraining"    = "llama-3.1-70b"
-    "llama3.1_70b_maxtext_pretraining" = "llama-3.1-70b"
-    "mixtral8_7b_nemo_pretraining"     = "mixtral-8-7b" 
-    "mixtral8_7b_maxtext_pretraining"  = "mixtral-8-7b" 
+    "llama3.1_7b_nemo_pretraining"     = "llama"
+    "llama3.1_70b_nemo_pretraining"    = "llama"
+    "llama3.1_70b_maxtext_pretraining" = "llama"
+    "mixtral8_7b_nemo_pretraining"     = "mixtral" 
+    "mixtral8_7b_maxtext_pretraining"  = "mixtral" 
     "gke-nccl"                         = null
   }[var.recipe]
  


### PR DESCRIPTION
- rename model label to be more generalized
- remove machine-type label

The following labels are added to each workload pod's metadata:
* `ai-on-gke-solution`: Static value "cluster-director-quick-start-solution"
* `ai-on-gke-framework`: Derived from the selected recipe (`nemo`, `maxtext`, or `nccltest`)
* `ai-on-gke-model`: Derived from the selected recipe (e.g., `llama`, `mixtral`), omitted for NCCL tests.