### PR TITLE
[TPU Webhook] Update Helm chart with Cert duration and renewBefore fields

### DIFF
--- a/ray-on-gke/tpu/kuberay-tpu-webhook/certs/cert.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/certs/cert.yaml
@@ -31,4 +31,6 @@ spec:
     - kuberay-tpu-webhook.ray-system.svc
     - kuberay-tpu-webhook.ray-system.svc.cluster.local
   issuerRef:
+    kind: Issuer
+    group: cert-manager.io
     name: selfsigned-issuer

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/Chart.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 0.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.2.3"
+appVersion: "1.2.4"

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/templates/cert.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/templates/cert.yaml
@@ -26,9 +26,13 @@ metadata:
   name: kuberay-tpu-webhook-certs
   namespace: {{ .Values.tpuWebhook.namespace.name }}
 spec:
+  duration: {{ .Values.tpuWebhook.cert.duration }}
+  renewBefore: {{ .Values.tpuWebhook.cert.renewBefore }}
   secretName: kuberay-tpu-webhook-certs
   dnsNames:
     - kuberay-tpu-webhook.{{ .Values.tpuWebhook.namespace.name }}.svc
     - kuberay-tpu-webhook.{{ .Values.tpuWebhook.namespace.name }}.svc.cluster.local
   issuerRef:
+    kind: Issuer
+    group: cert-manager.io
     name: selfsigned-issuer

--- a/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/values.yaml
+++ b/ray-on-gke/tpu/kuberay-tpu-webhook/helm-chart/values.yaml
@@ -17,3 +17,7 @@ tpuWebhook:
   service:
     type: ClusterIP
     port: 443
+
+  cert:
+    duration: 2160h # 90d
+    renewBefore: 360h # 15d


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/GoogleCloudPlatform/ai-on-gke/blob/main/contributing.md
2. Please label this pull request according to what type of issue you are addressing.
3. Ensure you have added or ran the appropriate tests for your PR.
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, press enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind breaking
> /kind bug
> /kind cleanup
> /kind documentation

/kind enhancement

**What this PR does / Why we need it**:

This PR adds additional fields to the helm chart to allow users to configure the Certificate duration and renewBefore fields. This PR also adds the issuerRef.group field to the webhook cert to avoid an issue where cert-manager fails to renew a self-signed issued certificate before expiry. Finally, this PR bumps the webhook image used to the latest recommended version.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Closes #<issue number>`, or `Closes (paste link of issue)`.
-->
Closes #

**Special notes for your reviewer**:
